### PR TITLE
Default and flowers: only run on-generated functions in mgv6. Remove indev code

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -207,69 +207,6 @@ minetest.register_ore({
 	flags          = "absheight",
 })
 
-if minetest.setting_get("mg_name") == "indev" then
-	-- Floatlands and high mountains springs
-	minetest.register_ore({
-		ore_type       = "scatter",
-		ore            = "default:water_source",
-		ore_param2     = 128,
-		wherein        = "default:stone",
-		clust_scarcity = 40*40*40,
-		clust_num_ores = 8,
-		clust_size     = 3,
-		height_min     = 100,
-		height_max     = 31000,
-	})
-
-	minetest.register_ore({
-		ore_type       = "scatter",
-		ore            = "default:lava_source",
-		ore_param2     = 128,
-		wherein        = "default:stone",
-		clust_scarcity = 50*50*50,
-		clust_num_ores = 5,
-		clust_size     = 2,
-		height_min     = 10000,
-		height_max     = 31000,
-	})
-
-	minetest.register_ore({
-		ore_type       = "scatter",
-		ore            = "default:sand",
-		wherein        = "default:stone",
-		clust_scarcity = 20*20*20,
-		clust_num_ores = 5*5*3,
-		clust_size     = 5,
-		height_min     = 500,
-		height_max     = 31000,
-	})
-
-	-- Underground springs
-	minetest.register_ore({
-		ore_type       = "scatter",
-		ore            = "default:water_source",
-		ore_param2     = 128,
-		wherein        = "default:stone",
-		clust_scarcity = 25*25*25,
-		clust_num_ores = 8,
-		clust_size     = 3,
-		height_min     = -10000,
-		height_max     = -10,
-	})
-
-	minetest.register_ore({
-		ore_type       = "scatter",
-		ore            = "default:lava_source",
-		ore_param2     = 128,
-		wherein        = "default:stone",
-		clust_scarcity = 35*35*35,
-		clust_num_ores = 5,
-		clust_size     = 2,
-		height_min     = -31000,
-		height_max     = -100,
-	})
-end
-
 minetest.register_ore({
 	ore_type       = "scatter",
 	ore            = "default:clay",
@@ -323,81 +260,38 @@ function default.generate_ore(name, wherein, minp, maxp, seed, chunks_per_volume
 	--print("generate_ore done")
 end
 
-function default.make_papyrus(pos, size)
-	for y=0,size-1 do
-		local p = {x=pos.x, y=pos.y+y, z=pos.z}
-		local nn = minetest.get_node(p).name
-		if minetest.registered_nodes[nn] and
-			minetest.registered_nodes[nn].buildable_to then
-			minetest.set_node(p, {name="default:papyrus"})
-		else
-			return
+--
+-- Mgv6 papyrus, cactus, long grasses
+--
+
+function default.mgv6_ongen(minp, maxp, seed)
+
+	function default.make_papyrus(pos, size)
+		for y=0,size-1 do
+			local p = {x=pos.x, y=pos.y+y, z=pos.z}
+			local nn = minetest.get_node(p).name
+			if minetest.registered_nodes[nn] and
+				minetest.registered_nodes[nn].buildable_to then
+				minetest.set_node(p, {name="default:papyrus"})
+			else
+				return
+			end
 		end
 	end
-end
-
-function default.make_cactus(pos, size)
-	for y=0,size-1 do
-		local p = {x=pos.x, y=pos.y+y, z=pos.z}
-		local nn = minetest.get_node(p).name
-		if minetest.registered_nodes[nn] and
-			minetest.registered_nodes[nn].buildable_to then
-			minetest.set_node(p, {name="default:cactus"})
-		else
-			return
+	
+	function default.make_cactus(pos, size)
+		for y=0,size-1 do
+			local p = {x=pos.x, y=pos.y+y, z=pos.z}
+			local nn = minetest.get_node(p).name
+			if minetest.registered_nodes[nn] and
+				minetest.registered_nodes[nn].buildable_to then
+				minetest.set_node(p, {name="default:cactus"})
+			else
+				return
+			end
 		end
 	end
-end
 
--- facedir: 0/1/2/3 (head node facedir value)
--- length: length of rainbow tail
-function default.make_nyancat(pos, facedir, length)
-	local tailvec = {x=0, y=0, z=0}
-	if facedir == 0 then
-		tailvec.z = 1
-	elseif facedir == 1 then
-		tailvec.x = 1
-	elseif facedir == 2 then
-		tailvec.z = -1
-	elseif facedir == 3 then
-		tailvec.x = -1
-	else
-		--print("default.make_nyancat(): Invalid facedir: "+dump(facedir))
-		facedir = 0
-		tailvec.z = 1
-	end
-	local p = {x=pos.x, y=pos.y, z=pos.z}
-	minetest.set_node(p, {name="default:nyancat", param2=facedir})
-	for i=1,length do
-		p.x = p.x + tailvec.x
-		p.z = p.z + tailvec.z
-		minetest.set_node(p, {name="default:nyancat_rainbow", param2=facedir})
-	end
-end
-
-function generate_nyancats(seed, minp, maxp)
-	local height_min = -31000
-	local height_max = -32
-	if maxp.y < height_min or minp.y > height_max then
-		return
-	end
-	local y_min = math.max(minp.y, height_min)
-	local y_max = math.min(maxp.y, height_max)
-	local volume = (maxp.x-minp.x+1)*(y_max-y_min+1)*(maxp.z-minp.z+1)
-	local pr = PseudoRandom(seed + 9324342)
-	local max_num_nyancats = math.floor(volume / (16*16*16))
-	for i=1,max_num_nyancats do
-		if pr:next(0, 1000) == 0 then
-			local x0 = pr:next(minp.x, maxp.x)
-			local y0 = pr:next(minp.y, maxp.y)
-			local z0 = pr:next(minp.z, maxp.z)
-			local p0 = {x=x0, y=y0, z=z0}
-			default.make_nyancat(p0, pr:next(0,3), pr:next(3,15))
-		end
-	end
-end
-
-minetest.register_on_generated(function(minp, maxp, seed)
 	if maxp.y >= 2 and minp.y <= 0 then
 		-- Generate papyrus
 		local perlin1 = minetest.get_perlin(354, 3, 0.7, 100)
@@ -506,8 +400,70 @@ minetest.register_on_generated(function(minp, maxp, seed)
 		end
 		end
 	end
+end
 
-	-- Generate nyan cats
-	generate_nyancats(seed, minp, maxp)
+--
+-- Detect mapgen and register suitable on-generated function
+--
+
+minetest.register_on_mapgen_init(function(MapgenParams)
+	mgname = MapgenParams.mgname
+	if mgname == "v6" then
+		minetest.register_on_generated(default.mgv6_ongen)
+	end
 end)
+
+--
+-- Generate nyan cats in all mapgens
+--
+
+-- facedir: 0/1/2/3 (head node facedir value)
+-- length: length of rainbow tail
+function default.make_nyancat(pos, facedir, length)
+	local tailvec = {x=0, y=0, z=0}
+	if facedir == 0 then
+		tailvec.z = 1
+	elseif facedir == 1 then
+		tailvec.x = 1
+	elseif facedir == 2 then
+		tailvec.z = -1
+	elseif facedir == 3 then
+		tailvec.x = -1
+	else
+		--print("default.make_nyancat(): Invalid facedir: "+dump(facedir))
+		facedir = 0
+		tailvec.z = 1
+	end
+	local p = {x=pos.x, y=pos.y, z=pos.z}
+	minetest.set_node(p, {name="default:nyancat", param2=facedir})
+	for i=1,length do
+		p.x = p.x + tailvec.x
+		p.z = p.z + tailvec.z
+		minetest.set_node(p, {name="default:nyancat_rainbow", param2=facedir})
+	end
+end
+
+function default.generate_nyancats(minp, maxp, seed)
+	local height_min = -31000
+	local height_max = -32
+	if maxp.y < height_min or minp.y > height_max then
+		return
+	end
+	local y_min = math.max(minp.y, height_min)
+	local y_max = math.min(maxp.y, height_max)
+	local volume = (maxp.x-minp.x+1)*(y_max-y_min+1)*(maxp.z-minp.z+1)
+	local pr = PseudoRandom(seed + 9324342)
+	local max_num_nyancats = math.floor(volume / (16*16*16))
+	for i=1,max_num_nyancats do
+		if pr:next(0, 1000) == 0 then
+			local x0 = pr:next(minp.x, maxp.x)
+			local y0 = pr:next(minp.y, maxp.y)
+			local z0 = pr:next(minp.z, maxp.z)
+			local p0 = {x=x0, y=y0, z=z0}
+			default.make_nyancat(p0, pr:next(0,3), pr:next(3,15))
+		end
+	end
+end
+
+minetest.register_on_generated(default.generate_nyancats)
 

--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -1,6 +1,9 @@
 -- Minetest 0.4 mod: default
 -- See README.txt for licensing and other information.
 
+-- Namespace for functions
+flowers = {}
+
 -- Map Generation
 dofile(minetest.get_modpath("flowers").."/mapgen.lua")
 

--- a/mods/flowers/mapgen.lua
+++ b/mods/flowers/mapgen.lua
@@ -1,4 +1,4 @@
-minetest.register_on_generated(function(minp, maxp, seed)
+function flowers.mgv6ongen(minp, maxp, seed)
 	if maxp.y >= 2 and minp.y <= 0 then
 		-- Generate flowers
 		local perlin1 = minetest.get_perlin(436, 3, 0.6, 100)
@@ -59,4 +59,14 @@ minetest.register_on_generated(function(minp, maxp, seed)
 		end
 		end
 	end
+end
+
+-- Enable in mapgen v6 only
+
+minetest.register_on_mapgen_init(function(MapgenParams)
+	mgname = MapgenParams.mgname
+	if mgname == "v6" then
+		minetest.register_on_generated(flowers.mgv6ongen)
+	end
 end)
+


### PR DESCRIPTION
I just discovered that default and flowers mods are running slow and unnecessary on-generation functions in mgv5, mgv7 and singlenode mapgens, these are making unwanted flora appear in mgv5 and mgv7 when default nodes are added using the biome API.
Mgv5, mgv7 and future mapgens will be using the biome API.
Nyancat generation is moved to a separate on-generated function to continue in all mapgens.
I also found some indev mapgen code to delete.
