### PR TITLE
Add support for “disable_locking” minetest.conf setting

### DIFF
--- a/mods/default/crafting.lua
+++ b/mods/default/crafting.lua
@@ -334,14 +334,16 @@ minetest.register_craft({
 	}
 })
 
-minetest.register_craft({
-	output = 'default:chest_locked',
-	recipe = {
-		{'group:wood', 'group:wood', 'group:wood'},
-		{'group:wood', 'default:steel_ingot', 'group:wood'},
-		{'group:wood', 'group:wood', 'group:wood'},
-	}
-})
+if(minetest.setting_getbool("disable_locking") ~= true) then
+	minetest.register_craft({
+		output = 'default:chest_locked',
+		recipe = {
+			{'group:wood', 'group:wood', 'group:wood'},
+			{'group:wood', 'default:steel_ingot', 'group:wood'},
+			{'group:wood', 'group:wood', 'group:wood'},
+		}
+	})
+end
 
 minetest.register_craft({
 	output = 'default:furnace',

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -321,14 +321,16 @@ doors.register_door("doors:door_steel", {
 	sunlight = false,
 })
 
-minetest.register_craft({
-	output = "doors:door_steel",
-	recipe = {
-		{"default:steel_ingot", "default:steel_ingot"},
-		{"default:steel_ingot", "default:steel_ingot"},
-		{"default:steel_ingot", "default:steel_ingot"}
-	}
-})
+if(minetest.setting_getbool("disable_locking") ~= true) then
+	minetest.register_craft({
+		output = "doors:door_steel",
+		recipe = {
+			{"default:steel_ingot", "default:steel_ingot"},
+			{"default:steel_ingot", "default:steel_ingot"},
+			{"default:steel_ingot", "default:steel_ingot"}
+		}
+	})
+end
 
 doors.register_door("doors:door_glass", {
 	description = "Glass Door",


### PR DESCRIPTION
When true, this setting disables the crafting recipes for stuff which can be locked. Currently, this is the steel door and the locked chest. When false, the crafting recipes are registered normally.
When not provided, the setting is assumed to be false.

Fixes #149