### PR TITLE
Move falling to builtin

### DIFF
--- a/mods/default/init.lua
+++ b/mods/default/init.lua
@@ -1603,95 +1603,9 @@ minetest.register_craftitem("default:scorched_stuff", {
 	inventory_image = "default_scorched_stuff.png",
 })
 
---
--- Falling stuff
---
-
-minetest.register_entity("default:falling_node", {
-	initial_properties = {
-		physical = true,
-		collisionbox = {-0.5,-0.5,-0.5, 0.5,0.5,0.5},
-		visual = "wielditem",
-		textures = {},
-		visual_size = {x=0.667, y=0.667},
-	},
-
-	nodename = "",
-
-	set_node = function(self, nodename)
-		self.nodename = nodename
-		local stack = ItemStack(nodename)
-		local itemtable = stack:to_table()
-		local itemname = nil
-		if itemtable then
-			itemname = stack:to_table().name
-		end
-		local item_texture = nil
-		local item_type = ""
-		if minetest.registered_items[itemname] then
-			item_texture = minetest.registered_items[itemname].inventory_image
-			item_type = minetest.registered_items[itemname].type
-		end
-		prop = {
-			is_visible = true,
-			textures = {nodename},
-		}
-		self.object:set_properties(prop)
-	end,
-
-	get_staticdata = function(self)
-		return self.nodename
-	end,
-
-	on_activate = function(self, staticdata)
-		self.nodename = staticdata
-		self.object:set_armor_groups({immortal=1})
-		--self.object:setacceleration({x=0, y=-10, z=0})
-		self:set_node(self.nodename)
-	end,
-
-	on_step = function(self, dtime)
-		-- Set gravity
-		self.object:setacceleration({x=0, y=-10, z=0})
-		-- Turn to actual sand when collides to ground or just move
-		local pos = self.object:getpos()
-		local bcp = {x=pos.x, y=pos.y-0.7, z=pos.z} -- Position of bottom center point
-		local bcn = minetest.env:get_node(bcp)
-		-- Note: walkable is in the node definition, not in item groups
-		if minetest.registered_nodes[bcn.name] and
-				minetest.registered_nodes[bcn.name].walkable then
-			local np = {x=bcp.x, y=bcp.y+1, z=bcp.z}
-			-- Check what's here
-			local n2 = minetest.env:get_node(np)
-			-- If it's not air or liquid, remove node and replace it with
-			-- it's drops
-			if n2.name ~= "air" and (not minetest.registered_nodes[n2.name] or
-					minetest.registered_nodes[n2.name].liquidtype == "none") then
-				local drops = minetest.get_node_drops(n2.name, "")
-				minetest.env:remove_node(np)
-				-- Add dropped items
-				local _, dropped_item
-				for _, dropped_item in ipairs(drops) do
-					minetest.env:add_item(np, dropped_item)
-				end
-				-- Run script hook
-				local _, callback
-				for _, callback in ipairs(minetest.registered_on_dignodes) do
-					callback(np, n2, nil)
-				end
-			end
-			-- Create node and remove entity
-			minetest.env:add_node(np, {name=self.nodename})
-			self.object:remove()
-		else
-			-- Do nothing
-		end
-	end
-})
-
+-- Support old code
 function default.spawn_falling_node(p, nodename)
-	obj = minetest.env:add_entity(p, "default:falling_node")
-	obj:get_luaentity():set_node(nodename)
+	spawn_falling_node(p, nodename)
 end
 
 -- Horrible crap to support old code
@@ -1702,36 +1616,6 @@ function default.register_falling_node(nodename, texture)
 	minetest.log('error', "WARNING: default.register_falling_node is deprecated")
 	if minetest.registered_nodes[nodename] then
 		minetest.registered_nodes[nodename].groups.falling_node = 1
-	end
-end
-
---
--- Some common functions
---
-
-function nodeupdate_single(p)
-	n = minetest.env:get_node(p)
-	if minetest.get_node_group(n.name, "falling_node") ~= 0 then
-		p_bottom = {x=p.x, y=p.y-1, z=p.z}
-		n_bottom = minetest.env:get_node(p_bottom)
-		-- Note: walkable is in the node definition, not in item groups
-		if minetest.registered_nodes[n_bottom.name] and
-				not minetest.registered_nodes[n_bottom.name].walkable then
-			minetest.env:remove_node(p)
-			default.spawn_falling_node(p, n.name)
-			nodeupdate(p)
-		end
-	end
-end
-
-function nodeupdate(p)
-	for x = -1,1 do
-	for y = -1,1 do
-	for z = -1,1 do
-		p2 = {x=p.x+x, y=p.y+y, z=p.z+z}
-		nodeupdate_single(p2)
-	end
-	end
 	end
 end
 
@@ -1747,13 +1631,11 @@ minetest.register_globalstep(on_step)
 
 function on_placenode(p, node)
 	--print("on_placenode")
-	nodeupdate(p)
 end
 minetest.register_on_placenode(on_placenode)
 
 function on_dignode(p, node)
 	--print("on_dignode")
-	nodeupdate(p)
 end
 minetest.register_on_dignode(on_dignode)
 


### PR DESCRIPTION
This allows other games to use falling nodes without defining them. Also the nodeupdate functions can be called without depending on default mod.
