### PR TITLE
Fix various fire sound bugs

### DIFF
--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -1,5 +1,7 @@
 -- minetest/fire/init.lua
 
+fire = {}
+
 minetest.register_node("fire:basic_flame", {
 	description = "Fire",
 	drawtype = "firelike",
@@ -14,17 +16,16 @@ minetest.register_node("fire:basic_flame", {
 	walkable = false,
 	buildable_to = true,
 	damage_per_second = 4,
-	
-	after_place_node = function(pos, placer)
-		fire.on_flame_add_at(pos)
+
+	on_construct = function(pos)
+		minetest.after(0, fire.on_flame_add_at, pos)
 	end,
-	
-	after_dig_node = function(pos, oldnode, oldmetadata, digger)
-		fire.on_flame_remove_at(pos)
+
+	on_destruct = function(pos)
+		minetest.after(0, fire.on_flame_remove_at, pos)
 	end,
 })
 
-fire = {}
 fire.D = 6
 -- key: position hash of low corner of area
 -- value: {handle=sound handle, name=sound name}
@@ -81,12 +82,10 @@ function fire.update_sounds_around(pos)
 end
 
 function fire.on_flame_add_at(pos)
-	--print("flame added at "..minetest.pos_to_string(pos))
 	fire.update_sounds_around(pos)
 end
 
 function fire.on_flame_remove_at(pos)
-	--print("flame removed at "..minetest.pos_to_string(pos))
 	fire.update_sounds_around(pos)
 end
 
@@ -117,7 +116,6 @@ minetest.register_abm({
 		local p = fire.find_pos_for_flame_around(p0)
 		if p then
 			minetest.set_node(p, {name="fire:basic_flame"})
-			fire.on_flame_add_at(p)
 		end
 	end,
 })
@@ -143,7 +141,6 @@ minetest.register_abm({
 			local p2 = fire.find_pos_for_flame_around(p)
 			if p2 then
 				minetest.set_node(p2, {name="fire:basic_flame"})
-				fire.on_flame_add_at(p2)
 			end
 		end
 	end,
@@ -158,7 +155,6 @@ minetest.register_abm({
 		-- If there is water or stuff like that around flame, remove flame
 		if fire.flame_should_extinguish(p0) then
 			minetest.remove_node(p0)
-			fire.on_flame_remove_at(p0)
 			return
 		end
 		-- Make the following things rarer
@@ -168,7 +164,6 @@ minetest.register_abm({
 		-- If there are no flammable nodes around flame, remove flame
 		if not minetest.find_node_near(p0, 1, {"group:flammable"}) then
 			minetest.remove_node(p0)
-			fire.on_flame_remove_at(p0)
 			return
 		end
 		if math.random(1,4) == 1 then
@@ -185,7 +180,6 @@ minetest.register_abm({
 		else
 			-- remove flame
 			minetest.remove_node(p0)
-			fire.on_flame_remove_at(p0)
 		end
 	end,
 })


### PR DESCRIPTION
Using `on_construct` and `on_destruct` makes sure that the update functions are called in all cases where the node placed or removed (not only when the player digs a fire node).
`minetest.after` is used to make sure the node is already replaced at the position (otherwise the old node is still present in `on_destruct`).
Fixes #274.
