### PR TITLE
stop using hacks for sign input

### DIFF
--- a/mods/default/init.lua
+++ b/mods/default/init.lua
@@ -1144,7 +1144,7 @@ minetest.register_node("default:sign_wall", {
 	on_construct = function(pos)
 		--local n = minetest.env:get_node(pos)
 		local meta = minetest.env:get_meta(pos)
-		meta:set_string("formspec", "hack:sign_text_input")
+		meta:set_string("formspec", "field[text;;${text}]")
 		meta:set_string("infotext", "\"\"")
 	end,
 	on_receive_fields = function(pos, formname, fields, sender)


### PR DESCRIPTION
use the proper formspec string instead of the old hack:sign_text_input
