### PR TITLE
Fix trapdoor recipe conflict with iron bar recipe.

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -539,11 +539,10 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-	output = 'doors:trapdoor_steel 2',
+	output = 'doors:trapdoor_steel',
 	recipe = {
-		{'default:steel_ingot', 'default:steel_ingot', 'default:steel_ingot'},
-		{'default:steel_ingot', 'default:steel_ingot', 'default:steel_ingot'},
-		{'', '', ''},
+		{'default:steel_ingot', 'default:steel_ingot'},
+		{'default:steel_ingot', 'default:steel_ingot'},
 	}
 })
 


### PR DESCRIPTION
In oversight, I added this recipe not verifying that it was already
taken.

We change this to a 2x2 iron bar recipe. The shape and amount are
reasonable (reduced to output 1 steel trapdoor), and I verified that
it wasn't in use.

Fixes #779