### PR TITLE
Minetest.conf: Move mapgen flags to engine .conf

### DIFF
--- a/minetest.conf
+++ b/minetest.conf
@@ -1,3 +1,0 @@
-mg_flags = dungeons
-mgv6_spflags = biomeblend, jungles
-


### PR DESCRIPTION
Dungeons and jungles flags are now in the engine .conf, the biomeblend flag was redundant as it is set by default in mapgen_v6.cpp.