### PR TITLE
Default/functions: Half rate of leafdecay ABM

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -233,7 +233,7 @@ minetest.register_abm({
 	neighbors = {"air", "group:liquid"},
 	-- A low interval and a high inverse chance spreads the load
 	interval = 2,
-	chance = 5,
+	chance = 10,
 
 	action = function(p0, node, _, _)
 		--print("leafdecay ABM at "..p0.x..", "..p0.y..", "..p0.z..")")


### PR DESCRIPTION
Currently leafdecay causes a huge lua load through it's lua action.
The way ABMs 'catch up' when an area is revisited will clear up any additional mess caused.