### PR TITLE
Default, fire: Disable catch-up in some ABMs

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -105,6 +105,7 @@ minetest.register_abm({
 	neighbors = {"group:water"},
 	interval = 1,
 	chance = 2,
+	catch_up = false,
 	action = function(...)
 		default.cool_lava_flowing(...)
 	end,
@@ -115,6 +116,7 @@ minetest.register_abm({
 	neighbors = {"group:water"},
 	interval = 1,
 	chance = 2,
+	catch_up = false,
 	action = function(...)
 		default.cool_lava_source(...)
 	end,
@@ -313,6 +315,7 @@ minetest.register_abm({
 	nodenames = {"default:dirt"},
 	interval = 2,
 	chance = 200,
+	catch_up = false,
 	action = function(pos, node)
 		local above = {x = pos.x, y = pos.y + 1, z = pos.z}
 		local name = minetest.get_node(above).name
@@ -338,6 +341,7 @@ minetest.register_abm({
 	nodenames = {"default:dirt_with_grass", "default:dirt_with_dry_grass"},
 	interval = 2,
 	chance = 20,
+	catch_up = false,
 	action = function(pos, node)
 		local above = {x = pos.x, y = pos.y + 1, z = pos.z}
 		local name = minetest.get_node(above).name

--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -171,6 +171,7 @@ minetest.register_abm({
 	neighbors = {"group:puts_out_fire"},
 	interval = 3,
 	chance = 2,
+	catch_up = false,
 	action = function(p0, node, _, _)
 		minetest.remove_node(p0)
 		minetest.sound_play("fire_extinguish_flame",
@@ -189,6 +190,7 @@ if minetest.setting_getbool("disable_fire") then
 		nodenames = {"fire:basic_flame"},
 		interval = 7,
 		chance = 2,
+		catch_up = false,
 		action = function(p0, node, _, _)
 			minetest.remove_node(p0)
 		end,
@@ -203,6 +205,7 @@ else
 		neighbors = {"group:igniter"},
 		interval = 7,
 		chance = 16,
+		catch_up = false,
 		action = function(p0, node, _, _)
 			-- If there is water or stuff like that around node, don't ignite
 			if fire.flame_should_extinguish(p0) then
@@ -221,6 +224,7 @@ else
 		nodenames = {"fire:basic_flame"},
 		interval = 5,
 		chance = 16,
+		catch_up = false,
 		action = function(p0, node, _, _)
 			-- If there are no flammable nodes around flame, remove flame
 			if not minetest.find_node_near(p0, 1, {"group:flammable"}) then


### PR DESCRIPTION
To avoid processing spikes where catch-up is non-essential
Disable in: Lavacooling, grass growing, grass removal
and all fire mod ABMs

This will help with server lag and smoothness.