### PR TITLE
Default/mapgen: Fix missing num_spawn_by = 1 line for papyrus

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -353,6 +353,7 @@ function default.register_mgv6_decorations()
 		height = 2,
 	        height_max = 4,
 		spawn_by = "default:water_source",
+		num_spawn_by = 1,
 	})
 
 	-- Cacti


### PR DESCRIPTION
Currently papyrus are spawning anywhere at y = 1, instead of at the water's edge.