### PR TITLE
bone-mod fixes: 1. don't delete protected nodes, 2. time out in loaded chunks, 3. don't crash when dying in certain nodes (like default doors or sign_lib signs)

### DIFF
--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -91,6 +91,7 @@ minetest.register_node("bones:bones", {
 			meta:set_string("infotext", meta:get_string("owner").."'s old bones")
 			meta:set_string("owner", "")
 		else
+			meta:set_int("time", time)
 			return true
 		end
 	end,

--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -9,6 +9,8 @@ local function is_owner(pos, name)
 	return false
 end
 
+local share_bones_time = tonumber(minetest.setting_get("share_bones_time") or 1200)
+
 minetest.register_node("bones:bones", {
 	description = "Bones",
 	tiles = {
@@ -84,15 +86,8 @@ minetest.register_node("bones:bones", {
 	
 	on_timer = function(pos, elapsed)
 		local meta = minetest.get_meta(pos)
-		local time = meta:get_int("time")+elapsed
-		local publish = 1200
-		if tonumber(minetest.setting_get("share_bones_time")) then
-			publish = tonumber(minetest.setting_get("share_bones_time"))
-		end
-		if publish == 0 then
-			return
-		end
-		if time >= publish then
+		local time = meta:get_int("time") + elapsed
+		if time >= share_bones_time then
 			meta:set_string("infotext", meta:get_string("owner").."'s old bones")
 			meta:set_string("owner", "")
 		else
@@ -188,10 +183,13 @@ minetest.register_on_dieplayer(function(player)
 	meta:set_string("formspec", "size[8,9;]"..
 			"list[current_name;main;0,0;8,4;]"..
 			"list[current_player;main;0,5;8,4;]")
-	meta:set_string("infotext", player_name.."'s fresh bones")
 	meta:set_string("owner", player_name)
-	meta:set_int("time", 0)
 	
-	local timer  = minetest.get_node_timer(pos)
-	timer:start(10)
+	if share_bones_time ~= 0 then
+		meta:set_string("infotext", player_name.."'s fresh bones")
+		meta:set_int("time", 0)
+		minetest.get_node_timer(pos):start(10)
+	else
+		meta:set_string("infotext", player_name.."'s bones")
+	end
 end)

--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -102,17 +102,23 @@ minetest.register_node("bones:bones", {
 })
 
 local function may_replace(pos, player)
-	local nodename = minetest.get_node(pos).name
+	local node_name = minetest.get_node(pos).name
+	local node_definition = minetest.registered_nodes[node_name]
 
-	-- allow replacing air and liquids
-	if nodename == "air" or minetest.registered_nodes[nodename].liquidtype ~= "none" then
-		return true
-	end
+	-- if the node is unknown, we let the protection mod decide
+	-- unknown decoration would often be removed
+	-- while unknown building materials in use would usually be left
+	if node_definition then
+		-- allow replacing air and liquids
+		if node_name == "air" or node_definition.liquidtype ~= "none" then
+			return true
+		end
 
-	-- don't replace filled chests and other nodes that don't allow it
-	if minetest.registered_nodes[nodename].can_dig and
-		not minetest.registered_nodes[nodename].can_dig(pos, player) then
-		return false
+		-- don't replace filled chests and other nodes that don't allow it
+		local can_dig_func = node_definition.can_dig
+		if can_dig_func and not can_dig_func(pos, player) then
+			return false
+		end
 	end
 
 	-- only replace nodes that are not protected

--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -103,7 +103,6 @@ minetest.register_node("bones:bones", {
 
 local function may_replace(pos, player)
 	local nodename = minetest.get_node(pos).name
-	print(nodename)
 
 	-- allow replacing air and liquids
 	if nodename == "air" or minetest.registered_nodes[nodename].liquidtype ~= "none" then

--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -139,17 +139,24 @@ minetest.register_on_dieplayer(function(player)
 	local player_inv = player:get_inventory()
 
 	if (not may_replace(pos, player)) then
-		-- drop items instead of delete
-		for i=1,player_inv:get_size("main") do
-			minetest.add_item(pos, player_inv:get_stack("main", i))
+		if (may_replace({x=pos.x, y=pos.y+1, z=pos.z}, player)) then
+			-- drop one node above if there's space
+			-- this should solve most cases of protection related deaths in which players dig straight down
+			-- yet keeps the bones reachable
+			pos.y = pos.y+1
+		else
+			-- drop items instead of delete
+			for i=1,player_inv:get_size("main") do
+				minetest.add_item(pos, player_inv:get_stack("main", i))
+			end
+			for i=1,player_inv:get_size("craft") do
+				minetest.add_item(pos, player_inv:get_stack("craft", i))
+			end
+			-- empty lists main and craft
+			player_inv:set_list("main", {})
+			player_inv:set_list("craft", {})
+			return
 		end
-		for i=1,player_inv:get_size("craft") do
-			minetest.add_item(pos, player_inv:get_stack("craft", i))
-		end
-		-- empty lists main and craft
-		player_inv:set_list("main", {})
-		player_inv:set_list("craft", {})
-		return
 	end
 	
 	minetest.set_node(pos, {name="bones:bones", param2=param2})

--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -10,6 +10,7 @@ local function is_owner(pos, name)
 end
 
 local share_bones_time = tonumber(minetest.setting_get("share_bones_time") or 1200)
+local share_bones_time_early = tonumber(minetest.setting_get("share_bones_time_early") or (share_bones_time/4))
 
 minetest.register_node("bones:bones", {
 	description = "Bones",
@@ -188,7 +189,13 @@ minetest.register_on_dieplayer(function(player)
 	
 	if share_bones_time ~= 0 then
 		meta:set_string("infotext", player_name.."'s fresh bones")
-		meta:set_int("time", 0)
+
+		if share_bones_time_early == 0 or not minetest.is_protected(pos, player_name) then
+			meta:set_int("time", 0)
+		else
+			meta:set_int("time", (share_bones_time - share_bones_time_early))
+		end
+
 		minetest.get_node_timer(pos):start(10)
 	else
 		meta:set_string("infotext", player_name.."'s bones")


### PR DESCRIPTION
uses specific checks, due to minetest/minetest#2015