### PR TITLE
Add steel block -> steel ingots recipe

### DIFF
--- a/mods/default/init.lua
+++ b/mods/default/init.lua
@@ -379,13 +379,6 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-	output = 'default:steel_ingot 9',
-	recipe = {
-		{'default:steelblock'},
-	}
-})
-
-minetest.register_craft({
 	output = 'default:steelblock',
 	recipe = {
 		{'default:steel_ingot', 'default:steel_ingot', 'default:steel_ingot'},
@@ -1504,6 +1497,7 @@ minetest.register_node("default:steelblock", {
 	tiles = {"default_steel_block.png"},
 	is_ground_content = true,
 	groups = {snappy=1,bendy=2,cracky=1,melty=2,level=2},
+	drop = "default:steel_ingot 9",
 	sounds = default.node_sound_stone_defaults(),
 })
 


### PR DESCRIPTION
Steel blocks in MineTest right now are not useful as storage for iron, since once you craft ingots into a block, you can't craft them back into ingots.

This commit adds a recipe allowing you to do just that, so steel blocks become more than just a decorative block.
