### PR TITLE
Default/trees: Add requirement of light level 13 for sapling growth

### DIFF
--- a/mods/default/trees.lua
+++ b/mods/default/trees.lua
@@ -16,6 +16,10 @@ local function can_grow(pos)
 	if is_soil == 0 then
 		return false
 	end
+	local ll = minetest.get_node_light(pos)
+	if not ll or ll < 13 then -- Minimum light level for growth
+		return false          -- matches grass, wheat and cotton
+	end
 	return true
 end
 


### PR DESCRIPTION
![screenshot_20151016_120850](https://cloud.githubusercontent.com/assets/3686677/10540824/7569a4be-7403-11e5-8507-646b4860a4e1.png)

PR for issue #704 
Saplings require a minimum light level of 13 to grow, matching grass, wheat and cotton.
Only default:meselamp or other light source of light level 14 placed beside the sapling is bright enough, any number of torches are not because they have light level 13. This creates another use for mese ore and mese blocks found deep underground, as essential 'grow lamps' for underground tree and crop farming.