### PR TITLE
Make some tools dig faster

### DIFF
--- a/mods/default/tools.lua
+++ b/mods/default/tools.lua
@@ -40,7 +40,7 @@ minetest.register_tool("default:pick_stone", {
 		full_punch_interval = 1.3,
 		max_drop_level=0,
 		groupcaps={
-			cracky = {times={[2]=2.0, [3]=1.20}, uses=20, maxlevel=1},
+			cracky = {times={[2]=2.0, [3]=1.00}, uses=20, maxlevel=1},
 		},
 		damage_groups = {fleshy=3},
 	},
@@ -188,7 +188,7 @@ minetest.register_tool("default:axe_wood", {
 		full_punch_interval = 1.0,
 		max_drop_level=0,
 		groupcaps={
-			choppy = {times={[2]=3.00, [3]=2.00}, uses=10, maxlevel=1},
+			choppy = {times={[2]=3.00, [3]=1.60}, uses=10, maxlevel=1},
 		},
 		damage_groups = {fleshy=2},
 	},
@@ -200,7 +200,7 @@ minetest.register_tool("default:axe_stone", {
 		full_punch_interval = 1.2,
 		max_drop_level=0,
 		groupcaps={
-			choppy={times={[1]=3.00, [2]=2.00, [3]=1.50}, uses=20, maxlevel=1},
+			choppy={times={[1]=3.00, [2]=2.00, [3]=1.30}, uses=20, maxlevel=1},
 		},
 		damage_groups = {fleshy=3},
 	},


### PR DESCRIPTION
* **Stone pickaxe:** 1.20 ⇒ 1.00 seconds to dig `cracky = 3` nodes like stone and coal ores. This should make the game feel much better to play.

* **Wooden axe:** 2.00 ⇒ 1.60 seconds to dig `choppy = 3` nodes like trees. Before, the wooden axe was no faster than the hand, as they both had 2.00 seconds digging time.

* **Stone axe:** 1.50 ⇒ 1.30 seconds to dig `choppy = 3` nodes like trees.