### PR TITLE
New water and lava source texture tile settings

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -446,7 +446,9 @@ minetest.register_node("default:water_source", {
 	inventory_image = minetest.inventorycube("default_water.png"),
 	drawtype = "liquid",
 	tiles = {
-		{name="default_water_source_animated.png", animation={type="vertical_frames", aspect_w=16, aspect_h=16, length=2.0}}
+		{name="default_water_source_animated.png", animation={type="vertical_frames", aspect_w=16, aspect_h=16, length=2.0}},
+		{name="default_water_source_animated.png", animation={type="vertical_frames", aspect_w=16, aspect_h=16, length=2.0}},
+		{name="default_water_flowing_animated.png", animation={type="vertical_frames", aspect_w=16, aspect_h=16, length=0.8}}
 	},
 	special_tiles = {
 		-- New-style water source material (mostly unused)
@@ -510,7 +512,9 @@ minetest.register_node("default:lava_source", {
 	inventory_image = minetest.inventorycube("default_lava.png"),
 	drawtype = "liquid",
 	tiles = {
-		{name="default_lava_source_animated.png", animation={type="vertical_frames", aspect_w=16, aspect_h=16, length=3.0}}
+		{name="default_lava_source_animated.png", animation={type="vertical_frames", aspect_w=16, aspect_h=16, length=3.0}},
+		{name="default_lava_source_animated.png", animation={type="vertical_frames", aspect_w=16, aspect_h=16, length=3.0}},
+		{name="default_lava_flowing_animated.png", animation={type="vertical_frames", aspect_w=16, aspect_h=16, length=3.3}}
 	},
 	special_tiles = {
 		-- New-style lava source material (mostly unused)


### PR DESCRIPTION
the water/lava source node has the flowing water/lava texture on the side and the source texture on the top and the bottom
It doesn't change the flowing nodes.
