### PR TITLE
Change name to “Minetest Game” (except text logo)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,22 +1,22 @@
-The main game for the Minetest game engine [minetest_game]
-==========================================================
+Minetest Game: The default game for the Minetest engine
+=======================================================
 
 To use this game with Minetest, insert this repository as
   /games/minetest_game
-in the Minetest Engine.
+in the Minetest engine.
 
-The Minetest Engine can be found in:
+The Minetest engine can be found in:
   https://github.com/minetest/minetest/
 
 Compatibility
 --------------
-The minetest_game github master HEAD is generally compatible with the github
-master HEAD of minetest.
+The minetest_game (repository name) GitHub master HEAD is generally
+compatible with the GitHub master HEAD of minetest.
 
 Additionally, when the minetest engine is tagged to be a certain version (eg.
 0.4.10), minetest_game is tagged with the version too.
 
-When stable releases are made, minetest_game is packaged and made available in
+When stable releases are made, Minetest Game is packaged and made available in
   http://minetest.net/download
 and in case the repository has grown too much, it may be reset. In that sense,
 this is not a "real" git repository. (Package maintainers please note!)

--- a/game.conf
+++ b/game.conf
@@ -1,1 +1,1 @@
-name = Minetest
+name = Minetest Game

--- a/game_api.txt
+++ b/game_api.txt
@@ -1,10 +1,10 @@
-minetest_game API
+Minetest Game API
 ======================
 GitHub Repo: https://github.com/minetest/minetest_game
 
 Introduction
 ------------
-The minetest_game gamemode offers multiple new possibilities in addition to Minetest's built-in API, allowing you to
+The Minetest Game gamemode offers multiple new possibilities in addition to Minetest's built-in API, allowing you to
 add new plants to farming mod, buckets for new liquids, new stairs and custom panes.
 For information on the Minetest API, visit https://github.com/minetest/minetest/blob/master/doc/lua_api.txt
 Please note:
@@ -147,7 +147,7 @@ farming.register_plant(name, Plant definition)
 Stairs API
 ----------
 The stairs API lets you register stairs and slabs and ensures that they are registered the same way as those
-delivered with minetest_game, to keep them compatible with other mods.
+delivered with Minetest Game, to keep them compatible with other mods.
 
 stairs.register_stair(subname, recipeitem, groups, images, description, sounds)
  -> Registers a stair.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1,4 +1,4 @@
-# This file contains settings of minetest_game that can be changed in
+# This file contains settings of Minetest Game that can be changed in
 # minetest.conf
 #
 # By default, all the settings are commented and not functional.


### PR DESCRIPTION
This changes some text files so that that the show the subgame's new name: “Minetest Game”.
This PR finishes off some tasks listed here:
https://github.com/minetest/minetest_game/issues/480

The text logo is not included in this PR, because no one has drawn one yet.