### PR TITLE
Make buckets control scheme consistent.

### DIFF
--- a/mods/bucket/init.lua
+++ b/mods/bucket/init.lua
@@ -110,7 +110,7 @@ minetest.register_craftitem("bucket:bucket_empty", {
 	inventory_image = "bucket.png",
 	stack_max = 99,
 	liquids_pointable = true,
-	on_use = function(itemstack, user, pointed_thing)
+	on_place = function(itemstack, user, pointed_thing)
 		-- Must be pointing to node
 		if pointed_thing.type ~= "node" then
 			return


### PR DESCRIPTION
This commit, fixes this strange feature of the empty bucket: the right mouse button (or a configured key), is used for filling and emptying the bucket, instead of left click to fill, right click to empty, which is harder to use than before this commit.

This allows mod makers to create nodes or entities that require on_punch while holding a bucket to interact with them, regardless of whether the bucket is full or not, because of this interaction, an empty bucket would be unable to be filled by a cow, or unable to fill a machine with a liquid due to the differences of on_use and on_place.

on_use() blocks on_punch() from activating, and on_place() blocks on_rightclick() from activating.