### PR TITLE
Place tree logs as decorations.

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -967,7 +967,7 @@ end
 function default.register_decorations()
 	minetest.clear_registered_decorations()
 
-	-- Apple tree
+	-- Apple tree and log
 
 	minetest.register_decoration({
 		deco_type = "schematic",
@@ -988,7 +988,33 @@ function default.register_decorations()
 		flags = "place_center_x, place_center_z",
 	})
 
-	-- Jungle tree
+	minetest.register_decoration({
+		deco_type = "schematic",
+		place_on = {"default:dirt_with_grass"},
+		sidelen = 80,
+		fill_ratio = 0.0015,
+		biomes = {"deciduous_forest"},
+		y_min = 1,
+		y_max = 31000,
+		schematic = {
+			size = { x = 3, y = 3, z = 1},
+			data = {
+				{ name = "air", prob = 0 },
+				{ name = "air", prob = 0 },
+				{ name = "air", prob = 0 },
+				{ name = "default:tree", param2 = 12, prob = 191 },
+				{ name = "default:tree", param2 = 12 },
+				{ name = "default:tree", param2 = 12, prob = 127 },
+				{ name = "air", prob = 0 },
+				{ name = "flowers:mushroom_brown", prob = 63 },
+				{ name = "air", prob = 0 },
+			},
+		},
+		flags = "place_center_x",
+		rotation = "random",
+	})
+
+	-- Jungle tree and log
 
 	minetest.register_decoration({
 		deco_type = "schematic",
@@ -1003,7 +1029,33 @@ function default.register_decorations()
 		rotation = "random",
 	})
 
-	-- Taiga and temperate coniferous forest pine tree
+	minetest.register_decoration({
+		deco_type = "schematic",
+		place_on = {"default:dirt_with_grass", "default:dirt"},
+		sidelen = 80,
+		fill_ratio = 0.01,
+		biomes = {"rainforest", "rainforest_swamp"},
+		y_min = 1,
+		y_max = 31000,
+		schematic = {
+			size = { x = 3, y = 3, z = 1},
+			data = {
+				{ name = "air", prob = 0 },
+				{ name = "air", prob = 0 },
+				{ name = "air", prob = 0 },
+				{ name = "default:jungletree", param2 = 12, prob = 191 },
+				{ name = "default:jungletree", param2 = 12 },
+				{ name = "default:jungletree", param2 = 12, prob = 127 },
+				{ name = "air", prob = 0 },
+				{ name = "flowers:mushroom_brown", prob = 127 },
+				{ name = "air", prob = 0 },
+			},
+		},
+		flags = "place_center_x",
+		rotation = "random",
+	})
+
+	-- Taiga and temperate coniferous forest pine tree and log
 
 	minetest.register_decoration({
 		deco_type = "schematic",
@@ -1024,7 +1076,33 @@ function default.register_decorations()
 		flags = "place_center_x, place_center_z",
 	})
 
-	-- Acacia tree
+	minetest.register_decoration({
+		deco_type = "schematic",
+		place_on = {"default:dirt_with_snow", "default:dirt_with_grass"},
+		sidelen = 80,
+		fill_ratio = 0.003,
+		biomes = {"taiga", "coniferous_forest"},
+		y_min = 1,
+		y_max = 31000,
+		schematic = {
+			size = { x = 3, y = 3, z = 1},
+			data = {
+				{ name = "air", prob = 0 },
+				{ name = "air", prob = 0 },
+				{ name = "air", prob = 0 },
+				{ name = "default:pine_tree", param2 = 12, prob = 191 },
+				{ name = "default:pine_tree", param2 = 12 },
+				{ name = "default:pine_tree", param2 = 12, prob = 127 },
+				{ name = "air", prob = 0 },
+				{ name = "flowers:mushroom_red", prob = 127 },
+				{ name = "air", prob = 0 },
+			},
+		},
+		flags = "place_center_x",
+		rotation = "random",
+	})
+
+	-- Acacia tree and log
 
 	minetest.register_decoration({
 		deco_type = "schematic",
@@ -1043,6 +1121,36 @@ function default.register_decorations()
 		y_max = 31000,
 		schematic = minetest.get_modpath("default").."/schematics/acacia_tree.mts",
 		flags = "place_center_x, place_center_z",
+		rotation = "random",
+	})
+
+	minetest.register_decoration({
+		deco_type = "schematic",
+		place_on = {"default:dirt_with_dry_grass"},
+		sidelen = 16,
+		noise_params = {
+			offset = 0,
+			scale = 0.001,
+			spread = {x = 250, y = 250, z = 250},
+			seed = 2,
+			octaves = 3,
+			persist = 0.66
+		},
+		biomes = {"savanna"},
+		y_min = 1,
+		y_max = 31000,
+		schematic = {
+			size = { x = 3, y = 2, z = 1},
+			data = {
+				{ name = "air", prob = 0 },
+				{ name = "air", prob = 0 },
+				{ name = "air", prob = 0 },
+				{ name = "default:acacia_tree", param2 = 12, prob = 191 },
+				{ name = "default:acacia_tree", param2 = 12 },
+				{ name = "default:acacia_tree", param2 = 12, prob = 127 },
+			},
+		},
+		flags = "place_center_x",
 		rotation = "random",
 	})
 


### PR DESCRIPTION
We can vary the landscape a bit more by placing "fallen logs"
around the various forests. These decorations are quite fast
and will provide some gameplay value but are still more rare
than the corresponding trees, so they don't provide free
materials.

I've manually put the schematic as lua tables since these log
schematics are only 8 blocks. We vary the log lengths between
2 and 4 blocks by making the end blocks have a lower chance
of appearing.

Amount is varied by fill_ratio, except for acacia trees where
we reduce the scale, so that acacia logs show up near places with
acacia trees consistently.