### PR TITLE
Default/mapgen: Tune biome points for improved disribution

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -335,7 +335,7 @@ function default.register_biomes()
 		node_river_water = "default:ice",
 		y_min = -8,
 		y_max = 31000,
-		heat_point = 5,
+		heat_point = 0,
 		humidity_point = 50,
 	})
 
@@ -353,7 +353,7 @@ function default.register_biomes()
 		--node_river_water = "",
 		y_min = -112,
 		y_max = -9,
-		heat_point = 5,
+		heat_point = 0,
 		humidity_point = 50,
 	})
 
@@ -361,7 +361,7 @@ function default.register_biomes()
 
 	minetest.register_biome({
 		name = "tundra",
-		node_dust = "default:snow",
+		--node_dust = "",
 		node_top = "default:dirt_with_snow",
 		depth_top = 1,
 		node_filler = "default:dirt",
@@ -374,7 +374,7 @@ function default.register_biomes()
 		y_min = 2,
 		y_max = 31000,
 		heat_point = 15,
-		humidity_point = 30,
+		humidity_point = 35,
 	})
 
 	minetest.register_biome({
@@ -392,17 +392,17 @@ function default.register_biomes()
 		y_min = -112,
 		y_max = 1,
 		heat_point = 15,
-		humidity_point = 30,
+		humidity_point = 35,
 	})
 
 
 	minetest.register_biome({
 		name = "taiga",
 		node_dust = "default:snow",
-		node_top = "default:snowblock",
+		node_top = "default:dirt_with_snow",
 		depth_top = 1,
 		node_filler = "default:dirt",
-		depth_filler = 4,
+		depth_filler = 3,
 		--node_stone = "",
 		--node_water_top = "",
 		--depth_water_top = ,
@@ -411,7 +411,7 @@ function default.register_biomes()
 		y_min = 2,
 		y_max = 31000,
 		heat_point = 15,
-		humidity_point = 70,
+		humidity_point = 65,
 	})
 
 	minetest.register_biome({
@@ -429,7 +429,7 @@ function default.register_biomes()
 		y_min = -112,
 		y_max = 1,
 		heat_point = 15,
-		humidity_point = 70,
+		humidity_point = 65,
 	})
 
 	-- Temperate
@@ -448,8 +448,8 @@ function default.register_biomes()
 		--node_river_water = "",
 		y_min = 5,
 		y_max = 31000,
-		heat_point = 45,
-		humidity_point = 30,
+		heat_point = 40,
+		humidity_point = 35,
 	})
 
 	minetest.register_biome({
@@ -466,8 +466,8 @@ function default.register_biomes()
 		--node_river_water = "",
 		y_min = -112,
 		y_max = 4,
-		heat_point = 45,
-		humidity_point = 30,
+		heat_point = 40,
+		humidity_point = 35,
 	})
 
 
@@ -485,8 +485,8 @@ function default.register_biomes()
 		--node_river_water = "",
 		y_min = 5,
 		y_max = 31000,
-		heat_point = 45,
-		humidity_point = 70,
+		heat_point = 40,
+		humidity_point = 65,
 	})
 
 	minetest.register_biome({
@@ -503,8 +503,8 @@ function default.register_biomes()
 		--node_river_water = "",
 		y_min = -112,
 		y_max = 4,
-		heat_point = 45,
-		humidity_point = 70,
+		heat_point = 40,
+		humidity_point = 65,
 	})
 
 
@@ -522,8 +522,8 @@ function default.register_biomes()
 		--node_river_water = "",
 		y_min = 5,
 		y_max = 31000,
-		heat_point = 55,
-		humidity_point = 30,
+		heat_point = 60,
+		humidity_point = 35,
 	})
 
 	minetest.register_biome({
@@ -540,8 +540,8 @@ function default.register_biomes()
 		--node_river_water = "",
 		y_min = -112,
 		y_max = 4,
-		heat_point = 55,
-		humidity_point = 30,
+		heat_point = 60,
+		humidity_point = 35,
 	})
 
 
@@ -559,8 +559,8 @@ function default.register_biomes()
 		--node_river_water = "",
 		y_min = 1,
 		y_max = 31000,
-		heat_point = 55,
-		humidity_point = 70,
+		heat_point = 60,
+		humidity_point = 65,
 	})
 
 	minetest.register_biome({
@@ -577,8 +577,8 @@ function default.register_biomes()
 		--node_river_water = "",
 		y_min = -3,
 		y_max = 0,
-		heat_point = 55,
-		humidity_point = 70,
+		heat_point = 60,
+		humidity_point = 65,
 	})
 
 	minetest.register_biome({
@@ -595,8 +595,8 @@ function default.register_biomes()
 		--node_river_water = "",
 		y_min = -112,
 		y_max = -4,
-		heat_point = 55,
-		humidity_point = 70,
+		heat_point = 60,
+		humidity_point = 65,
 	})
 
 	-- Hot
@@ -616,7 +616,7 @@ function default.register_biomes()
 		y_min = 5,
 		y_max = 31000,
 		heat_point = 85,
-		humidity_point = 10,
+		humidity_point = 20,
 	})
 
 	minetest.register_biome({
@@ -634,7 +634,7 @@ function default.register_biomes()
 		y_min = -112,
 		y_max = 4,
 		heat_point = 85,
-		humidity_point = 10,
+		humidity_point = 20,
 	})
 
 
@@ -708,7 +708,7 @@ function default.register_biomes()
 		y_min = 1,
 		y_max = 31000,
 		heat_point = 85,
-		humidity_point = 90,
+		humidity_point = 80,
 	})
 
 	minetest.register_biome({
@@ -726,7 +726,7 @@ function default.register_biomes()
 		y_min = -3,
 		y_max = 0,
 		heat_point = 85,
-		humidity_point = 90,
+		humidity_point = 80,
 	})
 
 	minetest.register_biome({
@@ -744,7 +744,7 @@ function default.register_biomes()
 		y_min = -112,
 		y_max = -4,
 		heat_point = 85,
-		humidity_point = 90,
+		humidity_point = 80,
 	})
 
 	-- Underground


### PR DESCRIPTION
![bsnarohum](https://cloud.githubusercontent.com/assets/3686677/11013793/82049eb0-8513-11e5-8af3-f0444eb4cf40.png)

Bring humidity points closer to reduce distortion of voronoi cells
Slightly increase spacing between hot and frozen biomes
Improve location of glacier biomes
Remove unnecessary snow nodeboxes from tundra to improve FPS
Add missing dirt_with_snow to taiga

Tested by generating a 'tiny biome' world (7.5 times smaller biomes than default) in mgv7, mapped above. Darkest green trees = rainforest. Ice blue = glacier.
Temperature thresholds for hot and frozen biomes are equal to those in both classic and new mgv6 biome systems.
Areas of desert, savanna and rainforest are more balanced, making desert and rainforest easier to find.
Glacier biomes are more centralised within the frozen biomes, moved away from the temperate biomes.