### PR TITLE
Add the listring functionality

### DIFF
--- a/mods/creative/init.lua
+++ b/mods/creative/init.lua
@@ -87,6 +87,10 @@ creative_inventory.set_creative_formspec = function(player, start_i, pagenum)
 			"label[2.0,6.55;"..tostring(pagenum).."/"..tostring(pagemax).."]"..
 			"button[0.3,6.5;1.6,1;creative_prev;<<]"..
 			"button[2.7,6.5;1.6,1;creative_next;>>]"..
+			"listring[current_player;main]"..
+			"listring[current_player;craft]"..
+			"listring[current_player;main]"..
+			"listring[detached:creative;main]"..
 			"label[5,1.5;Trash:]"..
 			"list[detached:creative_trash;main;5,2;1,1;]"..
 			default.get_hotbar_bg(5,3.5)

--- a/mods/default/furnace.lua
+++ b/mods/default/furnace.lua
@@ -18,6 +18,10 @@ local function active_formspec(fuel_percent, item_percent)
 		"list[current_name;dst;4.75,0.96;2,2;]"..
 		"list[current_player;main;0,4.25;8,1;]"..
 		"list[current_player;main;0,5.5;8,3;8]"..
+		"listring[current_name;dst]"..
+		"listring[current_player;main]"..
+		"listring[current_name;src]"..
+		"listring[current_player;main]"..
 		default.get_hotbar_bg(0, 4.25)
 	return formspec
 end
@@ -34,6 +38,10 @@ local inactive_formspec =
 	"list[current_name;dst;4.75,0.96;2,2;]"..
 	"list[current_player;main;0,4.25;8,1;]"..
 	"list[current_player;main;0,5.5;8,3;8]"..
+	"listring[current_name;dst]"..
+	"listring[current_player;main]"..
+	"listring[current_name;src]"..
+	"listring[current_player;main]"..
 	default.get_hotbar_bg(0, 4.25)
 
 --

--- a/mods/default/init.lua
+++ b/mods/default/init.lua
@@ -30,6 +30,8 @@ default.gui_survival_form = "size[8,8.5]"..
 			"list[current_player;craft;1.75,0.5;3,3;]"..
 			"list[current_player;craftpreview;5.75,1.5;1,1;]"..
 			"image[4.75,1.5;1,1;gui_furnace_arrow_bg.png^[transformR270]"..
+			"listring[current_player;main]"..
+			"listring[current_player;craft]"..
 			default.get_hotbar_bg(0,4.25)
 
 -- Load files

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1220,6 +1220,8 @@ local chest_formspec =
 	"list[current_name;main;0,0.3;8,4;]"..
 	"list[current_player;main;0,4.85;8,1;]"..
 	"list[current_player;main;0,6.08;8,3;8]"..
+	"listring[current_name;main]"..
+	"listring[current_player;main]"..
 	default.get_hotbar_bg(0,4.85)
 
 local function get_locked_chest_formspec(pos)
@@ -1232,6 +1234,8 @@ local function get_locked_chest_formspec(pos)
 		"list[nodemeta:".. spos .. ";main;0,0.3;8,4;]"..
 		"list[current_player;main;0,4.85;8,1;]"..
 		"list[current_player;main;0,6.08;8,3;8]"..
+		"listring[nodemeta:".. spos .. ";main]"..
+		"listring[current_player;main]"..
 		default.get_hotbar_bg(0,4.85)
  return formspec
 end
@@ -1361,6 +1365,8 @@ local bookshelf_formspec =
 	"list[context;books;0,0.3;8,2;]"..
 	"list[current_player;main;0,2.85;8,1;]"..
 	"list[current_player;main;0,4.08;8,3;8]"..
+	"listring[context;books]"..
+	"listring[current_player;main]"..
 	default.get_hotbar_bg(0,2.85)
 
 minetest.register_node("default:bookshelf", {

--- a/mods/vessels/init.lua
+++ b/mods/vessels/init.lua
@@ -9,6 +9,8 @@ local vessels_shelf_formspec =
 	"list[context;vessels;0,0.3;8,2;]"..
 	"list[current_player;main;0,2.85;8,1;]"..
 	"list[current_player;main;0,4.08;8,3;8]"..
+	"listring[context;vessels]"..
+	"listring[current_player;main]"..
 	default.get_hotbar_bg(0,2.85)
 
 minetest.register_node("vessels:shelf", {


### PR DESCRIPTION
This makes chests, locked chests, the creative inventory and the craft grid work with https://github.com/minetest/minetest/commit/c977fbd9288d0e80019554411a2f1885f7760568

Bookshelves and vessel shelves also work nominally with it, but because both of those only allow one item per slot, shift+click seems to fail... I'm fairly certain this is an engine problem, so should I remove the listring code for those two items?