### PR TITLE
Default/functions: ABM for moss growth on cobble near water

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -306,7 +306,7 @@ minetest.register_abm({
 
 
 --
--- Grass growing
+-- Grass growing on well-lit dirt
 --
 
 minetest.register_abm({
@@ -329,6 +329,11 @@ minetest.register_abm({
 	end
 })
 
+
+--
+-- Grass and dry grass removed in darkness
+--
+
 minetest.register_abm({
 	nodenames = {"default:dirt_with_grass", "default:dirt_with_dry_grass"},
 	interval = 2,
@@ -345,3 +350,18 @@ minetest.register_abm({
 	end
 })
 
+
+--
+-- Moss growth on cobble near water
+--
+
+minetest.register_abm({
+	nodenames = {"default:cobble"},
+	neighbors = {"group:water"},
+	interval = 17,
+	chance = 200,
+	catch_up = false,
+	action = function(pos, node)
+		minetest.set_node(pos, {name = "default:mossycobble"})
+	end
+})


### PR DESCRIPTION
![screenshot_20151022_204919](https://cloud.githubusercontent.com/assets/3686677/10676499/85dfb518-78fe-11e5-84e5-1e2c0e05c7cf.png)

^ 20 node wall after 10 minutes.

See issue #699 
Uses a 2 ABM method suggested by PilzAdam:

"The problem with doing any kind of scan in Lua is that you have a lot of core -> Lua switches.

I'd suggest to use 2 ABMs that both run on cobble: one that has neighbor="group:water" and turns cobble into mossy cobble, and one that has neighbor="mossy_cobble" and scans for water nearby, before turning the cobble into mossy cobble. This would reduce the the number of nodes that the ABM runs on which needs to do checks in Lua. Thus this reduces the number of core -> Lua switches drastically."

catch_up is false because this is a low-priority feature, and it uses a chance value of 200, having this chance value change to 1 on returning to an area would cause processing spikes due to the 2 node radius scan.

Intervals are prime numbers to keep ABM actions out of phase as much as possible. Intervals of around 16s mean very few nodes are missed when a player walks past (64 nodes / 4 metres per second).

Currently i'm testing the chance value, checking this will be a slow process.