### PR TITLE
Make TNT respect on_blast, implement on_blast for some nodes

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1234,6 +1234,7 @@ minetest.register_node("default:chest_locked", {
 			)
 		end
 	end,
+	on_blast = function() end,
 })
 
 

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -25,6 +25,9 @@ function doors.register_door(name, def)
 	if not def.sound_open_door then
 		def.sound_open_door = "doors_door_open"
 	end
+	if def.only_placer_can_open then
+		def.on_blast = function() end
+	end
 	
 	
 	minetest.register_craftitem(name, {
@@ -173,7 +176,8 @@ function doors.register_door(name, def)
 		
 		can_dig = check_player_priv,
 		sounds = def.sounds,
-        	sunlight_propagates = def.sunlight
+		sunlight_propagates = def.sunlight,
+		on_blast = def.on_blast,
 	})
 
 	minetest.register_node(name.."_t_1", {
@@ -205,7 +209,8 @@ function doors.register_door(name, def)
 		
 		can_dig = check_player_priv,
 		sounds = def.sounds,
-        	sunlight_propagates = def.sunlight,
+		sunlight_propagates = def.sunlight,
+		on_blast = def.on_blast,
 	})
 
 	minetest.register_node(name.."_b_2", {
@@ -237,7 +242,8 @@ function doors.register_door(name, def)
 		
 		can_dig = check_player_priv,
 		sounds = def.sounds,
-        	sunlight_propagates = def.sunlight
+		sunlight_propagates = def.sunlight,
+		on_blast = def.on_blast,
 	})
 
 	minetest.register_node(name.."_t_2", {
@@ -269,7 +275,8 @@ function doors.register_door(name, def)
 		
 		can_dig = check_player_priv,
 		sounds = def.sounds,
-        	sunlight_propagates = def.sunlight
+		sunlight_propagates = def.sunlight,
+		on_blast = def.on_blast,
 	})
 
 end

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -25,10 +25,6 @@ function doors.register_door(name, def)
 	if not def.sound_open_door then
 		def.sound_open_door = "doors_door_open"
 	end
-	if def.only_placer_can_open then
-		-- unaffected by explosions
-		def.on_blast = function() end
-	end
 	
 	
 	minetest.register_craftitem(name, {
@@ -112,6 +108,33 @@ function doors.register_door(name, def)
 		end
 	end
 
+	local function check_and_blast(pos, name)
+		local node = minetest.get_node(pos)
+		if node.name == name then
+			minetest.remove_node(pos)
+		end
+	end
+
+	local function make_on_blast(base_name, door_type, other_door_type)
+		if def.only_placer_can_open then
+			return function() end
+		else
+			if door_type == "_b_1" or door_type == "_b_2" then
+				return function(pos, intensity)
+					check_and_blast(pos, name..door_type)
+					pos.y = pos.y + 1
+					check_and_blast(pos, name..other_door_type)
+				end
+			elseif door_type == "_t_1" or door_type == "_t_2" then
+				return function(pos, intensity)
+					check_and_blast(pos, name..door_type)
+					pos.y = pos.y - 1
+					check_and_blast(pos, name..other_door_type)
+				end
+			end
+		end
+	end
+
 	local function on_rightclick(pos, dir, check_name, replace, replace_dir, params)
 		pos.y = pos.y+dir
 		if not minetest.get_node(pos).name == check_name then
@@ -178,7 +201,7 @@ function doors.register_door(name, def)
 		can_dig = check_player_priv,
 		sounds = def.sounds,
 		sunlight_propagates = def.sunlight,
-		on_blast = def.on_blast,
+		on_blast = make_on_blast(name, "_b_1", "_t_1")
 	})
 
 	minetest.register_node(name.."_t_1", {
@@ -211,7 +234,7 @@ function doors.register_door(name, def)
 		can_dig = check_player_priv,
 		sounds = def.sounds,
 		sunlight_propagates = def.sunlight,
-		on_blast = def.on_blast,
+		on_blast = make_on_blast(name, "_t_1", "_b_1")
 	})
 
 	minetest.register_node(name.."_b_2", {
@@ -244,7 +267,7 @@ function doors.register_door(name, def)
 		can_dig = check_player_priv,
 		sounds = def.sounds,
 		sunlight_propagates = def.sunlight,
-		on_blast = def.on_blast,
+		on_blast = make_on_blast(name, "_b_2", "_t_2")
 	})
 
 	minetest.register_node(name.."_t_2", {
@@ -277,7 +300,7 @@ function doors.register_door(name, def)
 		can_dig = check_player_priv,
 		sounds = def.sounds,
 		sunlight_propagates = def.sunlight,
-		on_blast = def.on_blast,
+		on_blast = make_on_blast(name, "_t_2", "_b_2")
 	})
 
 end

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -26,6 +26,7 @@ function doors.register_door(name, def)
 		def.sound_open_door = "doors_door_open"
 	end
 	if def.only_placer_can_open then
