### PR TITLE
Default/mapgen: Add mapgen aliases for sandstone brick and sandstone brick stair

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -14,8 +14,8 @@ minetest.register_alias("mapgen_gravel", "default:gravel")
 minetest.register_alias("mapgen_desert_stone", "default:desert_stone")
 minetest.register_alias("mapgen_desert_sand", "default:desert_sand")
 minetest.register_alias("mapgen_dirt_with_snow", "default:dirt_with_snow")
-minetest.register_alias("mapgen_snow", "default:snow")
 minetest.register_alias("mapgen_snowblock", "default:snowblock")
+minetest.register_alias("mapgen_snow", "default:snow")
 minetest.register_alias("mapgen_ice", "default:ice")
 
 minetest.register_alias("mapgen_tree", "default:tree")
@@ -30,6 +30,8 @@ minetest.register_alias("mapgen_pine_needles", "default:pine_needles")
 minetest.register_alias("mapgen_cobble", "default:cobble")
 minetest.register_alias("mapgen_stair_cobble", "stairs:stair_cobble")
 minetest.register_alias("mapgen_mossycobble", "default:mossycobble")
+minetest.register_alias("mapgen_sandstonebrick", "default:sandstonebrick")
+minetest.register_alias("mapgen_stair_sandstonebrick", "stairs:stair_sandstonebrick")
 
 
 --


### PR DESCRIPTION
To enable sandstone brick dungeons in the sandstone biomes of mgv5/v7.

Looking at previous code it seems that desert temples were originally meant to be made from sandstone brick, but the aliases were never added to MTGame so they ended up made of the fallback node desert stone, which makes more sense in our deserts anyway, there is no sandstone around to use.

Sandstone biomes will soon be added to mgv5/v7 so we will have the chance to finally have these sandstone dungeons. I plan to detect sandstone in a mapchunk and have this enable the generation of sandstone brick dungeons within that mapchunk.