### PR TITLE
Verify node type is facedir.

### DIFF
--- a/mods/screwdriver/init.lua
+++ b/mods/screwdriver/init.lua
@@ -35,6 +35,10 @@ local function screwdriver_handler(itemstack, user, pointed_thing, mode)
 
 	local node = minetest.get_node(pos)
 	local ndef = minetest.registered_nodes[node.name]
+	-- verify node is facedir (expected to be rotatable)
+	if ndef.paramtype2 ~= "facedir" then
+		return
+	end
 	-- Compute param2
 	local rotationPart = node.param2 % 32 -- get first 4 bits
 	local preservePart = node.param2 - rotationPart


### PR DESCRIPTION
This prevents nodes that are not of the "facedir" paramtype2,
as these are generally not expected to be able to rotate. Mods
and other methods may still manipulate param2 of these nodes
as expected.

Addresses #712