### PR TITLE
Add access privilege that allows players to bypass protection.

### DIFF
--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -5,7 +5,7 @@ bones = {}
 
 local function is_owner(pos, name)
 	local owner = minetest.get_meta(pos):get_string("owner")
-	if owner == "" or owner == name then
+	if owner == "" or owner == name or minetest.check_player_privs(placer, "protection_bypass") then
 		return true
 	end
 	return false

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1412,6 +1412,9 @@ end
 local function has_locked_chest_privilege(meta, player)
 	local name = ""
 	if player then
+		if minetest.check_player_privs(player, "protection_bypass") then
+			return true
+		end
 		name = player:get_player_name()
 	end
 	if name ~= meta:get_string("owner") then

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -121,7 +121,7 @@ function _doors.door_toggle(pos, clicker)
 	local def = minetest.registered_nodes[minetest.get_node(pos).name]
 	local name = def.door.name
 
-	if clicker then
+	if clicker and not minetest.check_player_privs(clicker, "protection_bypass") then
 		local owner = meta:get_string("doors_owner")
 		if owner ~= "" then
 			if clicker:get_player_name() ~= owner then
@@ -492,7 +492,7 @@ end
 ----trapdoor----
 
 function _doors.trapdoor_toggle(pos, clicker)
-	if clicker then
+	if clicker and not minetest.check_player_privs(clicker, "protection_bypass") then
 		local meta = minetest.get_meta(pos)
 		local owner = meta:get_string("doors_owner")
 		if owner ~= "" then
@@ -519,7 +519,7 @@ function doors.register_trapdoor(name, def)
 	local name_opened = name.."_open"
 
 	local function check_player_priv(pos, player)
-		if not def.protected then
+		if not def.protected or minetest.check_player_privs(player, "protection_bypass") then
 			return true
 		end
 		local meta = minetest.get_meta(pos)


### PR DESCRIPTION
The access privilege allows players that have it to bypass protection
on locked doors/trapdoors, chests and bones.

The priv also allows bypassing any minetest.is_protected() check,
including digging nodes and placing them. It is meant for world
moderators to clean up and fix map issues.

Original patch by red-001. Split up and rebased/rewritten by sofar.

This patch requires https://github.com/minetest/minetest/pull/3800