### PR TITLE
stairs mod too complicated

### DIFF
--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -5,10 +5,10 @@ stairs = {}
 
 -- Node will be called stairs:stair_<subname>
 function stairs.register_stair(subname, recipeitem, groups, images, description, sounds)
-	minetest.register_node(":stairs:stair_" .. subname, {
+	minetest.register_node("stairs:stair_" .. subname, {
 		description = description,
 		drawtype = "nodebox",
-		tiles = images,
+		tile_images = images,
 		paramtype = "light",
 		paramtype2 = "facedir",
 		is_ground_content = true,
@@ -21,59 +21,14 @@ function stairs.register_stair(subname, recipeitem, groups, images, description,
 				{-0.5, 0, 0, 0.5, 0.5, 0.5},
 			},
 		},
-		on_place = function(itemstack, placer, pointed_thing)
-			if pointed_thing.type ~= "node" then
-				return itemstack
-			end
-
-			local p0 = pointed_thing.under
-			local p1 = pointed_thing.above
-			local param2 = 0
-
-			local placer_pos = placer:getpos()
-			if placer_pos then
-				local dir = {
-					x = p1.x - placer_pos.x,
-					y = p1.y - placer_pos.y,
-					z = p1.z - placer_pos.z
-				}
-				param2 = minetest.dir_to_facedir(dir)
-			end
-
-			if p0.y-1 == p1.y then
-				param2 = param2 + 20
-				if param2 == 21 then
-					param2 = 23
-				elseif param2 == 23 then
-					param2 = 21
-				end
-			end
-
-			return minetest.item_place(itemstack, placer, pointed_thing, param2)
-		end,
-	})
-
-	-- for replace ABM
-	minetest.register_node(":stairs:stair_" .. subname.."upside_down", {
-		replace_name = "stairs:stair_" .. subname,
-		groups = {slabs_replace=1},
+		on_place = minetest.rotate_node
 	})
 
 	minetest.register_craft({
-		output = 'stairs:stair_' .. subname .. ' 6',
+		output = 'stairs:stair_' .. subname .. ' 4',
 		recipe = {
 			{recipeitem, "", ""},
 			{recipeitem, recipeitem, ""},
-			{recipeitem, recipeitem, recipeitem},
-		},
-	})
-
-	-- Flipped recipe for the silly minecrafters
-	minetest.register_craft({
-		output = 'stairs:stair_' .. subname .. ' 6',
-		recipe = {
-			{"", "", recipeitem},
-			{"", recipeitem, recipeitem},
 			{recipeitem, recipeitem, recipeitem},
 		},
 	})
@@ -81,12 +36,11 @@ end
 
 -- Node will be called stairs:slab_<subname>
 function stairs.register_slab(subname, recipeitem, groups, images, description, sounds)
-	minetest.register_node(":stairs:slab_" .. subname, {
+	minetest.register_node("stairs:slab_" .. subname, {
 		description = description,
 		drawtype = "nodebox",
-		tiles = images,
+		tile_images = images,
 		paramtype = "light",
-		paramtype2 = "facedir",
 		is_ground_content = true,
 		groups = groups,
 		sounds = sounds,
@@ -94,117 +48,20 @@ function stairs.register_slab(subname, recipeitem, groups, images, description, 
 			type = "fixed",
 			fixed = {-0.5, -0.5, -0.5, 0.5, 0, 0.5},
 		},
-		on_place = function(itemstack, placer, pointed_thing)
-			if pointed_thing.type ~= "node" then
-				return itemstack
-			end
-
-			-- If it's being placed on an another similar one, replace it with
-			-- a full block
-			local slabpos = nil
-			local slabnode = nil
-			local p0 = pointed_thing.under
-			local p1 = pointed_thing.above
-			local n0 = minetest.get_node(p0)
-			local n1 = minetest.get_node(p1)
-			local param2 = 0
-
-			local n0_is_upside_down = (n0.name == "stairs:slab_" .. subname and
-					n0.param2 >= 20)
-
-			if n0.name == "stairs:slab_" .. subname and not n0_is_upside_down and p0.y+1 == p1.y then
-				slabpos = p0
-				slabnode = n0
-			elseif n1.name == "stairs:slab_" .. subname then
-				slabpos = p1
-				slabnode = n1
-			end
-			if slabpos then
-				-- Remove the slab at slabpos
-				minetest.remove_node(slabpos)
-				-- Make a fake stack of a single item and try to place it
-				local fakestack = ItemStack(recipeitem)
-				fakestack:set_count(itemstack:get_count())
-
-				pointed_thing.above = slabpos
-				local success
-				fakestack, success = minetest.item_place(fakestack, placer, pointed_thing)
-				-- If the item was taken from the fake stack, decrement original
-				if success then
-					itemstack:set_count(fakestack:get_count())
-				-- Else put old node back
-				else
-					minetest.set_node(slabpos, slabnode)
-				end
-				return itemstack
-			end
-			
-			-- Upside down slabs
-			if p0.y-1 == p1.y then
-				-- Turn into full block if pointing at a existing slab
-				if n0_is_upside_down  then
-					-- Remove the slab at the position of the slab
-					minetest.remove_node(p0)
-					-- Make a fake stack of a single item and try to place it
-					local fakestack = ItemStack(recipeitem)
-					fakestack:set_count(itemstack:get_count())
-
-					pointed_thing.above = p0
-					local success
-					fakestack, success = minetest.item_place(fakestack, placer, pointed_thing)
-					-- If the item was taken from the fake stack, decrement original
-					if success then
-						itemstack:set_count(fakestack:get_count())
-					-- Else put old node back
-					else
-						minetest.set_node(p0, n0)
-					end
-					return itemstack
-				end
-
-				-- Place upside down slab
-				param2 = 20
-			end
-
-			-- If pointing at the side of a upside down slab
-			if n0_is_upside_down and p0.y+1 ~= p1.y then
-				param2 = 20
-			end
-
-			return minetest.item_place(itemstack, placer, pointed_thing, param2)
-		end,
-	})
-
-	-- for replace ABM
-	minetest.register_node(":stairs:slab_" .. subname.."upside_down", {
-		replace_name = "stairs:slab_"..subname,
-		groups = {slabs_replace=1},
+		selection_box = {
+			type = "fixed",
+			fixed = {-0.5, -0.5, -0.5, 0.5, 0, 0.5},
+		},
+		on_place = minetest.rotate_node
 	})
 
 	minetest.register_craft({
-		output = 'stairs:slab_' .. subname .. ' 6',
+		output = 'stairs:slab_' .. subname .. ' 3',
 		recipe = {
 			{recipeitem, recipeitem, recipeitem},
 		},
 	})
 end
-
--- Replace old "upside_down" nodes with new param2 versions
-minetest.register_abm({
-	nodenames = {"group:slabs_replace"},
-	interval = 1,
-	chance = 1,
-	action = function(pos, node)
-		node.name = minetest.registered_nodes[node.name].replace_name
-		node.param2 = node.param2 + 20
-		if node.param2 == 21 then
-			node.param2 = 23
-		elseif node.param2 == 23 then
-			node.param2 = 21
-		end
-		minetest.set_node(pos, node)
-	end,
-})
 
 -- Nodes will be called stairs:{stair,slab}_<subname>
 function stairs.register_stair_and_slab(subname, recipeitem, groups, images, desc_stair, desc_slab, sounds)


### PR DESCRIPTION
Having stairs mod use abm's to rotate is over complicated and interferes with certain protection mods stopping stairs from displaying properly, reverted to using on_place = minetest.rotate_node which is a lot easier and plays ball with other mods...