+		-- unaffected by explosions
 		def.on_blast = function() end
 	end
 	

--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -25,6 +25,7 @@ minetest.register_node("fire:basic_flame", {
 		minetest.after(0, fire.on_flame_remove_at, pos)
 	end,
 
+	-- unaffected by explosions
 	on_blast = function() end,
 })
 

--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -24,6 +24,8 @@ minetest.register_node("fire:basic_flame", {
 	on_destruct = function(pos)
 		minetest.after(0, fire.on_flame_remove_at, pos)
 	end,
+
+	on_blast = function() end,
 })
 
 fire.D = 6

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -248,6 +248,7 @@ minetest.register_node("tnt:tnt_burning", {
 	drop = "",
 	sounds = default.node_sound_wood_defaults(),
 	on_timer = boom,
+	-- unaffected by explosions
 	on_blast = function() end,
 })
 
@@ -261,6 +262,7 @@ minetest.register_node("tnt:boom", {
 	on_timer = function(pos, elapsed)
 		minetest.remove_node(pos)
 	end,
+	-- unaffected by explosions
 	on_blast = function() end,
 })
 
@@ -328,6 +330,7 @@ minetest.register_node("tnt:gunpowder_burning", {
 		end
 		minetest.remove_node(pos)
 	end,
+	-- unaffected by explosions
 	on_blast = function() end,
 })
 

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -82,7 +82,14 @@ local function destroy(drops, pos, cid)
 	if def and def.flammable then
 		minetest.set_node(pos, fire_node)
 	else
-		minetest.remove_node(pos)
+		local nodename = minetest.get_node(pos).name
+		local on_blast = minetest.registered_nodes[nodename].on_blast
+		if on_blast ~= nil then
+			on_blast(pos, 1)
+			return
+		else
+			minetest.remove_node(pos)
+		end
 		if def then
 			local node_drops = minetest.get_node_drops(def.name, "")
 			for _, item in ipairs(node_drops) do
@@ -172,12 +179,6 @@ local function explode(pos, radius)
 	local p = {}
 
 	local c_air = minetest.get_content_id("air")
-	local c_tnt = minetest.get_content_id("tnt:tnt")
-	local c_tnt_burning = minetest.get_content_id("tnt:tnt_burning")
-	local c_gunpowder = minetest.get_content_id("tnt:gunpowder")
-	local c_gunpowder_burning = minetest.get_content_id("tnt:gunpowder_burning")
-	local c_boom = minetest.get_content_id("tnt:boom")
-	local c_fire = minetest.get_content_id("fire:basic_flame")
 
 	for z = -radius, radius do
 	for y = -radius, radius do
@@ -189,13 +190,7 @@ local function explode(pos, radius)
 			p.x = pos.x + x
 			p.y = pos.y + y
 			p.z = pos.z + z
