### PR TITLE
on_burn callback for nodes to handle burning

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -145,6 +145,17 @@ farming.register_plant(name, Plant definition)
 	maxlight = default.LIGHT_MAX           -- Maximum light to grow
 }
 
+Fire API
+--------
+The fire API supports nodes with groups.flammable set, with an optional callback function:
+
+on_burn(position, igniter_node_name, action)
+^ Optionally return true to prevent node being removed
+ -> position: "Burn position"
+ -> igniter_node_name: "Igniting node's name"
+ -> action: "Action in progress"
+ ^ Current <action> passed to, is "remove"
+
 Screwdriver API
 ---------------
 The screwdriver API allows you to control a node's behaviour when a screwdriver is used on it.


### PR DESCRIPTION
Allows nodes to define on_burn(position, igniter_node_name, action_string) to handle different(future) burn actions (E.g. allows nodes to change burnt nodes to a charred/burnt version or reduce chance of removal, rather than just remove equally).

Optimised by removing duplicate call to find_node_near before removing flammable nodes.
Improved readability with meaningful variable names and some added comments.
Provided fire.features.on_burn_callback (Thanks, Celeron55!) to allow mods to save recreating functionality with their own burning ABMs by testing fire.features.