### PR TITLE
Dig the whole papyrus/cactus (see issue #83)

### DIFF
--- a/mods/default/leafdecay.lua
+++ b/mods/default/leafdecay.lua
@@ -91,3 +91,15 @@ minetest.register_abm({
 	end
 })
 
+-- Nodes in the group plant_dig (papyrus and cactus) go into the diggers inventory if the node below is removed
+minetest.register_on_dignode(function(pos, node, digger)
+  local np = {x = pos.x, y = pos.y + 1, z = pos.z}
+  local nn = minetest.env:get_node(np)
+  while minetest.get_item_group(nn.name, "plant_dig") > 0 do
+    minetest.env:remove_node(np)
+    digger:get_inventory():add_item('main', nn.name)
+    np = {x = np.x, y = np.y + 1, z = np.z}
+    nn = minetest.env:get_node(np)
+  end
+end)
+


### PR DESCRIPTION
Just like in the growing-mod the plant is removed from the dug node upwards and added to the players inventory.
