### PR TITLE
Adding bones' drop feature

### DIFF
--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -76,6 +76,10 @@ minetest.register_node("bones:bones", {
 			return
 		end
 		
+		if(minetest.get_meta(pos):get_string("infotext") == "") then
+			return
+		end
+		
 		local inv = minetest.get_meta(pos):get_inventory()
 		local player_inv = player:get_inventory()
 		local has_space = true
@@ -93,6 +97,11 @@ minetest.register_node("bones:bones", {
 		
 		-- remove bones if player emptied them
 		if has_space then
+			if player_inv:room_for_item("main", {name = "bones:bones"}) then
+				player_inv:add_item("main", {name = "bones:bones"})
+			else
+				minetest.add_item(pos,"bones:bones")
+			end
 			minetest.remove_node(pos)
 		end
 	end,


### PR DESCRIPTION
Before, when you died, you got to punch you bones to get back your stuff, the bones block was not dropped.
However, a lot of people wants to use them for decorations/building, and have to install a dedicated mod since 0.4.10's version of minetest_game.
With this commit, a bones block containing an inventory is dropped/added to inventory (if enough room) when the bones block is removed.
Then, when a player places a bones block by himself, he will dig it like any other basic node (eg. default:tree), not just punch it.

Thanks for reading.