### PR TITLE
Clean up trapdoors code and make them more flexible

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -26,11 +26,17 @@ The bucket API allows registering new types of buckets for non-default liquids.
 
 Doors API
 ---------
-The doors mod allows modders to register custom doors.
+The doors mod allows modders to register custom doors and trapdoors.
 
-	doors.register_door(name, def)
-	^ name: "Door name"
-	^ def: See [#Door definition]
+doors.register_door(name, def)
+^ name: "Door name"
+^ def: See [#Door definition]
+ -> Registers new door
+
+doors.register_trapdoor(name, def)
+^ name: "Trapdoor name"
+^ def: See [#Trapdoor definition]
+ -> Registers new trapdoor
 
 #Door definition
 ----------------
@@ -50,6 +56,21 @@ The doors mod allows modders to register custom doors.
 	sound_close_door = sound play for close door, OPTIONAL,
 	only_placer_can_open = true/false,
 	^ If true, only placer can open the door (locked for others)
+}
+
+#Trapdoor definition
+----------------
+{
+	tile_front = "doors_trapdoor.png",
+	^ the texture for the front and back of the trapdoor
+	tile_side: "doors_trapdoor_side.png",
+	^ the tiles of the four side parts of the trapdoor
+	sound_open = sound to play when opening the trapdoor, OPTIONAL,
+	sound_close = sound to play when closing the trapdoor, OPTIONAL,
+	-> You can add any other node definition properties for minetest.register_node,
+	   such as wield_image, inventory_image, sounds, groups, description, ...
+	   Only node_box, selection_box, tiles, drop, drawtype, paramtype, paramtype2, on_rightclick
+	   will be overwritten by the trapdoor registration function
 }
 
 Farming API

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -354,77 +354,69 @@ minetest.register_craft({
 
 ----trapdoor----
 
-local function update_door(pos, node) 
-	minetest.set_node(pos, node)
-end
+function doors.register_trapdoor(name, def)
+	local name_closed = name
+	local name_opened = name.."_open"
 
-local function punch(pos)
-	local meta = minetest.get_meta(pos)
-	local state = meta:get_int("state")
-	local me = minetest.get_node(pos)
-	local tmp_node
-	local tmp_node2
-	if state == 1 then
-		state = 0
-		minetest.sound_play("doors_door_close", {pos = pos, gain = 0.3, max_hear_distance = 10})
-		tmp_node = {name="doors:trapdoor", param1=me.param1, param2=me.param2}
-	else
-		state = 1
-		minetest.sound_play("doors_door_open", {pos = pos, gain = 0.3, max_hear_distance = 10})
-		tmp_node = {name="doors:trapdoor_open", param1=me.param1, param2=me.param2}
+	def.on_rightclick = function (pos, node)
+		local newname = node.name == name_closed and name_opened or name_closed
+		local sound = false
+		if node.name == name_closed then sound = def.sound_open end
+		if node.name == name_opened then sound = def.sound_close end
+		if sound then
+			minetest.sound_play(sound, {pos = pos, gain = 0.3, max_hear_distance = 10})
+		end
+		minetest.set_node(pos, {name = newname, param1 = node.param1, param2 = node.param2})
 	end
-	update_door(pos, tmp_node)
-	meta:set_int("state", state)
+
+	-- Common trapdoor configuration
+	def.drawtype = "nodebox"
+	def.paramtype = "light"
+	def.paramtype2 = "facedir"
+
+	local def_opened = table.copy(def)
+	local def_closed = table.copy(def)
+
+	def_closed.node_box = {
+		type = "fixed",
+		fixed = {-0.5, -0.5, -0.5, 0.5, -0.4, 0.5}
+	}
+	def_closed.selection_box = {
+		type = "fixed",
+		fixed = {-0.5, -0.5, -0.5, 0.5, -0.4, 0.5}
+	}
+	def_closed.tiles = { def.tile_front, def.tile_front, def.tile_side, def.tile_side,
+		def.tile_side, def.tile_side }
+
+	def_opened.node_box = {
+		type = "fixed",
+		fixed = {-0.5, -0.5, 0.4, 0.5, 0.5, 0.5}
+	}
+	def_opened.selection_box = {
+		type = "fixed",
+		fixed = {-0.5, -0.5, 0.4, 0.5, 0.5, 0.5}
+	}
+	def_opened.tiles = { def.tile_side, def.tile_side, def.tile_side, def.tile_side,
+		def.tile_front, def.tile_front }
+	def_opened.drop = name_closed
+	def_opened.groups.not_in_creative_inventory = 1
+
+	minetest.register_node(name_opened, def_opened)
+	minetest.register_node(name_closed, def_closed)
 end
 
-minetest.register_node("doors:trapdoor", {
+
+
+doors.register_trapdoor("doors:trapdoor", {
 	description = "Trapdoor",
 	inventory_image = "doors_trapdoor.png",
-	drawtype = "nodebox",
-	tiles = {"doors_trapdoor.png", "doors_trapdoor.png",  "doors_trapdoor_side.png",  "doors_trapdoor_side.png", "doors_trapdoor_side.png", "doors_trapdoor_side.png"},
-	paramtype = "light",
-	paramtype2 = "facedir",
-	groups = {snappy=1,choppy=2,oddly_breakable_by_hand=2,flammable=2,door=1},
+	wield_image = "doors_trapdoor.png",
+	tile_front = "doors_trapdoor.png",
+	tile_side = "doors_trapdoor_side.png",
+	groups = {snappy=1, choppy=2, oddly_breakable_by_hand=2, flammable=2, door=1},
 	sounds = default.node_sound_wood_defaults(),
-	drop = "doors:trapdoor",
-	node_box = {
-		type = "fixed",
-		fixed = {-0.5, -0.5, -0.5, 0.5, -0.4, 0.5}
-	},
-	selection_box = {
-		type = "fixed",
-		fixed = {-0.5, -0.5, -0.5, 0.5, -0.4, 0.5}
-	},
-	on_creation = function(pos)
-		state = 0
-	end,
-	on_rightclick = function(pos, node, clicker)
-		punch(pos)
-	end,
-})
-
-minetest.register_node("doors:trapdoor_open", {
-	drawtype = "nodebox",
-	tiles = {"doors_trapdoor_side.png", "doors_trapdoor_side.png",  "doors_trapdoor_side.png",  "doors_trapdoor_side.png", "doors_trapdoor.png", "doors_trapdoor.png"},
-	paramtype = "light",
-	paramtype2 = "facedir",
-	pointable = true,
-	stack_max = 0,
-	groups = {snappy=1,choppy=2,oddly_breakable_by_hand=2,flammable=2,door=1},
-	climbable = true,
-	sounds = default.node_sound_wood_defaults(),
-	drop = "doors:trapdoor",
-	node_box = {
-		type = "fixed",
-		fixed = {-0.5, -0.5, 0.4, 0.5, 0.5, 0.5}
-	},
-	selection_box = {
-		type = "fixed",
-		fixed = {-0.5, -0.5, 0.4, 0.5, 0.5, 0.5}
-	},
-	on_rightclick = function(pos, node, clicker)
-		punch(pos)
-	end,
+	sound_open = "doors_door_open",
+	sound_close = "doors_door_close"
 })
 
 minetest.register_craft({


### PR DESCRIPTION
The trapdoors code was really weird before, with unneccessary `minetest.get_node(pos)` requests, variables that were defined but never used (`tmp_node2`) and things that, I guess, are mainly there because of historic reasons.

That's why I decided to clean up that piece of code and changed it so that  hird-party mods can now also use:

```Lua
doors.register_trapdoor("doors:trapdoor", {
	description = "Trapdoor",
	inventory_image = "doors_trapdoor.png",
	tile_front = "doors_trapdoor.png",
	tile_side = "doors_trapdoor_side.png",
	groups = {snappy=1, choppy=2, oddly_breakable_by_hand=2, flammable=2, door=1},
	sounds = default.node_sound_wood_defaults()
})
```

There might be bugs, please report them to me. I haven't tested this thoroughly enough, but it should work just the way the current trapdoors work and shouldn't break compatibility. That is unless any mod happens to depend on the variable `"state"` in the trapdoor node's meta. I don't believe that is the case, but maintaining compatibility there would be an easy fix.