### PR TITLE
Fix door's glitch in creative mode

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -82,7 +82,9 @@ function doors:register_door(name, def)
 				meta:set_string("infotext", "Owned by "..pn)
 			end
 			
-			itemstack:take_item()
+			if not minetest.setting_getbool("creative_mode") then
+				itemstack:take_item()
+			end
 			return itemstack
 		end,
 	})


### PR DESCRIPTION
Now, it could be possible place infinite doors on the world witout take new one in creative
