### PR TITLE
default/mapgen.lua: Remove absheight to remove rare ores from mgv5/mgv7 mountains

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -4,27 +4,31 @@
 
 
 minetest.register_alias("mapgen_stone", "default:stone")
+minetest.register_alias("mapgen_dirt", "default:dirt")
+minetest.register_alias("mapgen_dirt_with_grass", "default:dirt_with_grass")
+minetest.register_alias("mapgen_sand", "default:sand")
+minetest.register_alias("mapgen_water_source", "default:water_source")
+minetest.register_alias("mapgen_lava_source", "default:lava_source")
+minetest.register_alias("mapgen_gravel", "default:gravel")
+minetest.register_alias("mapgen_desert_stone", "default:desert_stone")
+minetest.register_alias("mapgen_desert_sand", "default:desert_sand")
+minetest.register_alias("mapgen_dirt_with_snow", "default:dirt_with_snow")
+minetest.register_alias("mapgen_snow", "default:snow")
+minetest.register_alias("mapgen_snowblock", "default:snowblock")
+minetest.register_alias("mapgen_ice", "default:ice")
+
 minetest.register_alias("mapgen_tree", "default:tree")
 minetest.register_alias("mapgen_leaves", "default:leaves")
+minetest.register_alias("mapgen_apple", "default:apple")
 minetest.register_alias("mapgen_jungletree", "default:jungletree")
 minetest.register_alias("mapgen_jungleleaves", "default:jungleleaves")
-minetest.register_alias("mapgen_apple", "default:apple")
-minetest.register_alias("mapgen_water_source", "default:water_source")
-minetest.register_alias("mapgen_dirt", "default:dirt")
-minetest.register_alias("mapgen_sand", "default:sand")
-minetest.register_alias("mapgen_gravel", "default:gravel")
-minetest.register_alias("mapgen_clay", "default:clay")
-minetest.register_alias("mapgen_lava_source", "default:lava_source")
-minetest.register_alias("mapgen_cobble", "default:cobble")
-minetest.register_alias("mapgen_mossycobble", "default:mossycobble")
-minetest.register_alias("mapgen_dirt_with_grass", "default:dirt_with_grass")
 minetest.register_alias("mapgen_junglegrass", "default:junglegrass")
-minetest.register_alias("mapgen_stone_with_coal", "default:stone_with_coal")
-minetest.register_alias("mapgen_stone_with_iron", "default:stone_with_iron")
-minetest.register_alias("mapgen_mese", "default:mese")
-minetest.register_alias("mapgen_desert_sand", "default:desert_sand")
-minetest.register_alias("mapgen_desert_stone", "default:desert_stone")
+minetest.register_alias("mapgen_pinetree", "default:pinetree")
+minetest.register_alias("mapgen_pine_needles", "default:pine_needles")
+
+minetest.register_alias("mapgen_cobble", "default:cobble")
 minetest.register_alias("mapgen_stair_cobble", "stairs:stair_cobble")
+minetest.register_alias("mapgen_mossycobble", "default:mossycobble")
 
 
 --
@@ -131,7 +135,6 @@ function default.register_ores()
 		clust_size     = 6,
 		y_min          = -31000,
 		y_max          = 0,
-		flags          = "absheight",
 	})
 
 	minetest.register_ore({
@@ -165,7 +168,6 @@ function default.register_ores()
 		clust_size     = 3,
 		y_min          = -31000,
 		y_max          = -64,
-		flags          = "absheight",
 	})
 
 	minetest.register_ore({
@@ -177,7 +179,6 @@ function default.register_ores()
 		clust_size     = 6,
 		y_min          = -31000,
 		y_max          = -64,
-		flags          = "absheight",
 	})
 
 	minetest.register_ore({
@@ -189,7 +190,6 @@ function default.register_ores()
 		clust_size     = 2,
 		y_min          = -255,
 		y_max          = -64,
-		flags          = "absheight",
 	})
 
 	minetest.register_ore({
@@ -201,7 +201,6 @@ function default.register_ores()
 		clust_size     = 3,
 		y_min          = -31000,
 		y_max          = -256,
-		flags          = "absheight",
 	})
 
 	minetest.register_ore({
@@ -213,7 +212,6 @@ function default.register_ores()
 		clust_size     = 2,
 		y_min          = -31000,
 		y_max          = -1024,
-		flags          = "absheight",
 	})
 
 	minetest.register_ore({
@@ -225,7 +223,6 @@ function default.register_ores()
 		clust_size     = 2,
 		y_min          = -255,
 		y_max          = -64,
-		flags          = "absheight",
 	})
 
 	minetest.register_ore({
@@ -237,7 +234,6 @@ function default.register_ores()
 		clust_size     = 3,
 		y_min          = -31000,
 		y_max          = -256,
-		flags          = "absheight",
 	})
 
 	minetest.register_ore({
@@ -249,7 +245,6 @@ function default.register_ores()
 		clust_size     = 3,
 		y_min          = -255,
 		y_max          = -128,
-		flags          = "absheight",
 	})
 
 	minetest.register_ore({
@@ -261,7 +256,6 @@ function default.register_ores()
 		clust_size     = 3,
 		y_min          = -31000,
 		y_max          = -256,
-		flags          = "absheight",
 	})
 
 	minetest.register_ore({
@@ -284,7 +278,6 @@ function default.register_ores()
 		clust_size     = 3,
 		y_min          = -31000,
 		y_max          = -64,
-		flags          = "absheight",
 	})
 end
 


### PR DESCRIPTION
Also: Mapgen aliases: Add pine and snow biome nodes for mgv6, organise, delete ores

Recently i have seen complaints of rare ores (mese, gold and diamond) being found too easily in the mountains of mgv5 and mgv7, as low as y = 64.
The absheight flag was added to mirror ore distrbution around y = 0, to generate it in the now removed indev floatlands up to the top of the world. The absheight method is crude and has unsuitable results, if ores are enabled for future (or custom noiseparam) floatlands it can be done more intelligently. See comment below by kwolekr (hmmmm).

Pine tree and snow biome nodes are added to mapgen aliases in preparation for optional snow biomes in mgv6. Mapgen aliases are organised and the unnecessary ones deleted: clay, coal ore, iron ore, mese, all these are now placed by register ore.