### PR TITLE
Remove log_mods from TNT

### DIFF
--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -395,8 +395,3 @@ minetest.register_craft({
 		{"",           "group:wood",    ""}
 	}
 })
-
-if minetest.setting_get("log_mods") then
-	minetest.debug("[TNT] Loaded!")
-end
-


### PR DESCRIPTION
This option is not documented nor is it used with any other mod in Minetest Game so why should it be used in TNT?