### PR TITLE
Stair and Slab groups.

### DIFF
--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -22,6 +22,7 @@ local replace = minetest.setting_getbool("enable_stairs_replace_abm")
 -- Node will be called stairs:stair_<subname>
 
 function stairs.register_stair(subname, recipeitem, groups, images, description, sounds)
+	groups.stair = 1
 	minetest.register_node(":stairs:stair_" .. subname, {
 		description = description,
 		drawtype = "mesh",
@@ -111,6 +112,7 @@ end
 -- Node will be called stairs:slab_<subname>
 
 function stairs.register_slab(subname, recipeitem, groups, images, description, sounds)
+	groups.slab = 1
 	minetest.register_node(":stairs:slab_" .. subname, {
 		description = description,
 		drawtype = "nodebox",


### PR DESCRIPTION
Organizing these in groups will allow mods to do several things
easier:

- create craft recipes using them as ingredients
- manipulate map nodes based on group properties

There are quite a few slab and stair blocks already, so automatically
add these groups at registration time for all of those. Since most
mods I've seen use the registration code in this submod, they will
also benefit.