### PR TITLE
make farming directly set/alter node drops, move waving=1 to default/nodes.lua

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -255,10 +255,10 @@ minetest.register_node("default:junglewood", {
 minetest.register_node("default:jungleleaves", {
 	description = "Jungle Leaves",
 	drawtype = "allfaces_optional",
+	waving = 1,
 	visual_scale = 1.3,
 	tiles = {"default_jungleleaves.png"},
 	paramtype = "light",
-	waving = 1,
 	is_ground_content = false,
 	groups = {snappy=3, leafdecay=3, flammable=2, leaves=1},
 	drop = {
@@ -299,6 +299,7 @@ minetest.register_node("default:junglesapling", {
 minetest.register_node("default:junglegrass", {
 	description = "Jungle Grass",
 	drawtype = "plantlike",
+	waving = 1,
 	visual_scale = 1.3,
 	tiles = {"default_junglegrass.png"},
 	inventory_image = "default_junglegrass.png",
@@ -318,10 +319,10 @@ minetest.register_node("default:junglegrass", {
 minetest.register_node("default:leaves", {
 	description = "Leaves",
 	drawtype = "allfaces_optional",
+	waving = 1,
 	visual_scale = 1.3,
 	tiles = {"default_leaves.png"},
 	paramtype = "light",
-	waving = 1,
 	is_ground_content = false,
 	groups = {snappy=3, leafdecay=3, flammable=2, leaves=1},
 	drop = {
@@ -1224,12 +1225,12 @@ minetest.register_node("default:apple", {
 minetest.register_node("default:dry_shrub", {
 	description = "Dry Shrub",
 	drawtype = "plantlike",
+	waving = 1,
 	visual_scale = 1.0,
 	tiles = {"default_dry_shrub.png"},
 	inventory_image = "default_dry_shrub.png",
 	wield_image = "default_dry_shrub.png",
 	paramtype = "light",
-	waving = 1,
 	walkable = false,
 	is_ground_content = true,
 	buildable_to = true,
@@ -1244,6 +1245,7 @@ minetest.register_node("default:dry_shrub", {
 minetest.register_node("default:grass_1", {
 	description = "Grass",
 	drawtype = "plantlike",
+	waving = 1,
 	tiles = {"default_grass_1.png"},
 	-- use a bigger inventory image
 	inventory_image = "default_grass_3.png",
@@ -1269,6 +1271,7 @@ minetest.register_node("default:grass_1", {
 minetest.register_node("default:grass_2", {
 	description = "Grass",
 	drawtype = "plantlike",
+	waving = 1,
 	tiles = {"default_grass_2.png"},
 	inventory_image = "default_grass_2.png",
 	wield_image = "default_grass_2.png",
@@ -1287,6 +1290,7 @@ minetest.register_node("default:grass_2", {
 minetest.register_node("default:grass_3", {
 	description = "Grass",
 	drawtype = "plantlike",
+	waving = 1,
 	tiles = {"default_grass_3.png"},
 	inventory_image = "default_grass_3.png",
 	wield_image = "default_grass_3.png",
@@ -1306,6 +1310,7 @@ minetest.register_node("default:grass_3", {
 minetest.register_node("default:grass_4", {
 	description = "Grass",
 	drawtype = "plantlike",
+	waving = 1,
 	tiles = {"default_grass_4.png"},
 	inventory_image = "default_grass_4.png",
 	wield_image = "default_grass_4.png",
@@ -1325,6 +1330,7 @@ minetest.register_node("default:grass_4", {
 minetest.register_node("default:grass_5", {
 	description = "Grass",
 	drawtype = "plantlike",
+	waving = 1,
 	tiles = {"default_grass_5.png"},
 	inventory_image = "default_grass_5.png",
 	wield_image = "default_grass_5.png",

--- a/mods/farming/init.lua
+++ b/mods/farming/init.lua
@@ -181,92 +181,27 @@ minetest.register_craft({
 --
 -- Override grass for drops
 --
-minetest.register_node(":default:grass_1", {
-	description = "Grass",
-	drawtype = "plantlike",
-	tiles = {"default_grass_1.png"},
-	-- use a bigger inventory image
-	inventory_image = "default_grass_3.png",
-	wield_image = "default_grass_3.png",
-	paramtype = "light",
-	waving = 1,
-	walkable = false,
-	buildable_to = true,
-	drop = {
-		max_items = 1,
-		items = {
-			{items = {'farming:seed_wheat'},rarity = 5},
-			{items = {'default:grass_1'}},
-		}
-	},
-	groups = {snappy=3,flammable=3,flora=1,attached_node=1},
-	sounds = default.node_sound_leaves_defaults(),
-	selection_box = {
-		type = "fixed",
-		fixed = {-0.5, -0.5, -0.5, 0.5, -5/16, 0.5},
-	},
-	on_place = function(itemstack, placer, pointed_thing)
-		-- place a random grass node
-		local stack = ItemStack("default:grass_"..math.random(1,5))
-		local ret = minetest.item_place(stack, placer, pointed_thing)
-		return ItemStack("default:grass_1 "..itemstack:get_count()-(1-ret:get_count()))
-	end,
-})
-
-for i=2,5 do
-	minetest.register_node(":default:grass_"..i, {
-		description = "Grass",
-		drawtype = "plantlike",
-		tiles = {"default_grass_"..i..".png"},
-		inventory_image = "default_grass_"..i..".png",
-		wield_image = "default_grass_"..i..".png",
-		paramtype = "light",
-		waving = 1,
-		walkable = false,
-		buildable_to = true,
-		is_ground_content = true,
-		drop = {
+for i = 1, 5 do
+	newgrass = minetest.clone_node("default:grass_"..i)
+		newgrass.drop = {
 			max_items = 1,
 			items = {
 				{items = {'farming:seed_wheat'},rarity = 5},
 				{items = {'default:grass_1'}},
 			}
-		},
-		groups = {snappy=3,flammable=3,flora=1,attached_node=1,not_in_creative_inventory=1},
-		sounds = default.node_sound_leaves_defaults(),
-		selection_box = {
-			type = "fixed",
-			fixed = {-0.5, -0.5, -0.5, 0.5, -5/16, 0.5},
-		},
-	})
+		}
+	minetest.register_node(":default:grass_"..i, newgrass)
 end
 
-minetest.register_node(":default:junglegrass", {
-	description = "Jungle Grass",
-	drawtype = "plantlike",
-	visual_scale = 1.3,
-	tiles = {"default_junglegrass.png"},
-	inventory_image = "default_junglegrass.png",
-	wield_image = "default_junglegrass.png",
-	paramtype = "light",
-	waving = 1,
-	walkable = false,
-	buildable_to = true,
-	is_ground_content = true,
-	drop = {
+newjunglegrass = minetest.clone_node("default:junglegrass")
+	newjunglegrass.drop = {
 		max_items = 1,
 		items = {
 			{items = {'farming:seed_cotton'},rarity = 8},
 			{items = {'default:junglegrass'}},
 		}
-	},
-	groups = {snappy=3,flammable=2,flora=1,attached_node=1},
-	sounds = default.node_sound_leaves_defaults(),
-	selection_box = {
-		type = "fixed",
-		fixed = {-0.5, -0.5, -0.5, 0.5, -5/16, 0.5},
-	},
-})
+	}
+minetest.register_node(":default:junglegrass", newjunglegrass)
 
 --
 -- Place seeds
@@ -366,9 +301,9 @@ for i=1,8 do
 	}
 	minetest.register_node("farming:wheat_"..i, {
 		drawtype = "plantlike",
+		waving = 1,
 		tiles = {"farming_wheat_"..i..".png"},
 		paramtype = "light",
-		waving = 1,
 		walkable = false,
 		buildable_to = true,
 		is_ground_content = true,
@@ -452,9 +387,9 @@ for i=1,8 do
 	}
 	minetest.register_node("farming:cotton_"..i, {
 		drawtype = "plantlike",
+		waving = 1,
 		tiles = {"farming_cotton_"..i..".png"},
 		paramtype = "light",
-		waving = 1,
 		walkable = false,
 		buildable_to = true,
 		is_ground_content = true,


### PR DESCRIPTION
This request depends on minetest.clone_node() being added to builtin via https://github.com/minetest/minetest/pull/1037
