### PR TITLE
Doors: Prevent placement in protected areas.

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -235,6 +235,11 @@ function doors.register(name, def)
 				return itemstack
 			end
 
+			local pn = placer:get_player_name()
+			if minetest.is_protected(pos, pn) or minetest.is_protected(above, pn) then
+				return itemstack
+			end
+
 			local dir = minetest.dir_to_facedir(placer:get_look_dir())
 
 			local ref = {


### PR DESCRIPTION
https://forum.minetest.net/viewtopic.php?f=42&t=1523&start=500#p208773

Currently, doors can be placed inside others' protected areas. We
need to check protection for both bottom and top halves.