### PR TITLE
Default/mapgen: Use sidelen 16 for low density decorations

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -783,7 +783,7 @@ function default.register_mgv6_decorations()
 	minetest.register_decoration({
 		deco_type = "simple",
 		place_on = {"default:dirt_with_grass"},
-		sidelen = 8,
+		sidelen = 16,
 		noise_params = {
 			offset = -0.3,
 			scale = 0.7,
@@ -971,10 +971,10 @@ function default.register_decorations()
 	minetest.register_decoration({
 		deco_type = "schematic",
 		place_on = {"default:dirt_with_dry_grass"},
-		sidelen = 80,
+		sidelen = 16,
 		noise_params = {
 			offset = 0,
-			scale = 0.003,
+			scale = 0.002,
 			spread = {x = 250, y = 250, z = 250},
 			seed = 2,
 			octaves = 3,
@@ -993,7 +993,7 @@ function default.register_decorations()
 	minetest.register_decoration({
 		deco_type = "schematic",
 		place_on = {"default:desert_sand"},
-		sidelen = 80,
+		sidelen = 16,
 		noise_params = {
 			offset = -0.0005,
 			scale = 0.0015,
@@ -1015,7 +1015,7 @@ function default.register_decorations()
 	minetest.register_decoration({
 		deco_type = "simple",
 		place_on = {"default:desert_sand"},
-		sidelen = 80,
+		sidelen = 16,
 		noise_params = {
 			offset = -0.0005,
 			scale = 0.0015,


### PR DESCRIPTION
The fixing of low density decorations allows returning to
sidelen 16 for acacia trees and cacti, previously sidelen
80 was required for low density decorations to appear
Also use sidelen 16 instead of 8 for mgv6 papyrus