### PR TITLE
Default: Add mapgen alias for air

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -2,6 +2,7 @@
 -- Aliases for map generator outputs
 --
 
+minetest.register_alias("mapgen_air", "air")
 minetest.register_alias("mapgen_stone", "default:stone")
 minetest.register_alias("mapgen_dirt", "default:dirt")
 minetest.register_alias("mapgen_dirt_with_grass", "default:dirt_with_grass")


### PR DESCRIPTION
Once core mapgen are modified to work with this, will enable subgames to use core mapgen to create space or alien realms with vacuum nodes or alien atmosphere nodes.