### PR TITLE
Added a recipe to return mese crystal fragments to their mese crystal form

### DIFF
--- a/mods/default/init.lua
+++ b/mods/default/init.lua
@@ -509,6 +509,27 @@ minetest.register_craft({
 	}
 })
 
+minetest.register_craft({
+	output = 'default:mese_crystal',
+	recipe = {
+		{
+			'default:mese_crystal_fragment',
+			'default:mese_crystal_fragment',
+			'default:mese_crystal_fragment',
+		},
+		{
+			'default:mese_crystal_fragment',
+			'default:mese_crystal_fragment',
+			'default:mese_crystal_fragment',
+		},
+		{
+			'default:mese_crystal_fragment',
+			'default:mese_crystal_fragment',
+			'default:mese_crystal_fragment',
+		},
+	}
+})
+
 --
 -- Crafting (tool repair)
 --


### PR DESCRIPTION
The problem with Minetest 0.4.5's mese crystal fragments is they have zero function whatsoever. They cannot be placed as nodes and they cannot be crafted into anything else. One mese crystal can be crafted into nine mese crystal fragments, but there is no way to craft them back from this useless fragment form. This commit fixes that, allowing them to at least be put back into a usable form.
