### PR TITLE
Ores: Allow dirt and sand blob ore in sandstone, desert stone

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -50,15 +50,15 @@ function default.register_ores()
 	-- Clay
 
 	minetest.register_ore({ 
-		ore_type         = "blob",
-		ore              = "default:clay",
-		wherein          = {"default:sand"},
-		clust_scarcity   = 16 * 16 * 16,
-		clust_size       = 5,
-		y_min            = -15,
-		y_max            = 0,
+		ore_type        = "blob",
+		ore             = "default:clay",
+		wherein         = {"default:sand"},
+		clust_scarcity  = 16 * 16 * 16,
+		clust_size      = 5,
+		y_min           = -15,
+		y_max           = 0,
 		noise_threshold = 0.0,
-		noise_params     = {
+		noise_params    = {
 			offset = 0.5,
 			scale = 0.2,
 			spread = {x = 5, y = 5, z = 5},
@@ -71,15 +71,16 @@ function default.register_ores()
 	-- Sand
 
 	minetest.register_ore({ 
-		ore_type         = "blob",
-		ore              = "default:sand",
-		wherein          = {"default:stone"},
-		clust_scarcity   = 16 * 16 * 16,
-		clust_size       = 5,
-		y_min            = -31,
-		y_max            = 4,
+		ore_type        = "blob",
+		ore             = "default:sand",
+		wherein         = {"default:stone", "default:sandstone",
+			"default:desert_stone"},
+		clust_scarcity  = 16 * 16 * 16,
+		clust_size      = 5,
+		y_min           = -31,
+		y_max           = 4,
 		noise_threshold = 0.0,
-		noise_params     = {
+		noise_params    = {
 			offset = 0.5,
 			scale = 0.2,
 			spread = {x = 5, y = 5, z = 5},
@@ -92,15 +93,15 @@ function default.register_ores()
 	-- Dirt
 
 	minetest.register_ore({
-		ore_type         = "blob",
-		ore              = "default:dirt",
-		wherein          = {"default:stone"},
-		clust_scarcity   = 16 * 16 * 16,
-		clust_size       = 5,
-		y_min            = -31,
-		y_max            = 31000,
+		ore_type        = "blob",
+		ore             = "default:dirt",
+		wherein         = {"default:stone", "default:sandstone"},
+		clust_scarcity  = 16 * 16 * 16,
+		clust_size      = 5,
+		y_min           = -31,
+		y_max           = 31000,
 		noise_threshold = 0.0,
-		noise_params     = {
+		noise_params    = {
 			offset = 0.5,
 			scale = 0.2,
 			spread = {x = 5, y = 5, z = 5},
@@ -113,15 +114,15 @@ function default.register_ores()
 	-- Gravel
 
 	minetest.register_ore({
-		ore_type         = "blob",
-		ore              = "default:gravel",
-		wherein          = {"default:stone"},
-		clust_scarcity   = 16 * 16 * 16,
-		clust_size       = 5,
-		y_min            = -31000,
-		y_max            = 31000,
+		ore_type        = "blob",
+		ore             = "default:gravel",
+		wherein         = {"default:stone"},
+		clust_scarcity  = 16 * 16 * 16,
+		clust_size      = 5,
+		y_min           = -31000,
+		y_max           = 31000,
 		noise_threshold = 0.0,
-		noise_params     = {
+		noise_params    = {
 			offset = 0.5,
 			scale = 0.2,
 			spread = {x = 5, y = 5, z = 5},


### PR DESCRIPTION
"Re-align parameter format in 'register ore'"

While testing blob ore in mgv7 recently i noticed blobs were missing from large volumes underground, i realised these were the sandstone and desert stone biomes extending to y = -112, when creating the new biome system i forgot to consider whether certain blob ores should appear in sandstone and desert stone.

The sandstone biomes have a dirt surface, so it seems reasonable to allow dirt blobs in sandstone.

Sand blobs were previouslly found in stone between y = 4 and y = -31 as these are considered to be beach and seabed sand that has penetrated the stone, so it seems reasonable to have sand blobs in sandstone and desert stone too. Although classic Minetest never had sand blobs in desert stone it also never had desert stone below y = 1, now more recently desert stone extends to y = -32 in mgv6 and to y = -112 in biome API mapgens.