### PR TITLE
Make ocean biomes more attractive.

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -1394,8 +1394,8 @@ if mg_params.mgname == "v6" then
 	default.register_mgv6_decorations()
 	minetest.register_on_generated(default.generate_nyancats)
 elseif mg_params.mgname ~= "singlenode" then
-	default.register_ores()
 	default.register_biomes()
+	default.register_ores()
 	default.register_decorations()
 	minetest.register_on_generated(default.generate_nyancats)
 end


### PR DESCRIPTION
Place larger clay blobs in all ocean biomes, but only at deeper
water depths (-10 through -50).

These biomes are very unattractive, and clay is relatively
sparse in the game already. These larger blobs may provide
an attractive resource for players to explore and mine in
the underwater areas. Since these will always be close to
the seafloor, they are likely more risky to dig due to
potential drowning.

In order to use the biomes option for ore registration, we
need to register biomes before ores.