### PR TITLE
Remove dig_up() from cactus.

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -879,10 +879,6 @@ minetest.register_node("default:cactus", {
 	groups = {snappy = 1, choppy = 3, flammable = 2},
 	sounds = default.node_sound_wood_defaults(),
 	on_place = minetest.rotate_node,
-
-	after_dig_node = function(pos, node, metadata, digger)
-		default.dig_up(pos, node, digger)
-	end,
 })
 
 minetest.register_node("default:papyrus", {


### PR DESCRIPTION
Digging a cactus leaves the branches hanging. With this change it will no longer happen.