### PR TITLE
Default/trees: Combine sapling ABMs into one ABM

### DIFF
--- a/mods/default/trees.lua
+++ b/mods/default/trees.lua
@@ -1,6 +1,8 @@
 --
--- Grow trees
+-- Grow trees from saplings
 --
+
+-- 'Can grow' function
 
 local random = math.random
 
@@ -17,10 +19,12 @@ local function can_grow(pos)
 	return true
 end
 
--- Sapling ABMs
+
+-- Sapling ABM
 
 minetest.register_abm({
-	nodenames = {"default:sapling"},
+	nodenames = {"default:sapling", "default:junglesapling",
+		"default:pine_sapling", "default:acacia_sapling"},
 	interval = 10,
 	chance = 50,
 	action = function(pos, node)
@@ -28,70 +32,45 @@ minetest.register_abm({
 			return
 		end
 
-		minetest.log("action", "A sapling grows into a tree at "..
-			minetest.pos_to_string(pos))
-		if minetest.get_mapgen_params().mgname == "v6" then
-			default.grow_tree(pos, random(1, 4) == 1)
-		else
-			default.grow_new_apple_tree(pos)
+		local mapgen = minetest.get_mapgen_params().mgname
+		if node.name == "default:sapling" then
+			minetest.log("action", "A sapling grows into a tree at "..
+				minetest.pos_to_string(pos))
+			if mapgen == "v6" then
+				default.grow_tree(pos, random(1, 4) == 1)
+			else
+				default.grow_new_apple_tree(pos)
+			end
+		elseif node.name == "default:junglesapling" then
+			minetest.log("action", "A jungle sapling grows into a tree at "..
+				minetest.pos_to_string(pos))
+			if mapgen == "v6" then
+				default.grow_jungle_tree(pos)
+			else
+				default.grow_new_jungle_tree(pos)
+			end
+		elseif node.name == "default:pine_sapling" then
+			minetest.log("action", "A pine sapling grows into a tree at "..
+				minetest.pos_to_string(pos))
+			if mapgen == "v6" then
+				default.grow_pine_tree(pos)
+			else
+				default.grow_new_pine_tree(pos)
+			end
+		elseif node.name == "default:acacia_sapling" then
+			minetest.log("action", "An acacia sapling grows into a tree at "..
+				minetest.pos_to_string(pos))
+			default.grow_new_acacia_tree(pos)
 		end
 	end
 })
 
-minetest.register_abm({
-	nodenames = {"default:junglesapling"},
-	interval = 11,
-	chance = 50,
-	action = function(pos, node)
-		if not can_grow(pos) then
-			return
-		end
 
-		minetest.log("action", "A jungle sapling grows into a tree at "..
-			minetest.pos_to_string(pos))
-		if minetest.get_mapgen_params().mgname == "v6" then
-			default.grow_jungle_tree(pos)
-		else
-			default.grow_new_jungle_tree(pos)
-		end
-	end
-})
+--
+-- Tree generation
+--
 
-minetest.register_abm({
-	nodenames = {"default:pine_sapling"},
-	interval = 12,
-	chance = 50,
-	action = function(pos, node)
-		if not can_grow(pos) then
-			return
-		end
-
-		minetest.log("action", "A pine sapling grows into a tree at "..
-			minetest.pos_to_string(pos))
-		if minetest.get_mapgen_params().mgname == "v6" then
-			default.grow_pine_tree(pos)
-		else
-			default.grow_new_pine_tree(pos)
-		end
-	end
-})
-
-minetest.register_abm({
-	nodenames = {"default:acacia_sapling"},
-	interval = 13,
-	chance = 50,
-	action = function(pos, node)
-		if not can_grow(pos) then
-			return
-		end
-
-		minetest.log("action", "An acacia sapling grows into a tree at "..
-			minetest.pos_to_string(pos))
-		default.grow_new_acacia_tree(pos)
-	end
-})
-
--- Appletree, jungletree function
+-- Apple tree and jungle tree trunk and leaves function
 
 local function add_trunk_and_leaves(data, a, pos, tree_cid, leaves_cid,
 		height, size, iters, is_apple_tree)
@@ -150,7 +129,8 @@ local function add_trunk_and_leaves(data, a, pos, tree_cid, leaves_cid,
 	end
 end
 
--- Appletree
+
+-- Apple tree
 
 function default.grow_tree(pos, is_apple_tree, bad)
 	--[[
@@ -182,7 +162,8 @@ function default.grow_tree(pos, is_apple_tree, bad)
 	vm:update_map()
 end
 
--- Jungletree
+
+-- Jungle tree
 
 function default.grow_jungle_tree(pos, bad)
 	--[[
@@ -233,7 +214,8 @@ function default.grow_jungle_tree(pos, bad)
 	vm:update_map()
 end
 
--- Pinetree from mg mapgen mod, design by sfan5, pointy top added by paramat
+
+-- Pine tree from mg mapgen mod, design by sfan5, pointy top added by paramat
 
 local function add_pine_needles(data, vi, c_air, c_ignore, c_snow, c_pine_needles)
 	local node_id = data[vi]
@@ -373,13 +355,15 @@ function default.grow_pine_tree(pos)
 	vm:update_map()
 end
 
--- New tree
+
+-- New apple tree
 
 function default.grow_new_apple_tree(pos)
 	local path = minetest.get_modpath("default") .. "/schematics/apple_tree.mts"
 	minetest.place_schematic({x = pos.x - 2, y = pos.y - 1, z = pos.z - 2},
 		path, 0, nil, false)
 end
+
 
 -- New jungle tree
 
@@ -389,6 +373,7 @@ function default.grow_new_jungle_tree(pos)
 		path, 0, nil, false)
 end
 
+
 -- New pine tree
 
 function default.grow_new_pine_tree(pos)
@@ -396,6 +381,7 @@ function default.grow_new_pine_tree(pos)
 	minetest.place_schematic({x = pos.x - 2, y = pos.y - 1, z = pos.z - 2},
 		path, 0, nil, false)
 end
+
 
 -- New acacia tree
 


### PR DESCRIPTION
A single ABM on "group:sapling" instead of 4 individual ABMs, this should reduce the processing load due to ABM searches.