### PR TITLE
Mgv5/mgv7 biomes: Enable patches of bare stone in deserts

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -604,8 +604,8 @@ function default.register_biomes()
 	minetest.register_biome({
 		name = "desert",
 		--node_dust = "",
-		node_top = "default:desert_sand",
-		depth_top = 1,
+		--node_top = "",
+		--depth_top = ,
 		node_filler = "default:desert_sand",
 		depth_filler = 1,
 		node_stone = "default:desert_stone",


### PR DESCRIPTION
As in mgv6. This is done by setting 'depth top' to 0. and allowing 'filler depth noise' to occasionally reduce 'filler depth' to 0.
The noise parameters for filler noise will need tuning in the mapgens so these blobs can have more detail and can have their scale and rarity changed. I'm thinking rarer, larger and more widely spaced.