### PR TITLE
Fire: Slow down spread and reduce lua load

### DIFF
--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -1,17 +1,23 @@
 -- minetest/fire/init.lua
 
+-- Global namespace for functions
+
 fire = {}
+
+
+-- Register flame node
 
 minetest.register_node("fire:basic_flame", {
 	description = "Fire",
 	drawtype = "firelike",
 	tiles = {{
-		name="fire_basic_flame_animated.png",
-		animation={type="vertical_frames", aspect_w=16, aspect_h=16, length=1},
+		name = "fire_basic_flame_animated.png",
+		animation = {type = "vertical_frames",
+			aspect_w = 16, aspect_h = 16, length = 1},
 	}},
 	inventory_image = "fire_basic_flame.png",
 	light_source = 14,
-	groups = {igniter=2,dig_immediate=3},
+	groups = {igniter = 2, dig_immediate = 3},
 	drop = '',
 	walkable = false,
 	buildable_to = true,
@@ -29,44 +35,55 @@ minetest.register_node("fire:basic_flame", {
 	on_blast = function() end,
 })
 
-fire.D = 6
+
+-- Fire sounds table
 -- key: position hash of low corner of area
 -- value: {handle=sound handle, name=sound name}
 fire.sounds = {}
 
+
+-- Get sound area of position
+
+-- size of sound areas
+fire.D = 6
+
 function fire.get_area_p0p1(pos)
 	local p0 = {
-		x=math.floor(pos.x/fire.D)*fire.D,
-		y=math.floor(pos.y/fire.D)*fire.D,
-		z=math.floor(pos.z/fire.D)*fire.D,
+		x = math.floor(pos.x / fire.D) * fire.D,
+		y = math.floor(pos.y / fire.D) * fire.D,
+		z = math.floor(pos.z / fire.D) * fire.D,
 	}
 	local p1 = {
-		x=p0.x+fire.D-1,
-		y=p0.y+fire.D-1,
-		z=p0.z+fire.D-1
+		x = p0.x + fire.D - 1,
+		y = p0.y + fire.D - 1,
+		z = p0.z + fire.D - 1
 	}
 	return p0, p1
 end
 
+
+-- Update fire sounds in sound area of position
+
 function fire.update_sounds_around(pos)
 	local p0, p1 = fire.get_area_p0p1(pos)
-	local cp = {x=(p0.x+p1.x)/2, y=(p0.y+p1.y)/2, z=(p0.z+p1.z)/2}
+	local cp = {x = (p0.x + p1.x) / 2, y = (p0.y + p1.y) / 2, z = (p0.z + p1.z) / 2}
 	local flames_p = minetest.find_nodes_in_area(p0, p1, {"fire:basic_flame"})
 	--print("number of flames at "..minetest.pos_to_string(p0).."/"
 	--		..minetest.pos_to_string(p1)..": "..#flames_p)
 	local should_have_sound = (#flames_p > 0)
 	local wanted_sound = nil
 	if #flames_p >= 9 then
-		wanted_sound = {name="fire_large", gain=1.5}
+		wanted_sound = {name = "fire_large", gain = 1.5}
 	elseif #flames_p > 0 then
-		wanted_sound = {name="fire_small", gain=1.5}
+		wanted_sound = {name = "fire_small", gain = 1.5}
 	end
 	local p0_hash = minetest.hash_node_position(p0)
 	local sound = fire.sounds[p0_hash]
 	if not sound then
 		if should_have_sound then
 			fire.sounds[p0_hash] = {
-				handle = minetest.sound_play(wanted_sound, {pos=cp, max_hear_distance = 16, loop=true}),
+				handle = minetest.sound_play(wanted_sound,
+					{pos = cp, max_hear_distance = 16, loop = true}),
 				name = wanted_sound.name,
 			}
 		end
@@ -77,40 +94,53 @@ function fire.update_sounds_around(pos)
 		elseif sound.name ~= wanted_sound.name then
 			minetest.sound_stop(sound.handle)
 			fire.sounds[p0_hash] = {
-				handle = minetest.sound_play(wanted_sound, {pos=cp, max_hear_distance = 16, loop=true}),
+				handle = minetest.sound_play(wanted_sound,
+					{pos = cp, max_hear_distance = 16, loop = true}),
 				name = wanted_sound.name,
 			}
 		end
 	end
 end
 
+
+-- Update fire sounds on flame node construct or destruct
+
 function fire.on_flame_add_at(pos)
 	fire.update_sounds_around(pos)
 end
+
 
 function fire.on_flame_remove_at(pos)
 	fire.update_sounds_around(pos)
 end
 
+
+-- Return positions for flames around a burning node
+
 function fire.find_pos_for_flame_around(pos)
 	return minetest.find_node_near(pos, 1, {"air"})
 end
 
+
+-- Detect nearby extinguishing nodes
+
 function fire.flame_should_extinguish(pos)
 	if minetest.setting_getbool("disable_fire") then return true end
 	--return minetest.find_node_near(pos, 1, {"group:puts_out_fire"})
-	local p0 = {x=pos.x-2, y=pos.y, z=pos.z-2}
-	local p1 = {x=pos.x+2, y=pos.y, z=pos.z+2}
+	local p0 = {x = pos.x - 1, y = pos.y, z = pos.z - 1}
+	local p1 = {x = pos.x + 1, y = pos.y + 1, z = pos.z + 1}
 	local ps = minetest.find_nodes_in_area(p0, p1, {"group:puts_out_fire"})
 	return (#ps ~= 0)
 end
 
+
 -- Ignite neighboring nodes
+
 minetest.register_abm({
 	nodenames = {"group:flammable"},
 	neighbors = {"group:igniter"},
-	interval = 5,
-	chance = 2,
+	interval = 7,
+	chance = 32,
 	action = function(p0, node, _, _)
 		-- If there is water or stuff like that around flame, don't ignite
 		if fire.flame_should_extinguish(p0) then
@@ -118,12 +148,17 @@ minetest.register_abm({
 		end
 		local p = fire.find_pos_for_flame_around(p0)
 		if p then
-			minetest.set_node(p, {name="fire:basic_flame"})
+			minetest.set_node(p, {name = "fire:basic_flame"})
 		end
 	end,
 })
 
+
 -- Rarely ignite things from far
+
+--[[ Currently disabled to reduce the chance of uncontrollable spreading
+	fires that disrupt servers. Also for less lua processing load.
+
 minetest.register_abm({
 	nodenames = {"group:igniter"},
 	neighbors = {"air"},
@@ -143,17 +178,20 @@ minetest.register_abm({
 			end
 			local p2 = fire.find_pos_for_flame_around(p)
 			if p2 then
-				minetest.set_node(p2, {name="fire:basic_flame"})
+				minetest.set_node(p2, {name = "fire:basic_flame"})
 			end
 		end
 	end,
 })
+--]]
+
 
 -- Remove flammable nodes and flame
+
 minetest.register_abm({
 	nodenames = {"fire:basic_flame"},
-	interval = 3,
-	chance = 2,
+	interval = 5,
+	chance = 16,
 	action = function(p0, node, _, _)
 		-- If there is water or stuff like that around flame, remove flame
 		if fire.flame_should_extinguish(p0) then
@@ -161,7 +199,7 @@ minetest.register_abm({
 			return
 		end
 		-- Make the following things rarer
-		if math.random(1,3) == 1 then
+		if math.random(1, 3) == 1 then
 			return
 		end
 		-- If there are no flammable nodes around flame, remove flame
@@ -169,7 +207,7 @@ minetest.register_abm({
 			minetest.remove_node(p0)
 			return
 		end
-		if math.random(1,4) == 1 then
+		if math.random(1, 4) == 1 then
 			-- remove a flammable node around flame
 			local p = minetest.find_node_near(p0, 1, {"group:flammable"})
 			if p then


### PR DESCRIPTION
See #408
Initial taming of the fire mod for release.
This makes fire spread slower and less exciting, so reduces the temptation for grefers to use it.
The ultimate intention is to make it possible for a single player to stop a forest fire in a dense rainforest by digging single-node gaps around the fire.
Even more imporatant now that all mapgens have very large dense rainforests by default.

Speed of fire spread and lua load caused are both halved by changing ABM chances from 2 to 4.
Igniting nodes from a distance, a heavy load ABM, is disabled by commenting. Now it is easier to stop fire spreading by digging a single-node gap.
The volume checked by 'should extinguish' is reduced to immediate neighbours but also including nodes just above, so fire below water is extinguished.
Also shorten lines, add double newlines between functions and add missing spaces.