### PR TITLE
Boats: Fix sinking through boat when detaching, by CProgrammerRU

### DIFF
--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -1,4 +1,3 @@
-
 --
 -- Helper functions
 --
@@ -8,6 +7,7 @@ local function is_water(pos)
 	return minetest.get_item_group(nn, "water") ~= 0
 end
 
+
 local function get_sign(i)
 	if i == 0 then
 		return 0
@@ -16,11 +16,13 @@ local function get_sign(i)
 	end
 end
 
+
 local function get_velocity(v, yaw, y)
 	local x = -math.sin(yaw) * v
 	local z =  math.cos(yaw) * v
 	return {x = x, y = y, z = z}
 end
+
 
 local function get_v(v)
 	return math.sqrt(v.x ^ 2 + v.z ^ 2)
@@ -32,7 +34,7 @@ end
 
 local boat = {
 	physical = true,
-	collisionbox = {-0.5, -0.4, -0.5, 0.5, 0.3, 0.5},
+	collisionbox = {-0.5, -0.35, -0.5, 0.5, 0.3, 0.5},
 	visual = "mesh",
 	mesh = "boat.obj",
 	textures = {"default_wood.png"},
@@ -42,6 +44,7 @@ local boat = {
 	last_v = 0,
 	removed = false
 }
+
 
 function boat.on_rightclick(self, clicker)
 	if not clicker or not clicker:is_player() then
@@ -53,9 +56,15 @@ function boat.on_rightclick(self, clicker)
 		clicker:set_detach()
 		default.player_attached[name] = false
 		default.player_set_animation(clicker, "stand" , 30)
+		local pos = clicker:getpos()
+		pos = {x = pos.x, y = pos.y + 0.2, z = pos.z}
+		minetest.after(0.1, function()
+			clicker:setpos(pos)
+		end)
 	elseif not self.driver then
 		self.driver = clicker
-		clicker:set_attach(self.object, "", {x = 0, y = 11, z = -3}, {x = 0, y = 0, z = 0})
+		clicker:set_attach(self.object, "",
+			{x = 0, y = 11, z = -3}, {x = 0, y = 0, z = 0})
 		default.player_attached[name] = true
 		minetest.after(0.2, function()
 			default.player_set_animation(clicker, "sit" , 30)
@@ -63,6 +72,7 @@ function boat.on_rightclick(self, clicker)
 		self.object:setyaw(clicker:get_look_yaw() - math.pi / 2)
 	end
 end
+
 
 function boat.on_activate(self, staticdata, dtime_s)
 	self.object:set_armor_groups({immortal = 1})
@@ -72,11 +82,14 @@ function boat.on_activate(self, staticdata, dtime_s)
 	self.last_v = self.v
 end
 
+
 function boat.get_staticdata(self)
 	return tostring(self.v)
 end
 
-function boat.on_punch(self, puncher, time_from_last_punch, tool_capabilities, direction)
+
+function boat.on_punch(self, puncher, time_from_last_punch,
+		tool_capabilities, direction)
 	if not puncher or not puncher:is_player() or self.removed then
 		return
 	end
@@ -96,6 +109,7 @@ function boat.on_punch(self, puncher, time_from_last_punch, tool_capabilities, d
 		end
 	end
 end
+
 
 function boat.on_step(self, dtime)
 	self.v = get_v(self.object:getvelocity()) * get_sign(self.v)
@@ -149,7 +163,8 @@ function boat.on_step(self, dtime)
 		else
 			new_acce = {x = 0, y = -9.8, z = 0}
 		end
-		new_velo = get_velocity(self.v, self.object:getyaw(), self.object:getvelocity().y)
+		new_velo = get_velocity(self.v, self.object:getyaw(),
+			self.object:getvelocity().y)
 		self.object:setpos(self.object:getpos())
 	else
 		p.y = p.y + 1
@@ -172,7 +187,8 @@ function boat.on_step(self, dtime)
 				self.object:setpos(pos)
 				new_velo = get_velocity(self.v, self.object:getyaw(), 0)
 			else
-				new_velo = get_velocity(self.v, self.object:getyaw(), self.object:getvelocity().y)
+				new_velo = get_velocity(self.v, self.object:getyaw(),
+					self.object:getvelocity().y)
 				self.object:setpos(self.object:getpos())
 			end
 		end
@@ -181,7 +197,9 @@ function boat.on_step(self, dtime)
 	self.object:setacceleration(new_acce)
 end
 
+
 minetest.register_entity("boats:boat", boat)
+
 
 minetest.register_craftitem("boats:boat", {
 	description = "Boat",
@@ -206,6 +224,7 @@ minetest.register_craftitem("boats:boat", {
 	end,
 })
 
+
 minetest.register_craft({
 	output = "boats:boat",
 	recipe = {
@@ -214,4 +233,3 @@ minetest.register_craft({
 		{"group:wood", "group:wood", "group:wood"},
 	},
 })
-


### PR DESCRIPTION
Also:
Slightly raise base of collision box.
Improve code style.

This is PR #630 by CProgrammerRU, it needed some editing so since we are so close to release i made this new PR and added extra minor changes.
Currently when detaching from a stationary boat, the player sinks down through the boat. With this commit the player stands on the boat.
The collision box base is closer to the boat while still being visible.