### PR TITLE
Default/mapgen: Make forest clearings larger and more common

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -991,8 +991,8 @@ function default.register_decorations()
 		place_on = {"default:dirt_with_grass"},
 		sidelen = 16,
 		noise_params = {
-			offset = 0.04,
-			scale = 0.02,
+			offset = 0.036,
+			scale = 0.022,
 			spread = {x = 250, y = 250, z = 250},
 			seed = 2,
 			octaves = 3,
@@ -1010,8 +1010,8 @@ function default.register_decorations()
 		place_on = {"default:dirt_with_grass"},
 		sidelen = 16,
 		noise_params = {
-			offset = 0.002,
-			scale = 0.001,
+			offset = 0.0018,
+			scale = 0.0011,
 			spread = {x = 250, y = 250, z = 250},
 			seed = 2,
 			octaves = 3,
@@ -1086,8 +1086,8 @@ function default.register_decorations()
 		place_on = {"default:dirt_with_snow", "default:dirt_with_grass"},
 		sidelen = 16,
 		noise_params = {
-			offset = 0.04,
-			scale = 0.02,
+			offset = 0.036,
+			scale = 0.022,
 			spread = {x = 250, y = 250, z = 250},
 			seed = 2,
 			octaves = 3,
@@ -1104,7 +1104,14 @@ function default.register_decorations()
 		deco_type = "schematic",
 		place_on = {"default:dirt_with_snow", "default:dirt_with_grass"},
 		sidelen = 80,
-		fill_ratio = 0.003,
+		noise_params = {
+			offset = 0.0018,
+			scale = 0.0011,
+			spread = {x = 250, y = 250, z = 250},
+			seed = 2,
+			octaves = 3,
+			persist = 0.66
+		},
 		biomes = {"taiga", "coniferous_forest"},
 		y_min = 1,
 		y_max = 31000,
@@ -1186,7 +1193,7 @@ function default.register_decorations()
 		sidelen = 16,
 		noise_params = {
 			offset = 0.0,
-			scale = -0.03,
+			scale = -0.015,
 			spread = {x = 250, y = 250, z = 250},
 			seed = 2,
 			octaves = 3,
@@ -1206,7 +1213,7 @@ function default.register_decorations()
 		sidelen = 16,
 		noise_params = {
 			offset = 0.0,
-			scale = -0.0015,
+			scale = -0.0008,
 			spread = {x = 250, y = 250, z = 250},
 			seed = 2,
 			octaves = 3,


### PR DESCRIPTION
In mgv5/v7/flat/fractal/valleys
Add missing noise parameters to pine logs for
density to vary in relation to pine tree density
////////////////////////////////

![screenshot_20160222_205236](https://cloud.githubusercontent.com/assets/3686677/13232270/5f9d871e-d9a6-11e5-9e2c-161f0d548f4d.png)

^ A large clearing in coniferous forest

![screenshot_20160222_213529](https://cloud.githubusercontent.com/assets/3686677/13233598/464e1462-d9ac-11e5-9988-1126b2cf70a0.png)

^ Deciduous forest, a low density aspen area

I find the forest biomes just a little too solid, lacking a variety of densities. This PR keeps the same maximum density but makes clearings (minimum density) larger and more common.
This is also in response to comments that the forests are too dense. The average density is lower.
This PR affects deciduous forest, coniferous forest and taiga.
Rainforest and savanna are unchanged.