### PR TITLE
Naming Conventions

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -194,7 +194,7 @@ minetest.register_node("default:desert_cobble", {
 
 minetest.register_node("default:desert_stonebrick", {
 	description = "Desert Stone Brick",
-	tiles = {"default_desert_stone_brick.png"},
+	tiles = {"default_desert_stonebrick.png"},
 	groups = {cracky=2, stone=1},
 	sounds = default.node_sound_stone_defaults(),
 })


### PR DESCRIPTION
Remove an underscore from desert stone brick's texture to follow naming conventions.