### PR TITLE
Make digging ores also give cobblestone

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -25,7 +25,12 @@ minetest.register_node("default:stone_with_coal", {
 	tiles = {"default_stone.png^default_mineral_coal.png"},
 	is_ground_content = true,
 	groups = {cracky=3},
-	drop = 'default:coal_lump',
+	drop = {
+		items = {
+			{items = {"default:cobble"}},
+			{items = {"default:coal_lump"}},
+		},
+	},
 	sounds = default.node_sound_stone_defaults(),
 })
 
@@ -34,7 +39,12 @@ minetest.register_node("default:stone_with_iron", {
 	tiles = {"default_stone.png^default_mineral_iron.png"},
 	is_ground_content = true,
 	groups = {cracky=2},
-	drop = 'default:iron_lump',
+	drop = {
+		items = {
+			{items = {"default:cobble"}},
+			{items = {"default:iron_lump"}},
+		},
+	},
 	sounds = default.node_sound_stone_defaults(),
 })
 
@@ -43,7 +53,12 @@ minetest.register_node("default:stone_with_copper", {
 	tiles = {"default_stone.png^default_mineral_copper.png"},
 	is_ground_content = true,
 	groups = {cracky=2},
-	drop = 'default:copper_lump',
+	drop = {
+		items = {
+			{items = {"default:cobble"}},
+			{items = {"default:copper_lump"}},
+		},
+	},
 	sounds = default.node_sound_stone_defaults(),
 })
 
@@ -52,7 +67,12 @@ minetest.register_node("default:stone_with_mese", {
 	tiles = {"default_stone.png^default_mineral_mese.png"},
 	is_ground_content = true,
 	groups = {cracky=1},
-	drop = "default:mese_crystal",
+	drop = {
+		items = {
+			{items = {"default:cobble"}},
+			{items = {"default:mese_crystal"}},
+		},
+	},
 	sounds = default.node_sound_stone_defaults(),
 })
 
@@ -61,7 +81,12 @@ minetest.register_node("default:stone_with_gold", {
 	tiles = {"default_stone.png^default_mineral_gold.png"},
 	is_ground_content = true,
 	groups = {cracky=2},
-	drop = "default:gold_lump",
+	drop = {
+		items = {
+			{items = {"default:cobble"}},
+			{items = {"default:gold_lump"}},
+		},
+	},
 	sounds = default.node_sound_stone_defaults(),
 })
 	
@@ -70,7 +95,12 @@ minetest.register_node("default:stone_with_diamond", {
 	tiles = {"default_stone.png^default_mineral_diamond.png"},
 	is_ground_content = true,
 	groups = {cracky=1},
-	drop = "default:diamond",
+	drop = {
+		items = {
+			{items = {"default:cobble"}},
+			{items = {"default:diamond"}},
+		},
+	},
 	sounds = default.node_sound_stone_defaults(),
 })
 


### PR DESCRIPTION
Currently, when you dig an ore, you don't get cobblestone. This may be a problem when you're mining in caves, because you may eventually run out of cobblestone if you only dig ores and not stone.

When you dig an ore, you now _also_ get a cobblestone.
