### PR TITLE
Fix leaked globals.

### DIFF
--- a/mods/bucket/init.lua
+++ b/mods/bucket/init.lua
@@ -135,8 +135,8 @@ minetest.register_craftitem("bucket:bucket_empty", {
 			return
 		end
 		-- Check if pointing to a liquid source
-		node = minetest.get_node(pointed_thing.under)
-		liquiddef = bucket.liquids[node.name]
+		local node = minetest.get_node(pointed_thing.under)
+		local liquiddef = bucket.liquids[node.name]
 		if liquiddef ~= nil and liquiddef.itemname ~= nil and
 			(node.name == liquiddef.source or
 			(node.name == liquiddef.flowing and


### PR DESCRIPTION
```
00:40:25: ERROR[ServerThread]: Assignment to undeclared global "node" inside a function at ...minetest\bin\..\games\minetest_game\mods\bucket\init.lua:138.
00:40:25: ERROR[ServerThread]: Assignment to undeclared global "liquiddef" inside a function at ...minetest\bin\..\games\minetest_game\mods\bucket\init.lua:139.
```
