### PR TITLE
Stairs: Lengthen interval of replace abm

### DIFF
--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -200,7 +200,7 @@ end
 -- Replace old "upside_down" nodes with new param2 versions
 minetest.register_abm({
 	nodenames = {"group:slabs_replace"},
-	interval = 1,
+	interval = 8,
 	chance = 1,
 	action = function(pos, node)
 		node.name = minetest.registered_nodes[node.name].replace_name


### PR DESCRIPTION
The interval is currently insanely frequent at 1 second. Because ABM range is 32 nodes, assuming a player walking past a node that needs replacing, the node is within range over a 64 node walk, at 4m/s this means a 16 second interval is all that is needed.