### PR TITLE
Consolidate ABMs

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -88,37 +88,24 @@ end
 -- Lavacooling
 --
 
-default.cool_lava_source = function(pos)
-	minetest.set_node(pos, {name = "default:obsidian"})
-	minetest.sound_play("default_cool_lava",
-		{pos = pos, max_hear_distance = 16, gain = 0.25})
-end
-
-default.cool_lava_flowing = function(pos)
-	minetest.set_node(pos, {name = "default:stone"})
+default.cool_lava = function(pos, node)
+	if node.name == "default:lava_source" then
+		minetest.set_node(pos, {name = "default:obsidian"})
+	else -- Lava flowing
+		minetest.set_node(pos, {name = "default:stone"})
+	end
 	minetest.sound_play("default_cool_lava",
 		{pos = pos, max_hear_distance = 16, gain = 0.25})
 end
 
 minetest.register_abm({
-	nodenames = {"default:lava_flowing"},
+	nodenames = {"default:lava_source", "default:lava_flowing"},
 	neighbors = {"group:water"},
 	interval = 1,
-	chance = 2,
+	chance = 1,
 	catch_up = false,
 	action = function(...)
-		default.cool_lava_flowing(...)
-	end,
-})
-
-minetest.register_abm({
-	nodenames = {"default:lava_source"},
-	neighbors = {"group:water"},
-	interval = 1,
-	chance = 2,
-	catch_up = false,
-	action = function(...)
-		default.cool_lava_source(...)
+		default.cool_lava(...)
 	end,
 })
 
