### PR TITLE
Allow placing decaying leaves when holding shift

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -201,9 +201,11 @@ minetest.register_globalstep(function(dtime)
 end)
 
 default.after_place_leaves = function(pos, placer, itemstack, pointed_thing)
-	local node = minetest.get_node(pos)
-	node.param2 = 1
-	minetest.set_node(pos, node)
+	if placer and placer:get_player_control().sneak ~= true then
+		local node = minetest.get_node(pos)
+		node.param2 = 1
+		minetest.set_node(pos, node)
+	end
 end
 
 minetest.register_abm({


### PR DESCRIPTION
The main use for this is tree schematics. Currently no leaves will decay in the placed schematic when they should naturally. Please let me know if you want the controls reversed, i.e. holding shift preserves leaves.