### PR TITLE
Control leaf decay with sneak.

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -257,9 +257,11 @@ minetest.register_globalstep(function(dtime)
 end)
 
 default.after_place_leaves = function(pos, placer, itemstack, pointed_thing)
-	local node = minetest.get_node(pos)
-	node.param2 = 1
-	minetest.set_node(pos, node)
+	if placer and not placer:get_player_control().sneak then
+		local node = minetest.get_node(pos)
+		node.param2 = 1
+		minetest.set_node(pos, node)
+	end
 end
 
 minetest.register_abm({


### PR DESCRIPTION
As requested by @paramat.
Leaves are preserved by default and only decay when using place + sneak.