### PR TITLE
Player animation bug

### DIFF
--- a/mods/default/player.lua
+++ b/mods/default/player.lua
@@ -16,10 +16,29 @@ animation_blend = 0
 default_model = "character.x"
 default_textures = {"character.png", }
 
+if default.player == nil then
+    default.player = {}
+end
+
+-- Each model (character.x weild3d_character.x pony.x etc)
+-- may have different uh... indexes(?) for the state changes
+-- such as beginning to stand or done sitting.
+
+local animations = {}
+default.player.register_model_animation = function(model,animation)
+    animations[model] = animation
+end
+
 -- Frame ranges for each player model
 function player_get_animations(model)
-	if model == "character.x" then
-		return {
+    local animation = animations[model]
+    if animation then 
+        return animation 
+    end
+    if default.player.default_animation then
+        return default.player.default_animation
+    end
+    return {
 		stand_START = 0,
 		stand_END = 79,
 		sit_START = 81,
@@ -33,7 +52,6 @@ function player_get_animations(model)
 		walk_mine_START = 200,
 		walk_mine_END = 219
 		}
-	end
 end
 
 --
@@ -69,6 +87,7 @@ end
 
 -- Update appearance when the player joins
 minetest.register_on_joinplayer(player_update_visuals)
+
 
 -- Check each player and apply animations
 function player_step(dtime)


### PR DESCRIPTION
The thing in default/player.lua was causing a crash if anyone used a
player model besides character.x. kaeza said they also needed a way to
register animations for models. (an animation being constants for a
finite state machine inside the model, which cannot be introspected
from the model?) So now it assumes the character.x animation is the
right constants for all models, except those who have an animation
registered, instead of crashing for all models besides character.x
