### PR TITLE
TNT damages now uses apply_damage

### DIFF
--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -123,7 +123,7 @@ local function entity_physics(pos, radius)
 		end
 
 		local damage = (4 / dist) * radius
-		obj:set_hp(obj:get_hp() - damage)
+		obj:apply_damage(damage)
 	end
 end
 


### PR DESCRIPTION
apply_damage added today to core to present wrong set_hp calls from Lua which doesn't check the enable_damage parameter.
This fix the damages applied to players whereas enable_damage is not enabled in core.