### PR TITLE
Papyrus: Grow on dirt and grass only, remove from desert ocean

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -152,8 +152,7 @@ end
 function default.grow_papyrus(pos, node)
 	pos.y = pos.y - 1
 	local name = minetest.get_node(pos).name
-	if name ~= "default:dirt_with_grass" and name ~= "default:dirt" and
-			name ~= "default:sand" then
+	if name ~= "default:dirt_with_grass" and name ~= "default:dirt" then
 		return
 	end
 	if not minetest.find_node_near(pos, 3, {"group:water"}) then

--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -1054,7 +1054,7 @@ function default.register_decorations()
 
 	minetest.register_decoration({
 		deco_type = "schematic",
-		place_on = {"default:dirt", "default:sand"},
+		place_on = {"default:dirt"},
 		sidelen = 16,
 		noise_params = {
 			offset = -0.3,
@@ -1064,7 +1064,7 @@ function default.register_decorations()
 			octaves = 3,
 			persist = 0.7
 		},
-		biomes = {"savanna_swamp", "desert_ocean"},
+		biomes = {"savanna_swamp"},
 		y_min = 0,
 		y_max = 0,
 		schematic = minetest.get_modpath("default").."/schematics/papyrus.mts",


### PR DESCRIPTION
Recently papyrus was made growable on sand, this was mainly due to how i was placing it in sandy areas of mgv5/mgv7 biomes. Now we have more dirt swamps we can return to papyrus only growing on dirt or grass. This seems more suitable as real papyrus needs soil to grow from.
The papyrus schematic has a dirt base so looks out of place in sandy desert ocean, so is removed from it.