### PR TITLE
Add background image to book formspec

### DIFF
--- a/mods/default/craftitems.lua
+++ b/mods/default/craftitems.lua
@@ -21,6 +21,7 @@ local function book_on_use(itemstack, user, pointed_thing)
 	local formspec
 	if owner == player_name then
 		formspec = "size[8,8]"..default.gui_bg..
+			default.gui_bg_img..
 			"field[0.5,1;7.5,0;title;Title:;"..
 				minetest.formspec_escape(title).."]"..
 			"textarea[0.5,1.5;7.5,7;text;Contents:;"..
@@ -28,6 +29,7 @@ local function book_on_use(itemstack, user, pointed_thing)
 			"button_exit[2.5,7.5;3,1;save;Save]"
 	else
 		formspec = "size[8,8]"..default.gui_bg..
+			default.gui_bg_img..
 			"label[0.5,0.5;by "..owner.."]"..
 			"label[0.5,0;"..minetest.formspec_escape(title).."]"..
 			"tableoptions[background=#00000000;highlight=#00000000;border=false]"..


### PR DESCRIPTION
It probably doesn't change text visibility but I think it looks better because every other formspec has one.

Edit: This was first discussed here: #413

Before:
![capture 2](https://cloud.githubusercontent.com/assets/7414772/13030381/d047e4d2-d276-11e5-9c3a-3550aea55831.PNG)

After:
![capture 1](https://cloud.githubusercontent.com/assets/7414772/13030408/a498ae38-d277-11e5-96f6-2e9f249ae0d2.PNG)

