### PR TITLE
Flowers: Make waterlily not walkable. Add missing flower group

### DIFF
--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -251,7 +251,8 @@ minetest.register_node("flowers:waterlily", {
 	inventory_image = "flowers_waterlily.png",
 	wield_image = "flowers_waterlily.png",
 	liquids_pointable = true,
-	groups = {snappy = 3},
+	walkable = false,
+	groups = {snappy = 3, flower = 1},
 	sounds = default.node_sound_leaves_defaults(),
 	node_box = {
 		type = "fixed",


### PR DESCRIPTION
I didn't add 'attached node = 1' because that is useless for a waterlily (i tested by bucketing the water from underneath, it didn't drop, anyway the water renews so the waterlily best remains in place).
I didn't add 'colour_white = 1' because that would make waterlilies a target for harvesting, when they do not yet have a way to reproduce, maybe in future.
'flora = 1' is left out because that triggers the flower spread abm that is incompatile with waterlilies.
Waterlilies are not flammable for obvious reason.