### PR TITLE
Default/mapgen: Confine Aspen to one half of deciduous forest

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -1185,8 +1185,8 @@ function default.register_decorations()
 		place_on = {"default:dirt_with_grass"},
 		sidelen = 16,
 		noise_params = {
-			offset = 0.01,
-			scale = -0.02,
+			offset = 0.0,
+			scale = -0.03,
 			spread = {x = 250, y = 250, z = 250},
 			seed = 2,
 			octaves = 3,
@@ -1205,8 +1205,8 @@ function default.register_decorations()
 		place_on = {"default:dirt_with_grass"},
 		sidelen = 16,
 		noise_params = {
-			offset = 0.0005,
-			scale = -0.001,
+			offset = 0.0,
+			scale = -0.0015,
 			spread = {x = 250, y = 250, z = 250},
 			seed = 2,
 			octaves = 3,


### PR DESCRIPTION
I miss the large areas of dark appletrees. Aspen is bright and visually dominant and feels too common being present in 2/3rds of the biome. This PR keeps one half of the biome appletrees, the other half a varying mix, the maximum density of Aspen is kept the same.