### PR TITLE
Fixed partial door issue in bones.

### DIFF
--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -89,8 +89,7 @@ minetest.register_on_dieplayer(function(player)
 	local param2 = minetest.dir_to_facedir(player:get_look_dir())
 	
 	local nn = minetest.get_node(pos).name
-	if minetest.registered_nodes[nn].can_dig and
-		not minetest.registered_nodes[nn].can_dig(pos, player) then
+	if minetest.registered_nodes[nn].can_dig then
 		local player_inv = player:get_inventory()
 
 		for i=1,player_inv:get_size("main") do


### PR DESCRIPTION
https://f.cloud.github.com/assets/950942/44526/bcc65de0-56c7-11e2-905e-d8a82d3e44a6.png

When a node's can_dig() function is checked, it only tells if that player can dig the node. However, bones uses this function, then assumes the node can be dug by a nil player, as opposed to having the player himself/herself dig the node. This assumption isn't always accurate, and results in partial doors in some cases, as depicted in the screenshot above. Basically, the player themselves can dig the locked door, but the nil player cannot, resulting in the door's after_dig_node() not getting called.

This patch fixes this issue by assuming the nil player cannot dig any node that specifies a can_dig() function. This allows nodes that prefer to limit who can dig them to function as usual (such as locked doors) while still allowing bones to remove the majority of nodes (including unlocked doors) with no error.