### PR TITLE
Let mods specify a modname in doors.register def.

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -119,7 +119,7 @@ function _doors.door_toggle(pos, clicker)
 	local meta = minetest.get_meta(pos)
 	local state = meta:get_int("state")
 	local def = minetest.registered_nodes[minetest.get_node(pos).name]
-	local name = def.door.basename
+	local fullname = def.door.fullname
 
 	if clicker then
 		local owner = meta:get_string("doors_owner")
@@ -146,7 +146,7 @@ function _doors.door_toggle(pos, clicker)
 	end
 
 	minetest.swap_node(pos, {
-		name = "doors:" .. name .. transform[state + 1][dir+1].v,
+		name = fullname .. transform[state + 1][dir+1].v,
 		param2 = transform[state + 1][dir+1].param2
 	})
 	meta:set_int("state", state)
@@ -174,9 +174,15 @@ local function on_place_node(place_to, newnode, placer, oldnode, itemstack, poin
 end
 
 function doors.register(name, def)
+	if not def.modname then
+		def.modname = "doors"
+	end
+	local fullname = def.modname .. ":" .. name
+
+
 	-- replace old doors of this type automatically
 	minetest.register_abm({
-		nodenames = {"doors:"..name.."_b_1", "doors:"..name.."_b_2"},
+		nodenames = {fullname.."_b_1", fullname.."_b_2"},
 		interval = 7.0,
 		chance = 1,
 		action = function(pos, node, active_object_count, active_object_count_wider)
@@ -190,14 +196,14 @@ function doors.register(name, def)
 			}
 			local new = replace[l][h]
 			-- retain infotext and doors_owner fields
-			minetest.swap_node(pos, { name = "doors:" .. name .. "_" .. new.type, param2 = p2})
+			minetest.swap_node(pos, { name = fullname .. "_" .. new.type, param2 = p2})
 			meta:set_int("state", new.state)
 			-- wipe meta on top node as it's unused
 			minetest.set_node({x = pos.x, y = pos.y + 1, z = pos.z}, { name = "doors:hidden" })
 		end
 	})
 
-	minetest.register_craftitem(":doors:" .. name, {
+	minetest.register_craftitem(":" .. fullname, {
 		description = def.description,
 		inventory_image = def.inventory_image,
 
@@ -249,9 +255,9 @@ function doors.register(name, def)
 			local state = 0
 			if minetest.get_item_group(minetest.get_node(aside).name, "door") == 1 then
 				state = state + 2
-				minetest.set_node(pos, {name = "doors:" .. name .. "_b", param2 = dir})
+				minetest.set_node(pos, {name = fullname .. "_b", param2 = dir})
 			else
-				minetest.set_node(pos, {name = "doors:" .. name .. "_a", param2 = dir})
+				minetest.set_node(pos, {name = fullname .. "_a", param2 = dir})
 			end
 			minetest.set_node(above, { name = "doors:hidden" })
 
@@ -296,9 +302,11 @@ function doors.register(name, def)
 
 	def.groups.not_in_creative_inventory = 1
 	def.groups.door = 1
-	def.drop = "doors:" .. name
+	def.drop = fullname
 	def.door = {
 		basename = name,
+		fullname = fullname,
+		modname = modname,
 		sounds = { def.sound_close, def.sound_open },
 	}
 
@@ -322,11 +330,11 @@ function doors.register(name, def)
 			minetest.remove_node(pos)
 			-- hidden node doesn't get blasted away.
 			minetest.remove_node({ x = pos.x, y = pos.y + 1, z = pos.z})
-			return { "doors:" .. name }
+			return { fullname }
 		end
 	end
 
-	minetest.register_node(":doors:" .. name .. "_a", {
+	minetest.register_node(":" .. fullname .. "_a", {
 		description = def.description,
 		visual = "mesh",
 		mesh = "door_a.obj",
@@ -358,7 +366,7 @@ function doors.register(name, def)
 		},
 	})
 
-	minetest.register_node(":doors:" .. name .. "_b", {
+	minetest.register_node(":" .. fullname .. "_b", {
 		description = def.description,
 		visual = "mesh",
 		mesh = "door_b.obj",
@@ -392,13 +400,13 @@ function doors.register(name, def)
 
 	if def.recipe then
 		minetest.register_craft({
-			output = "doors:" .. name,
+			output = fullname,
 			recipe = def.recipe,
 		})
 	end
 
-	_doors.registered_doors["doors:" .. name .. "_a"] = true
-	_doors.registered_doors["doors:" .. name .. "_b"] = true
+	_doors.registered_doors[fullname .. "_a"] = true
+	_doors.registered_doors[fullname .. "_b"] = true
 end
 
 doors.register("door_wood", {


### PR DESCRIPTION
This let's mods to use the doors api and create nodes in their own namespace.
This makes it easier to switch from the old api to the new one and solves #854 (the door node name contains the mod name).

To register nodes in your mod namespace, just add a "modname" attribute in the doors definition.

On the implementation level, I've let the door basename attribute, and added a "fullname" that's the concatenation of basename and modname. 
In fact, the modname attribute could be dropped and rollback to the old way of doing by registering doors with the modname included in the door name like "my_mod:my_door".

I know this tries to solve the same issue as #858 but I find it more clean for mods that want to switch to the new api.
