### PR TITLE
Default/mapgen: Remove unused 'mapgen_air' alias 

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -2,7 +2,6 @@
 -- Aliases for map generator outputs
 --
 
-minetest.register_alias("mapgen_air", "air")
 minetest.register_alias("mapgen_stone", "default:stone")
 minetest.register_alias("mapgen_dirt", "default:dirt")
 minetest.register_alias("mapgen_dirt_with_grass", "default:dirt_with_grass")


### PR DESCRIPTION
EDIT: PR changed to just remove the unused 'mapgen_air' alias.