### PR TITLE
Add ores support for singlenode

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -784,5 +784,8 @@ elseif mg_params.mgname == "v7" then
 	default.register_biomes()
 	default.register_blobs()
 	default.register_ores()
+elseif mg_params.mgname == "singlenode" then -- custom mapgens may use these features
+	default.register_blobs()
+	default.register_ores()
 end
 


### PR DESCRIPTION
The ores aren't registered in singlenode. So we can't generate the ores with `minetest.generate_ores(vm)` in a custom mapgen.