@@ -177,8 +164,8 @@ end
 minetest.register_abm({
 	nodenames = {"default:cactus"},
 	neighbors = {"group:sand"},
-	interval = 50,
-	chance = 20,
+	interval = 12,
+	chance = 83,
 	action = function(...)
 		default.grow_cactus(...)
 	end
@@ -186,9 +173,9 @@ minetest.register_abm({
 
 minetest.register_abm({
 	nodenames = {"default:papyrus"},
-	neighbors = {"default:dirt", "default:dirt_with_grass", "default:sand"},
-	interval = 50,
-	chance = 20,
+	neighbors = {"default:dirt", "default:dirt_with_grass"},
+	interval = 14,
+	chance = 71,
 	action = function(...)
 		default.grow_papyrus(...)
 	end
@@ -358,8 +345,9 @@ minetest.register_abm({
 
 minetest.register_abm({
 	nodenames = {"default:dirt"},
-	interval = 2,
-	chance = 200,
+	neighbors = {"air"},
+	interval = 6,
+	chance = 67,
 	catch_up = false,
 	action = function(pos, node)
 		local above = {x = pos.x, y = pos.y + 1, z = pos.z}
@@ -384,8 +372,8 @@ minetest.register_abm({
 
 minetest.register_abm({
 	nodenames = {"default:dirt_with_grass", "default:dirt_with_dry_grass"},
-	interval = 2,
-	chance = 20,
+	interval = 8,
+	chance = 50,
 	catch_up = false,
 	action = function(pos, node)
 		local above = {x = pos.x, y = pos.y + 1, z = pos.z}
@@ -407,7 +395,7 @@ minetest.register_abm({
 minetest.register_abm({
 	nodenames = {"default:cobble"},
 	neighbors = {"group:water"},
-	interval = 17,
+	interval = 16,
 	chance = 200,
 	catch_up = false,
 	action = function(pos, node)

--- a/mods/farming/api.lua
+++ b/mods/farming/api.lua
@@ -264,8 +264,8 @@ farming.register_plant = function(name, def)
 	minetest.register_abm({
 		nodenames = {"group:" .. pname, "group:seed"},
 		neighbors = {"group:soil"},
-		interval = 90,
-		chance = 2,
+		interval = 9,
+		chance = 20,
 		action = function(pos, node)
 			local plant_height = minetest.get_item_group(node.name, pname)
 

--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -170,7 +170,7 @@ minetest.register_abm({
 	nodenames = {"fire:basic_flame", "fire:permanent_flame"},
 	neighbors = {"group:puts_out_fire"},
 	interval = 3,
-	chance = 2,
+	chance = 1,
 	catch_up = false,
 	action = function(p0, node, _, _)
 		minetest.remove_node(p0)
@@ -189,7 +189,7 @@ if minetest.setting_getbool("disable_fire") then
 	minetest.register_abm({
 		nodenames = {"fire:basic_flame"},
 		interval = 7,
-		chance = 2,
+		chance = 1,
 		catch_up = false,
 		action = function(p0, node, _, _)
 			minetest.remove_node(p0)

--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -76,8 +76,8 @@ end
 minetest.register_abm({
 	nodenames = {"group:flora"},
 	neighbors = {"default:dirt_with_grass", "default:desert_sand"},
-	interval = 50,
-	chance = 25,
+	interval = 13,
+	chance = 96,
 	action = function(pos, node)
 		pos.y = pos.y - 1
 		local under = minetest.get_node(pos)

--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -233,7 +233,7 @@ end
 if replace then
 	minetest.register_abm({
 		nodenames = {"group:slabs_replace"},
-		interval = 8,
+		interval = 16,
 		chance = 1,
 		action = function(pos, node)
 			node.name = minetest.registered_nodes[node.name].replace_name

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -376,7 +376,7 @@ minetest.register_node("tnt:gunpowder_burning", {
 minetest.register_abm({
 	nodenames = {"tnt:tnt", "tnt:gunpowder"},
 	neighbors = {"fire:basic_flame", "default:lava_source", "default:lava_flowing"},
-	interval = 1,
+	interval = 4,
 	chance = 1,
 	action = burn,
 })


### PR DESCRIPTION
Spread ABM intervals evenly across 1 to 16 seconds
16s ensures no nodes are missed when player walks past
Adjust chance values to compensate, for identical action rates
Combine lavacooling ABMs into one, return to chance = 1
Grass growth: add 'neighbors = "air"' to avoid
processing the thousands of underground dirt nodes
Grass death: Reduce action rate to that of grass growth
Fire: Use chance = 1 for flame extinguishing
and flame removal when mod is disabled

////////////////////////////////////

PR for issue #827 

1. Reduce all intervals to 16s or less.
With the default active block range of 32 nodes and a player speed of 4 nodes per second, a player walking without stopping can cross the triggering distance of an ABM in 16s. Any higher interval means that ABM actions can be missed.

2. Adjust chance parameter to compensate for the change in interval, to result in the same rate of ABM actons.
The advantage of shorter intervals and higher chance parameters is that stuff is done in a larger number of smaller batches, this reduces the length of individual lua lags and makes the lua server smoother.

3. Adjust intervals to be more evenly spread out across 1s and 16s.
This makes ABM intervals more out-of-phase instead of all firing at once causing lua lag spikes. We could even choose prime number intervals for the heaviest ABMs to keep them out of phase with each other even more.

4. Other optimisations where possible, see comments.

Below, changed values are in brackets.

```
default/
functions.lua/

Lavacooling x 2.
	interval = 1,
	chance = 2, (1)
* Interval unchangeable. Chance back to 1 for classic behaviour.
* Combine into 1 ABM for less search load.

Cactus growth.
	interval = 50, (12)
	chance = 20, (83)

Papyrus growth.
	interval = 50, (14)
	chance = 20, (71)

Leafdecay.
	interval = 2,
	chance = 5,
* Lua-heavy. Interval is expected to be small and spreads the load.

Grass growth on dirt.
	interval = 2, (6)
	chance = 200, (67)
* Lua heavy due to 3 x 4096 dirt around.
* Add 'neighbors = air' to hugely reduce number of actions.

Grass death in darkness.
	interval = 2, (8)
	chance = 20, (50)
* Action rate can be reduced, currently unnecessarily fast.
* Equalise action rate to grass growth rate.

Moss growth on cobble near water.
	interval = 17, (16)
	chance = 200,
* Lua-light so can share an interval with stairs replace ABM.

trees.lua/

Grow saplings.
	interval = 10,
	chance = 50,


doors/
init.lua/

Door replace ABMs,
	interval = 7,
	chance = 1,
* Might be replaced with LBM later. Fairly lua-light due to few doors present.
* So can share an interval with fire mod.


farming/
api.lua/

Crop growing.
	interval = 90, (9)
	chance = 2, (20)

nodes.lua/

Saturation and drying of soil.
	interval = 15,
	chance = 4,


fire/
init.lua/

Extinguish with water/snow/ice.
	interval = 3,
	chance = 2, (1)
* Lua-light. Chance = 1 for more effective extinguishing.

Remove flames when fire mod, and the 2 ABMs below, are disabled.
	interval = 7,
	chance = 2, (1)
* Lua-light. Chance = 1 for more effective removal.

Ignition.
	interval = 7,
	chance = 16,

Remove burnt nodes and flames.
	interval = 5,
	chance = 16,


flowers/
init.lua/

Flower spread.
	interval = 50, (13)
	chance = 25, (96)
* Lua heavy so prime interval 13.

Mushroom spread.
	interval = 11,
	chance = 50,


stairs/
init.lua/

Replace old nodes. Disabled by default.
	interval = 8, (16)
	chance = 1,
* Lua-light. Increase interval to maximum for less search load.
* Might be replaced by LBM later.


tnt/
init.lua/

Ignite TNT and gunpowder.
	interval = 1, (4)
	chance = 1,
* Increase interval for less search load.
* TNT and gunpowder can take a while to ignite.
```
and flame removal when mod is disabled