### PR TITLE
Default/mapgen blob ores: Tune, make faithful to mgv6

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -53,18 +53,18 @@ function default.register_ores()
 		ore_type         = "blob",
 		ore              = "default:clay",
 		wherein          = {"default:sand"},
-		clust_scarcity   = 24 * 24 * 24,
-		clust_size       = 7,
+		clust_scarcity   = 16 * 16 * 16,
+		clust_size       = 5,
 		y_min            = -15,
 		y_max            = 0,
-		noise_threshhold = 0,
+		noise_threshhold = 0.0,
 		noise_params     = {
-			offset = 0.35,
+			offset = 0.5,
 			scale = 0.2,
 			spread = {x = 5, y = 5, z = 5},
 			seed = -316,
 			octaves = 1,
-			persist = 0.5
+			persist = 0.0
 		},
 	})
 
@@ -74,18 +74,18 @@ function default.register_ores()
 		ore_type         = "blob",
 		ore              = "default:sand",
 		wherein          = {"default:stone"},
-		clust_scarcity   = 24 * 24 * 24,
-		clust_size       = 7,
-		y_min            = -63,
+		clust_scarcity   = 16 * 16 * 16,
+		clust_size       = 5,
+		y_min            = -31,
 		y_max            = 4,
-		noise_threshhold = 0,
+		noise_threshhold = 0.0,
 		noise_params     = {
-			offset = 0.35,
+			offset = 0.5,
 			scale = 0.2,
 			spread = {x = 5, y = 5, z = 5},
 			seed = 2316,
 			octaves = 1,
-			persist = 0.5
+			persist = 0.0
 		},
 	})
 
@@ -95,18 +95,18 @@ function default.register_ores()
 		ore_type         = "blob",
 		ore              = "default:dirt",
 		wherein          = {"default:stone"},
-		clust_scarcity   = 24 * 24 * 24,
-		clust_size       = 7,
-		y_min            = -63,
+		clust_scarcity   = 16 * 16 * 16,
+		clust_size       = 5,
+		y_min            = -31,
 		y_max            = 31000,
-		noise_threshhold = 0,
+		noise_threshhold = 0.0,
 		noise_params     = {
-			offset = 0.35,
+			offset = 0.5,
 			scale = 0.2,
 			spread = {x = 5, y = 5, z = 5},
 			seed = 17676,
 			octaves = 1,
-			persist = 0.5
+			persist = 0.0
 		},
 	})
 
@@ -116,18 +116,18 @@ function default.register_ores()
 		ore_type         = "blob",
 		ore              = "default:gravel",
 		wherein          = {"default:stone"},
-		clust_scarcity   = 24 * 24 * 24,
-		clust_size       = 7,
+		clust_scarcity   = 16 * 16 * 16,
+		clust_size       = 5,
 		y_min            = -31000,
 		y_max            = 31000,
-		noise_threshhold = 0,
+		noise_threshhold = 0.0,
 		noise_params     = {
-			offset = 0.35,
+			offset = 0.5,
 			scale = 0.2,
 			spread = {x = 5, y = 5, z = 5},
 			seed = 766,
 			octaves = 1,
-			persist = 0.5
+			persist = 0.0
 		},
 	})
 


### PR DESCRIPTION
![screenshot_20150919_225400](https://cloud.githubusercontent.com/assets/3686677/9978368/cd54b99e-5f21-11e5-87c1-22f6d6b9b8ac.png)

I saw a comment somewhere about clay being rare. Checking this i discovered blob ore generation was broken (blobs too small), that was recently fixed here https://github.com/minetest/minetest/pull/3185. I also noticed i had made clay blobs more rare than in classic mgv6.

This commit makes clay blobs a similar size and rarity to classic mgv6.
Other blob ores are changed to match clay in size and rarity. Dirt, sand and gravel blobs will be more common, as in classic mgv6, and easier to find in cave walls.
Dirt blob ore lower limit is now y = -31 as in classic mgv6.
Sand blob ore lower limit is changed to match that of dirt, y = -31 being a reasonable average lowest seabed depth for the various mapgens.