### PR TITLE
Make Steel Block drop 9 Steel Ingots

### DIFF
--- a/mods/default/init.lua
+++ b/mods/default/init.lua
@@ -1497,6 +1497,7 @@ minetest.register_node("default:steelblock", {
 	tiles = {"default_steel_block.png"},
 	is_ground_content = true,
 	groups = {snappy=1,bendy=2,cracky=1,melty=2,level=2},
+	drop = "default:steel_ingot 9",
 	sounds = default.node_sound_stone_defaults(),
 })
 


### PR DESCRIPTION
In response to pull #23, I've put this into a single commit. The steel block is now generally more useful for the storage of steel ingots.
