### PR TITLE
Give 24 rails per craft instead of 15

### DIFF
--- a/mods/default/crafting.lua
+++ b/mods/default/crafting.lua
@@ -317,7 +317,7 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-	output = 'default:rail 15',
+	output = 'default:rail 24',
 	recipe = {
 		{'default:steel_ingot', '', 'default:steel_ingot'},
 		{'default:steel_ingot', 'group:stick', 'default:steel_ingot'},


### PR DESCRIPTION
This should hopefully make it easier to build railroads. Also, an even number makes more sense.