### PR TITLE
Flowers: Make flowers wave when waving shader enabled

### DIFF
--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -39,6 +39,7 @@ local function add_simple_flower(name, desc, box, f_groups)
 	minetest.register_node("flowers:" .. name, {
 		description = desc,
 		drawtype = "plantlike",
+		waving = 1,
 		tiles = {"flowers_" .. name .. ".png"},
 		inventory_image = "flowers_" .. name .. ".png",
 		wield_image = "flowers_" .. name .. ".png",


### PR DESCRIPTION
Now that https://github.com/minetest/minetest/pull/3146 has been merged we can make flowers wave without the plantlike textures splitting, which seems to be the reason they didn't wave before, see issue #661.