### PR TITLE
Set player animations based on movement rather than pressed keys

### DIFF
--- a/mods/default/player.lua
+++ b/mods/default/player.lua
@@ -164,6 +164,8 @@ end)
 local player_set_animation = default.player_set_animation
 local player_attached = default.player_attached
 
+local ps = {}
+
 -- Check each player and apply animations
 minetest.register_globalstep(function(dtime)
 	for _, player in pairs(minetest.get_connected_players()) do
@@ -171,37 +173,34 @@ minetest.register_globalstep(function(dtime)
 		local model_name = player_model[name]
 		local model = model_name and models[model_name]
 		if model and not player_attached[name] then
+			local pos = player:getpos()
+			pos.y = 0
+			local lastpos = ps[name] or {x=0, y=0, z=0}
+			local v
+			if not vector.equals(lastpos, pos) then
+				ps[name] = pos
+				v = 6*vector.distance(lastpos, pos)/dtime
+			end
+
 			local controls = player:get_player_control()
-			local walking = false
-			local animation_speed_mod = model.animation_speed or 30
-
-			-- Determine if the player is walking
-			if controls.up or controls.down or controls.left or controls.right then
-				walking = true
-			end
-
-			-- Determine if the player is sneaking, and reduce animation speed if so
-			if controls.sneak then
-				animation_speed_mod = animation_speed_mod / 2
-			end
 
 			-- Apply animations based on what the player is doing
 			if player:get_hp() == 0 then
 				player_set_animation(player, "lay")
-			elseif walking then
+			elseif v then
 				if player_sneak[name] ~= controls.sneak then
 					player_anim[name] = nil
 					player_sneak[name] = controls.sneak
 				end
 				if controls.LMB then
-					player_set_animation(player, "walk_mine", animation_speed_mod)
+					player_set_animation(player, "walk_mine", v)
 				else
-					player_set_animation(player, "walk", animation_speed_mod)
+					player_set_animation(player, "walk", v)
 				end
 			elseif controls.LMB then
 				player_set_animation(player, "mine")
 			else
-				player_set_animation(player, "stand", animation_speed_mod)
+				player_set_animation(player, "stand", model.animation_speed or 30)
 			end
 		end
 	end

--- a/mods/default/player.lua
+++ b/mods/default/player.lua
@@ -161,7 +161,9 @@ minetest.register_on_leaveplayer(function(player)
 end)
 
 
-if not minetest.is_singleplayer() then
+if minetest.is_singleplayer() then
+	return
+end
 
 -- Localize for better performance.
 local player_set_animation = default.player_set_animation
@@ -179,11 +181,11 @@ minetest.register_globalstep(function(dtime)
 			local pos = player:getpos()
 			pos.y = nil
 			local lastpos = ps[name] or {x=0, z=0}
-			local v
+			local animation_speed
 			if not (lastpos.x == pos.x
 			and lastpos.z == pos.z) then
 				ps[name] = pos
-				v = 6*math.hypot(lastpos.x-pos.x, lastpos.z-pos.z)/dtime
+				animation_speed = 6*math.hypot(lastpos.x-pos.x, lastpos.z-pos.z)/dtime
 			end
 
 			local controls = player:get_player_control()
@@ -191,15 +193,15 @@ minetest.register_globalstep(function(dtime)
 			-- Apply animations based on what the player is doing
 			if player:get_hp() == 0 then
 				player_set_animation(player, "lay")
-			elseif v then
+			elseif animation_speed then
 				if player_sneak[name] ~= controls.sneak then
 					player_anim[name] = nil
 					player_sneak[name] = controls.sneak
 				end
 				if controls.LMB then
-					player_set_animation(player, "walk_mine", v)
+					player_set_animation(player, "walk_mine", animation_speed)
 				else
-					player_set_animation(player, "walk", v)
+					player_set_animation(player, "walk", animation_speed)
 				end
 			elseif controls.LMB then
 				player_set_animation(player, "mine")
@@ -209,5 +211,3 @@ minetest.register_globalstep(function(dtime)
 		end
 	end
 end)
-
-end

--- a/mods/default/player.lua
+++ b/mods/default/player.lua
@@ -160,6 +160,9 @@ minetest.register_on_leaveplayer(function(player)
 	player_textures[name] = nil
 end)
 
+
+if not minetest.is_singleplayer() then
+
 -- Localize for better performance.
 local player_set_animation = default.player_set_animation
 local player_attached = default.player_attached
@@ -174,12 +177,13 @@ minetest.register_globalstep(function(dtime)
 		local model = model_name and models[model_name]
 		if model and not player_attached[name] then
 			local pos = player:getpos()
-			pos.y = 0
-			local lastpos = ps[name] or {x=0, y=0, z=0}
+			pos.y = nil
+			local lastpos = ps[name] or {x=0, z=0}
 			local v
-			if not vector.equals(lastpos, pos) then
+			if not (lastpos.x == pos.x
+			and lastpos.z == pos.z) then
 				ps[name] = pos
-				v = 6*vector.distance(lastpos, pos)/dtime
+				v = 6*math.hypot(lastpos.x-pos.x, lastpos.z-pos.z)/dtime
 			end
 
 			local controls = player:get_player_control()
@@ -205,3 +209,5 @@ minetest.register_globalstep(function(dtime)
 		end
 	end
 end)
+
+end


### PR DESCRIPTION
let players walk if their position changes and not if they hold specific keys
and disable the animation update globalstep on singleplayer mode because it's not necessary and 3d person view is independent from this globalstep