### PR TITLE
Make it possible to craft sticks into wood

### DIFF
--- a/mods/default/crafting.lua
+++ b/mods/default/crafting.lua
@@ -22,6 +22,14 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
+	output = 'default:wood',
+	recipe = {
+		{'default:stick', 'default:stick'},
+		{'default:stick', 'default:stick'},
+	}
+})
+
+minetest.register_craft({
 	output = 'default:fence_wood 2',
 	recipe = {
 		{'group:stick', 'group:stick', 'group:stick'},


### PR DESCRIPTION
You can craft 4 sticks into 1 wooden plank. This is only possible for “standard” wood, not jungle wood since there are no jungle sticks.