### PR TITLE
Default: Thicker snow nodebox

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -356,19 +356,19 @@ minetest.register_node("default:snow", {
 	node_box = {
 		type = "fixed",
 		fixed = {
-			{-0.5, -0.5, -0.5,  0.5, -0.5+2/16, 0.5},
+			{-0.5, -0.5, -0.5, 0.5, -0.25, 0.5},
 		},
 	},
-	groups = {crumbly=3,falling_node=1},
+	groups = {crumbly = 3, falling_node = 1},
 	sounds = default.node_sound_dirt_defaults({
-		footstep = {name="default_snow_footstep", gain=0.25},
-		dug = {name="default_snow_footstep", gain=0.75},
+		footstep = {name = "default_snow_footstep", gain = 0.25},
+		dug = {name = "default_snow_footstep", gain = 0.75},
 	}),
 
 	on_construct = function(pos)
 		pos.y = pos.y - 1
 		if minetest.get_node(pos).name == "default:dirt_with_grass" then
-			minetest.set_node(pos, {name="default:dirt_with_snow"})
+			minetest.set_node(pos, {name = "default:dirt_with_snow"})
 		end
 	end,
 })


### PR DESCRIPTION
![screenshot_20150724_013244](https://cloud.githubusercontent.com/assets/3686677/8865245/61593b48-31a4-11e5-94af-a88b5bc154c2.png)

Makes the snow nodebox twice as thick = 1/4 node, the current nodebox is unsatisfyingly thin.
Partially solves the problem of the footstep sound being of the material beneath the snow, half the time the footstep sound is now snow.
Also add missing spaces to node definition.