### PR TITLE
Flowers: Add sporeless mushrooms

### DIFF
--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -130,7 +130,46 @@ local mushrooms_datas = {
 for _, m in pairs(mushrooms_datas) do
 	local name, nut = m[1], m[2]
 
-	-- Register mushrooms
+	-- Register fertile mushrooms
+
+	-- These are placed by mapgen and the growing ABM.
+	-- These drop an infertile mushroom, and 0 to 3 spore
+	-- nodes with an average of 1.25 per mushroom, for
+	-- a slow multiplication of mushrooms when farming.
+
+	minetest.register_node("flowers:mushroom_fertile_" .. name, {
+		description = string.sub(string.upper(name), 0, 1) ..
+			string.sub(name, 2) .. " Fertile Mushroom",
+		tiles = {"flowers_mushroom_" .. name .. ".png"},
+		inventory_image = "flowers_mushroom_" .. name .. ".png",
+		wield_image = "flowers_mushroom_" .. name .. ".png",
+		drawtype = "plantlike",
+		paramtype = "light",
+		sunlight_propagates = true,
+		walkable = false,
+		buildable_to = true,
+		groups = {snappy = 3, flammable = 3, attached_node = 1,
+			not_in_creative_inventory = 1},
+		drop = {
+			items = {
+				{items = {"flowers:mushroom_" .. name}},
+				{items = {"flowers:mushroom_spores_" .. name}, rarity = 4},
+				{items = {"flowers:mushroom_spores_" .. name}, rarity = 2},
+				{items = {"flowers:mushroom_spores_" .. name}, rarity = 2}
+			}
+		},
+		sounds = default.node_sound_leaves_defaults(),
+		on_use = minetest.item_eat(nut),
+		selection_box = {
+			type = "fixed",
+			fixed = {-0.3, -0.5, -0.3, 0.3, 0, 0.3}
+		}
+	})
+
+	-- Register infertile mushrooms
+
+	-- These do not drop spores, to avoid the use of repeated digging
+	-- and placing of a single mushroom to generate unlimited spores.
 
 	minetest.register_node("flowers:mushroom_" .. name, {
 		description = string.sub(string.upper(name), 0, 1) ..
@@ -144,15 +183,6 @@ for _, m in pairs(mushrooms_datas) do
 		walkable = false,
 		buildable_to = true,
 		groups = {snappy = 3, flammable = 3, attached_node = 1},
-		drop = {
-			max_items = 1,
-			items = {
-				{items = {"flowers:mushroom_" .. name}, rarity = 2,},
-				{items = {"flowers:mushroom_spores_" .. name}, rarity = 3,},
-				{items = {"flowers:mushroom_spores_" .. name .. " 2"}, rarity = 2,},
-				{items = {"flowers:mushroom_spores_" .. name .. " 3"}, rarity = 2,},
-			},
-		},
 		sounds = default.node_sound_leaves_defaults(),
 		on_use = minetest.item_eat(nut),
 		selection_box = {
@@ -198,9 +228,9 @@ minetest.register_abm({
 		if minetest.get_item_group(node_under.name, "soil") ~= 0 and
 				minetest.get_node_light(pos, nil) <= 13 then
 			if node.name == "flowers:mushroom_spores_brown" then
-				minetest.set_node(pos, {name = "flowers:mushroom_brown"})
-			else
-				minetest.set_node(pos, {name = "flowers:mushroom_red"})
+				minetest.set_node(pos, {name = "flowers:mushroom_fertile_brown"})
+			elseif node.name == "flowers:mushroom_spores_red" then
+				minetest.set_node(pos, {name = "flowers:mushroom_fertile_red"})
 			end
 		end
 	end

--- a/mods/flowers/mapgen.lua
+++ b/mods/flowers/mapgen.lua
@@ -50,8 +50,8 @@ function flowers.register_mgv6_decorations()
 	register_mgv6_flower("viola")
 	register_mgv6_flower("dandelion_white")
 
-	register_mgv6_mushroom("mushroom_brown")
-	register_mgv6_mushroom("mushroom_red")
+	register_mgv6_mushroom("mushroom_fertile_brown")
+	register_mgv6_mushroom("mushroom_fertile_red")
 end
 
 
@@ -112,8 +112,8 @@ function flowers.register_decorations()
 	register_flower(1133,    "viola")
 	register_flower(73133,   "dandelion_white")
 
-	register_mushroom("mushroom_brown")
-	register_mushroom("mushroom_red")
+	register_mushroom("mushroom_fertile_brown")
+	register_mushroom("mushroom_fertile_red")
 end
 
 


### PR DESCRIPTION
'Fertile mushrooms' ('flowers:mushroom_fertile_brown/red') are placed by mapgen and the spore growing ABM.
These drop an infertile mushroom and 0 to 3 spores, with an average of just above 1 spore per mushroom for a slow multiplication of mushrooms when farming.

Infertile mushrooms do not drop spores to avoid the cheat of repeated digging and placing of a single mushroom to generate unlimited spores. These have the simpler technical name 'flowers:mushroom_brown/red' so that modders have a short name to work with in their recipies.