### PR TITLE
farming:string should be equal to farming:cotton

### DIFF
--- a/mods/farming/init.lua
+++ b/mods/farming/init.lua
@@ -50,10 +50,7 @@ farming.register_plant("farming:cotton", {
 	fertility = {"grassland", "desert"}
 })
 
-minetest.register_craftitem("farming:string", {
-	description = "String",
-	inventory_image = "farming_cotton.png",
-})
+minetest.register_alias("farming:string", "farming:cotton")
 
 minetest.register_craft({
 	output = "wool:white",


### PR DESCRIPTION
Cotton plants used to drop strings, now they drop farming:cotton. Some mods (namely, throwing) still use farming:string, therefore we need farming:string to be equal farming:cotton.
