### PR TITLE
Default/mapgen: Add gravel beach in Tundra

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -379,6 +379,24 @@ function default.register_biomes()
 	})
 
 	minetest.register_biome({
+		name = "tundra_beach",
+		--node_dust = "",
+		node_top = "default:gravel",
+		depth_top = 1,
+		node_filler = "default:gravel",
+		depth_filler = 2,
+		--node_stone = "",
+		--node_water_top = "",
+		--depth_water_top = ,
+		--node_water = "",
+		--node_river_water = "",
+		y_min = -3,
+		y_max = 1,
+		heat_point = 15,
+		humidity_point = 35,
+	})
+
+	minetest.register_biome({
 		name = "tundra_ocean",
 		--node_dust = "",
 		node_top = "default:sand",
@@ -391,7 +409,7 @@ function default.register_biomes()
 		--node_water = "",
 		--node_river_water = "",
 		y_min = -112,
-		y_max = 1,
+		y_max = -4,
 		heat_point = 15,
 		humidity_point = 35,
 	})


### PR DESCRIPTION
![screenshot_20160128_015942](https://cloud.githubusercontent.com/assets/3686677/12635363/4c5820b4-c57a-11e5-836c-32d7688f2341.png)

For more variety of shore types, a gravel beach suits the barren rocky nature of  tundra.
The gravel beach extends down to y = -3 just as swamps do.