### PR TITLE
Give back empty bottles on dye usage in wool

### DIFF
--- a/mods/wool/init.lua
+++ b/mods/wool/init.lua
@@ -42,6 +42,7 @@ for _, row in ipairs(wool.dyes) do
 			type = "shapeless",
 			output = 'wool:'..name..' 16',
 			recipe = {'group:dye,'..craft_color_group, 'wool:white'},
+			replacements = { { "wool:white", "unifieddyes:empty_bottle"} }
 		})
 	end
 end


### PR DESCRIPTION
If Unified Dyes is in place, this one-liner gives back the empty bottle when one such dye is used with a white wool block to craft a colored one.