-			if cid == c_tnt or cid == c_gunpowder then
-				burn(p)
-			elseif cid ~= c_tnt_burning and
-					cid ~= c_gunpowder_burning and
-					cid ~= c_air and
-					cid ~= c_fire and
-					cid ~= c_boom then
+			if cid ~= c_air then
 				destroy(drops, p, cid)
 			end
 		end
@@ -231,6 +226,9 @@ minetest.register_node("tnt:tnt", {
 			minetest.get_node_timer(pos):start(4)
 		end
 	end,
+	on_blast = function(pos, intensity)
+		burn(pos)
+	end,
 	mesecons = {effector = {action_on = boom}},
 })
 
@@ -250,6 +248,7 @@ minetest.register_node("tnt:tnt_burning", {
 	drop = "",
 	sounds = default.node_sound_wood_defaults(),
 	on_timer = boom,
+	on_blast = function() end,
 })
 
 minetest.register_node("tnt:boom", {
@@ -262,6 +261,7 @@ minetest.register_node("tnt:boom", {
 	on_timer = function(pos, elapsed)
 		minetest.remove_node(pos)
 	end,
+	on_blast = function() end,
 })
 
 minetest.register_node("tnt:gunpowder", {
@@ -284,6 +284,9 @@ minetest.register_node("tnt:gunpowder", {
 		if puncher:get_wielded_item():get_name() == "default:torch" then
 			burn(pos)
 		end
+	end,
+	on_blast = function(pos, intensity)
+		burn(pos)
 	end,
 })
 
@@ -324,7 +327,8 @@ minetest.register_node("tnt:gunpowder_burning", {
 		end
 		end
 		minetest.remove_node(pos)
-	end
+	end,
+	on_blast = function() end,
 })
 
 minetest.register_abm({

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -83,7 +83,6 @@ local function destroy(drops, pos, cid)
 	if def and def.flammable then
 		minetest.set_node(pos, fire_node)
 	else
-		local nodename = def.name
 		local on_blast = def.on_blast
 		if on_blast ~= nil then
 			on_blast(pos, 1)

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -23,6 +23,7 @@ minetest.after(0, function()
 			name = name,
 			drops = def.drops,
 			flammable = def.groups.flammable,
+			on_blast = def.on_blast,
 		}
 	end
 end)
@@ -82,8 +83,8 @@ local function destroy(drops, pos, cid)
 	if def and def.flammable then
 		minetest.set_node(pos, fire_node)
 	else
-		local nodename = cid_data[cid].name
-		local on_blast = minetest.registered_nodes[nodename].on_blast
+		local nodename = def.name
+		local on_blast = def.on_blast
 		if on_blast ~= nil then
 			on_blast(pos, 1)
 			return

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -82,7 +82,7 @@ local function destroy(drops, pos, cid)
 	if def and def.flammable then
 		minetest.set_node(pos, fire_node)
 	else
-		local nodename = minetest.get_node(pos).name
+		local nodename = cid_data[cid].name
 		local on_blast = minetest.registered_nodes[nodename].on_blast
 		if on_blast ~= nil then
 			on_blast(pos, 1)


### PR DESCRIPTION
This PR alters the way how TNT destroys nodes in a way which I think is much saner and more mod-friendly.

It makes TNT check first whether the node which is about to be destoyed implements `on_blast`, a function which is supposed to be called when explosions occour (see `lua_api.txt`). If this function exists, this function will be called. If this function does not exist, the TNT reverts to the default behavior, which is destroying the node with `minetest.remove_node`.
This should now finally make it possible to define nodes which are able to “defend themselves” against TNT explosions.

While I was at it, I also implemented on_blast for the following nodes:
- Steel Door: Ignores explosion (meaning that it does not get destroyed)
- Locked Chest: Ignores explosion
- Fire: Ignores explosion
- TNT: Starts burning
- Burning TNT: Ignores explosion
- Gunpowder: Starts burning
- Burning Gunpowder: Ignores explosion

This also replaces some of the destruction logic from the TNT node itself, it now only checks against air directly.