### PR TITLE
Fix some undeclared global variables

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -309,7 +309,7 @@ minetest.register_abm({
 		end
 		if not do_preserve then
 			-- Drop stuff other than the node itself
-			itemstacks = minetest.get_node_drops(n0.name)
+			local itemstacks = minetest.get_node_drops(n0.name)
 			for _, itemname in ipairs(itemstacks) do
 				if minetest.get_item_group(n0.name, "leafdecay_drop") ~= 0 or
 						itemname ~= n0.name then

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -393,19 +393,19 @@ minetest.register_node("default:bookshelf", {
 	groups = {choppy=3,oddly_breakable_by_hand=2,flammable=3},
 	sounds = default.node_sound_wood_defaults(),
 	on_construct = function(pos)
-		local meta = minetest.env:get_meta(pos)
+		local meta = minetest.get_meta(pos)
 		meta:set_string("formspec", default.bookshelf_formspec)
 		local inv = meta:get_inventory()
 		inv:set_size("books", 8*2)
 	end,
 	can_dig = function(pos,player)
-		local meta = minetest.env:get_meta(pos);
+		local meta = minetest.get_meta(pos);
 		local inv = meta:get_inventory()
 		return inv:is_empty("books")
 	end,
 
 	allow_metadata_inventory_put = function(pos, listname, index, stack, player)
-		local meta = minetest.env:get_meta(pos)
+		local meta = minetest.get_meta(pos)
 		local inv = meta:get_inventory()
 		if listname == "books" then
 			if stack:get_name() == "default:book" then
@@ -417,7 +417,7 @@ minetest.register_node("default:bookshelf", {
 	end,
 
 	allow_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)
-		local meta = minetest.env:get_meta(pos)
+		local meta = minetest.get_meta(pos)
 		local inv = meta:get_inventory()
 		local stack = inv:get_stack(from_list, from_index)
 		local to_stack = inv:get_stack(to_list, to_index)

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -380,18 +380,17 @@ local function punch(pos)
 	local me = minetest.get_node(pos)
 	local tmp_node
 	local tmp_node2
-	oben = {x=pos.x, y=pos.y+1, z=pos.z}
-		if state == 1 then
-			state = 0
-			minetest.sound_play("door_close", {pos = pos, gain = 0.3, max_hear_distance = 10})
-			tmp_node = {name="doors:trapdoor", param1=me.param1, param2=me.param2}
-		else
-			state = 1
-			minetest.sound_play("door_open", {pos = pos, gain = 0.3, max_hear_distance = 10})
-			tmp_node = {name="doors:trapdoor_open", param1=me.param1, param2=me.param2}
-		end
-		update_door(pos, tmp_node)
-		meta:set_int("state", state)
+	if state == 1 then
+		state = 0
+		minetest.sound_play("door_close", {pos = pos, gain = 0.3, max_hear_distance = 10})
+		tmp_node = {name="doors:trapdoor", param1=me.param1, param2=me.param2}
+	else
+		state = 1
+		minetest.sound_play("door_open", {pos = pos, gain = 0.3, max_hear_distance = 10})
+		tmp_node = {name="doors:trapdoor_open", param1=me.param1, param2=me.param2}
+	end
+	update_door(pos, tmp_node)
+	meta:set_int("state", state)
 end
 
 minetest.register_node("doors:trapdoor", {

--- a/mods/farming/nodes.lua
+++ b/mods/farming/nodes.lua
@@ -106,8 +106,8 @@ minetest.register_abm({
 			return
 		end
 		-- check if there is water nearby
+		local wet_lvl = minetest.get_item_group(node.name, "wet")
 		if minetest.find_node_near(pos, 3, {"group:water"}) then
-			local wet_lvl = minetest.get_item_group(node.name, "wet")
 			-- if it is dry soil and not base node, turn it into wet soil
 			if wet_lvl == 0 then
 				minetest.set_node(pos, {name = wet})

--- a/mods/sethome/init.lua
+++ b/mods/sethome/init.lua
@@ -30,7 +30,7 @@ minetest.register_chatcommand("home", {
     description = "Teleport you to your home point",
     privs = {home=true},
     func = function(name)
-        local player = minetest.env:get_player_by_name(name)
+        local player = minetest.get_player_by_name(name)
         if player == nil then
             -- just a check to prevent the server crashing
             return false
@@ -48,7 +48,7 @@ minetest.register_chatcommand("sethome", {
     description = "Set your home point",
     privs = {home=true},
     func = function(name)
-        local player = minetest.env:get_player_by_name(name)
+        local player = minetest.get_player_by_name(name)
         local pos = player:getpos()
         homepos[player:get_player_name()] = pos
         minetest.chat_send_player(name, "Home set!")


### PR DESCRIPTION
Addresses #344 and fixes warnings in bucket, default and farming.

```
21:30:26: ERROR[ServerThread]: Assignment to undeclared global "node" inside a function at ...t-servers/bin/../worlds/server/game/mods/bucket/init.lua:138.
21:30:26: ERROR[ServerThread]: Assignment to undeclared global "liquiddef" inside a function at ...t-servers/bin/../worlds/server/game/mods/bucket/init.lua:139.
13:14:16: ERROR[ServerThread]: Assignment to undeclared global "itemstacks" inside a function at ...ers/bin/../worlds/server/game/mods/default/functions.lua:258.
12:56:24: WARNING: Undeclared global variable "wet_lvl" accessed at ...servers/bin/../worlds/server/game/mods/farming/nodes.lua:117
12:56:24: WARNING: Undeclared global variable "wet_lvl" accessed at ...servers/bin/../worlds/server/game/mods/farming/nodes.lua:124 
```

Also removes an unused line in doors which causes a warning.
And might as well remove a few references to .env rather than creating a seperate commit.
