### PR TITLE
Default/crafting: Add composting of leaves group to dirt

### DIFF
--- a/mods/default/crafting.lua
+++ b/mods/default/crafting.lua
@@ -635,6 +635,15 @@ minetest.register_craft({
 	}
 })
 
+minetest.register_craft({
+	output = 'default:dirt',
+	recipe = {
+		{'group:leaves', 'group:leaves', 'group:leaves'},
+		{'group:leaves', 'group:leaves', 'group:leaves'},
+		{'group:leaves', 'group:leaves', 'group:leaves'},
+	}
+})
+
 --
 -- Crafting (tool repair)
 --


### PR DESCRIPTION
Creates a useful node from any leaves removed manually, ideal for skyblock worlds.