### PR TITLE
Fix player skin changing code.

### DIFF
--- a/mods/default/player.lua
+++ b/mods/default/player.lua
@@ -143,6 +143,13 @@ minetest.register_on_joinplayer(function(player)
 	default.player_set_model(player, "character.x")
 end)
 
+minetest.register_on_leaveplayer(function(player)
+	local name = player:get_player_name()
+	player_model[name] = nil
+	player_anim[name] = nil
+	player_textures[name] = nil
+end)
+
 -- Localize for better performance.
 local player_set_animation = default.player_set_animation
 


### PR DESCRIPTION
The issue is that the player model was not unset when he/she leaves the game, and in next join without a server restart, an `if` block in `player_set_model` prevents changing the model and texture again, because the model previously set (which is still in memory in `player_textures` table) and the "new" model are the same. This caused the player's visual to be set to the old 2D sprite.

The issue can be reproduced as follows:
- Start a server and join two clients (one for viewing the other's skin).
- Make one of the clients leave and rejoin. Now the player uses the 2D sprite.

This patch fixes the issue.
