### PR TITLE
dig upwards for papyrus and cactus

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -267,6 +267,19 @@ minetest.register_abm({
 })
 
 --
+-- dig upwards
+--
+
+function default.dig_up(pos, node, digger)
+	if digger == nil then return end
+	local np = {x = pos.x, y = pos.y + 1, z = pos.z}
+	local nn = minetest.get_node(np)
+	if nn.name == node.name then
+		minetest.node_dig(np, nn, digger)
+	end
+end
+
+--
 -- Leafdecay
 --
 

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -347,7 +347,10 @@ minetest.register_node("default:cactus", {
 	is_ground_content = true,
 	groups = {snappy=1,choppy=3,flammable=2},
 	sounds = default.node_sound_wood_defaults(),
-	on_place = minetest.rotate_node
+	on_place = minetest.rotate_node,
+	after_dig_node = function(pos, node, metadata, digger)
+		default.dig_up(pos, node, digger)
+	end,
 })
 
 minetest.register_node("default:papyrus", {
@@ -365,6 +368,9 @@ minetest.register_node("default:papyrus", {
 	},
 	groups = {snappy=3,flammable=2},
 	sounds = default.node_sound_leaves_defaults(),
+	after_dig_node = function(pos, node, metadata, digger)
+		default.dig_up(pos, node, digger)
+	end,
 })
 
 minetest.register_node("default:bookshelf", {


### PR DESCRIPTION
When papyrus or cactus is dug all the papyrus/cactus above is dug too. Everything goes directly into the players inventory.
