### PR TITLE
Doors: fix unability to register doors outside of doors mod

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -178,7 +178,7 @@ function doors.register(name, def)
 		end
 	})
 
-	minetest.register_craftitem("doors:" .. name, {
+	minetest.register_craftitem(":doors:" .. name, {
 		description = def.description,
 		inventory_image = def.inventory_image,
 
@@ -288,7 +288,7 @@ function doors.register(name, def)
 		end
 	end
 
-	minetest.register_node("doors:" .. name .. "_a", {
+	minetest.register_node(":doors:" .. name .. "_a", {
 		description = def.description,
 		visual = "mesh",
 		mesh = "door_a.obj",
@@ -320,7 +320,7 @@ function doors.register(name, def)
 		},
 	})
 
-	minetest.register_node("doors:" .. name .. "_b", {
+	minetest.register_node(":doors:" .. name .. "_b", {
 		description = def.description,
 		visual = "mesh",
 		mesh = "door_b.obj",


### PR DESCRIPTION
Regression caused by https://github.com/minetest/minetest_game/commit/f600a9f645af40d22c8eb7c17aff89507b71816e

Using the new API : 
```
Name doors:japanese_door does not follow naming conventions: "xdecor:" or ":" prefix required
```

To merge ASAP.