### PR TITLE
Default/functions: Reduce lavacooling ABM/sound overload

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -90,19 +90,21 @@ end
 
 default.cool_lava_source = function(pos)
 	minetest.set_node(pos, {name = "default:obsidian"})
-	minetest.sound_play("default_cool_lava", {pos = pos, gain = 0.25})
+	minetest.sound_play("default_cool_lava",
+		{pos = pos, max_hear_distance = 16, gain = 0.25})
 end
 
 default.cool_lava_flowing = function(pos)
 	minetest.set_node(pos, {name = "default:stone"})
-	minetest.sound_play("default_cool_lava", {pos = pos, gain = 0.25})
+	minetest.sound_play("default_cool_lava",
+		{pos = pos, max_hear_distance = 16, gain = 0.25})
 end
 
 minetest.register_abm({
 	nodenames = {"default:lava_flowing"},
 	neighbors = {"group:water"},
 	interval = 1,
-	chance = 1,
+	chance = 2,
 	action = function(...)
 		default.cool_lava_flowing(...)
 	end,
@@ -112,7 +114,7 @@ minetest.register_abm({
 	nodenames = {"default:lava_source"},
 	neighbors = {"group:water"},
 	interval = 1,
-	chance = 1,
+	chance = 2,
 	action = function(...)
 		default.cool_lava_source(...)
 	end,


### PR DESCRIPTION
'Max hear distance' is added as in the fire mod.
Lavacooling chance is changed from 1 to 2 to spread out lavacooling events, for less of a processing spike.
There is less overloading of lavacooling sounds, which prints many sound error messages to terminal.