### PR TITLE
TNT damages now uses apply_damages

### DIFF
--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -123,7 +123,7 @@ local function entity_physics(pos, radius)
 		end
 
 		local damage = (4 / dist) * radius
-		obj:set_hp(obj:get_hp() - damage)
+		obj:apply_damages(damage)
 	end
 end
 


### PR DESCRIPTION
This permit to do damages only if enable_damage parameter is set.

Require: https://github.com/minetest/minetest/pull/2511