### PR TITLE
Change written book formspec to word-wrap

### DIFF
--- a/mods/default/craftitems.lua
+++ b/mods/default/craftitems.lua
@@ -30,10 +30,10 @@ local function book_on_use(itemstack, user, pointed_thing)
 	else
 		formspec = "size[8,8]"..default.gui_bg..
 			default.gui_bg_img..
-			"label[0.5,0.5;by "..owner.."]"..
+			"label[0.5,0.7;by "..owner.."]"..
 			"label[0.5,0;"..minetest.formspec_escape(title).."]"..
-			"tableoptions[background=#00000000;highlight=#00000000;border=false]"..
-			"table[0.5,1.5;7.5,7;;"..minetest.formspec_escape(text):gsub("\n", ",")..";1]"
+			"textarea[0.5,1.5;7.5,7;text;;"..
+				minetest.formspec_escape(text).."]"
 	end
 	minetest.show_formspec(user:get_player_name(), "default:book", formspec)
 end
@@ -94,6 +94,13 @@ minetest.register_craft({
 	type = "shapeless",
 	output = "default:book_written",
 	recipe = { "default:book", "default:book_written" }
+})
+
+-- clear book recipe
+minetest.register_craft({
+	type = "shapeless",
+	output = "default:book",
+	recipe = {"default:book_written", "dye:white"},
 })
 
 minetest.register_on_craft(function(itemstack, player, old_craft_grid, craft_inv)


### PR DESCRIPTION
Books still don't wrap long lines of text properly so until this has been sorted out I suggest reverting back to a previous working formspec which lets players read books properly until a fix is found (and maybe scrollbars added to texarea's).  Also adding a recipe to blank written books.