### PR TITLE
Fix mese block alias

### DIFF
--- a/mods/default/aliases.lua
+++ b/mods/default/aliases.lua
@@ -69,4 +69,4 @@ minetest.register_alias("clay_brick", "default:clay_brick")
 minetest.register_alias("snow", "default:snow")
 
 -- Mese now comes in the form of blocks, ore, crystal and fragments
-minetest.register_alias("default:mese", "default:mese_block")
+minetest.register_alias("default:mese_block", "default:mese")


### PR DESCRIPTION
It should alias the old name (mese_block) to the new/current name (mese) rather than the other way round.