### PR TITLE
Add a setting to disable bones

### DIFF
--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -78,7 +78,8 @@ minetest.register_node("bones:bones", {
 })
 
 minetest.register_on_dieplayer(function(player)
-	if minetest.setting_getbool("creative_mode") then
+	if minetest.setting_getbool("creative_mode") or
+	   minetest.setting_getbool("disable_bones") then
 		return
 	end
 	


### PR DESCRIPTION
As with the fire setting this does not remove existing bones but doesn't add any new ones.