### PR TITLE
Make sandstone only craftable with normal sand

### DIFF
--- a/mods/default/init.lua
+++ b/mods/default/init.lua
@@ -417,8 +417,8 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'default:sandstone',
 	recipe = {
-		{'group:sand', 'group:sand'},
-		{'group:sand', 'group:sand'},
+		{'default:sand', 'default:sand'},
+		{'default:sand', 'default:sand'},
 	}
 })
 


### PR DESCRIPTION
With group:sand it would be possible to craft 4 desertsand ---> sandstone ---> 4 normal sand. Therefor only use default:sand.
