### PR TITLE
Beds: Re-add commas at list ends

### DIFF
--- a/mods/beds/api.lua
+++ b/mods/beds/api.lua
@@ -13,11 +13,11 @@ function beds.register_bed(name, def)
 		sounds = default.node_sound_wood_defaults(),
 		node_box = {
 			type = "fixed",
-			fixed = def.nodebox.bottom
+			fixed = def.nodebox.bottom,
 		},
 		selection_box = {
 			type = "fixed",
-			fixed = def.selectionbox
+			fixed = def.selectionbox,
 		},
 		after_place_node = function(pos, placer, itemstack)
 			local n = minetest.get_node_or_nil(pos)
@@ -94,7 +94,7 @@ function beds.register_bed(name, def)
 		node_box = {
 			type = "fixed",
 			fixed = def.nodebox.top,
-		}
+		},
 	})
 
 	minetest.register_alias(name, name .. "_bottom")


### PR DESCRIPTION
Correct missing commas at list ends, removed by a recent commit.