### PR TITLE
Alter mintest_game/mods/default/nodes.lua

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1196,24 +1196,12 @@ minetest.register_node("default:chest_locked", {
 		return inv:is_empty("main") and has_locked_chest_privilege(meta, player)
 	end,
 	allow_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)
-		local meta = minetest.get_meta(pos)
-		if not has_locked_chest_privilege(meta, player) then
-			return 0
-		end
 		return count
 	end,
     allow_metadata_inventory_put = function(pos, listname, index, stack, player)
-		local meta = minetest.get_meta(pos)
-		if not has_locked_chest_privilege(meta, player) then
-			return 0
-		end
 		return stack:get_count()
 	end,
     allow_metadata_inventory_take = function(pos, listname, index, stack, player)
-		local meta = minetest.get_meta(pos)
-		if not has_locked_chest_privilege(meta, player) then
-			return 0
-		end
 		return stack:get_count()
 	end,
     on_metadata_inventory_put = function(pos, listname, index, stack, player)


### PR DESCRIPTION
Locked chests are checked for ownership when right-clicking to enter and trying to destroy, it is not needed in inventory_move, inventory_put and inventory_take so will save a little server time checking...