### PR TITLE
Allow trapdoors to be rotated all ways.

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -451,8 +451,6 @@ function doors.register_trapdoor(name, def)
 		minetest.swap_node(pos, {name = newname, param1 = node.param1, param2 = node.param2})
 	end
 
-	def.on_rotate = minetest.get_modpath("screwdriver") and screwdriver.rotate_simple
-
 	-- Common trapdoor configuration
 	def.drawtype = "nodebox"
 	def.paramtype = "light"


### PR DESCRIPTION
There really is no reason to prevent rotation in trapdoors, I
expect this to be an oversight.

Trapdoors work perfectly well sideways, upside down and can
work like fences, gates and more. Most commonly, people will
want to put them in the top half of the node so they remain
flush with a floor.

Fixes #545