### PR TITLE
Dye: Make pink dye mixable

### DIFF
--- a/mods/dye/init.lua
+++ b/mods/dye/init.lua
@@ -2,7 +2,28 @@
 
 dye = {}
 dye.basecolors = {"white", "grey", "black", "red", "yellow", "green", "cyan", "blue", "magenta"}
-dye.excolors = {"white", "lightgrey", "grey", "darkgrey", "black", "red", "orange", "yellow", "lime", "green", "aqua", "cyan", "sky_blue", "blue", "violet", "magenta", "red_violet"}
+dye.excolors = {"white", "lightgrey", "grey", "darkgrey", "black", "red", "orange", "yellow",
+	"lime", "green", "aqua", "cyan", "sky_blue", "blue", "violet", "magenta", "red_violet"}
+
+-- Make dye names and descriptions available globally
+
+dye.dyes = {
+	{"white",      "White"},
+	{"grey",       "Grey"},
+	{"dark_grey",  "Dark grey"},
+	{"black",      "Black"},
+	{"violet",     "Violet"},
+	{"blue",       "Blue"},
+	{"cyan",       "Cyan"},
+	{"dark_green", "Dark green"},
+	{"green",      "Green"},
+	{"yellow",     "Yellow"},
+	{"brown",      "Brown"},
+	{"orange",     "Orange"},
+	{"red",        "Red"},
+	{"magenta",    "Magenta"},
+	{"pink",       "Pink"},
+}
 
 -- This collection of colors is partly a historic thing, partly something else
 

--- a/mods/dye/init.lua
+++ b/mods/dye/init.lua
@@ -1,39 +1,37 @@
--- minetest/dye/init.lua
-
 -- Other mods can use these for looping through available colors
+
 dye = {}
 dye.basecolors = {"white", "grey", "black", "red", "yellow", "green", "cyan", "blue", "magenta"}
 dye.excolors = {"white", "lightgrey", "grey", "darkgrey", "black", "red", "orange", "yellow", "lime", "green", "aqua", "cyan", "sky_blue", "blue", "violet", "magenta", "red_violet"}
 
--- Local stuff
-local dyelocal = {}
+-- This collection of colors is partly a historic thing, partly something else
 
--- This collection of colors is partly a historic thing, partly something else.
-dyelocal.dyes = {
-	{"white",      "White dye",     {dye=1, basecolor_white=1,   excolor_white=1,     unicolor_white=1}},
-	{"grey",       "Grey dye",      {dye=1, basecolor_grey=1,    excolor_grey=1,      unicolor_grey=1}},
-	{"dark_grey",  "Dark grey dye", {dye=1, basecolor_grey=1,    excolor_darkgrey=1,  unicolor_darkgrey=1}},
-	{"black",      "Black dye",     {dye=1, basecolor_black=1,   excolor_black=1,     unicolor_black=1}},
-	{"violet",     "Violet dye",    {dye=1, basecolor_magenta=1, excolor_violet=1,    unicolor_violet=1}},
-	{"blue",       "Blue dye",      {dye=1, basecolor_blue=1,    excolor_blue=1,      unicolor_blue=1}},
-	{"cyan",       "Cyan dye",      {dye=1, basecolor_cyan=1,    excolor_cyan=1,      unicolor_cyan=1}},
-	{"dark_green", "Dark green dye",{dye=1, basecolor_green=1,   excolor_green=1,     unicolor_dark_green=1}},
-	{"green",      "Green dye",     {dye=1, basecolor_green=1,   excolor_green=1,     unicolor_green=1}},
-	{"yellow",     "Yellow dye",    {dye=1, basecolor_yellow=1,  excolor_yellow=1,    unicolor_yellow=1}},
-	{"brown",      "Brown dye",     {dye=1, basecolor_brown=1,   excolor_orange=1,    unicolor_dark_orange=1}},
-	{"orange",     "Orange dye",    {dye=1, basecolor_orange=1,  excolor_orange=1,    unicolor_orange=1}},
-	{"red",        "Red dye",       {dye=1, basecolor_red=1,     excolor_red=1,       unicolor_red=1}},
-	{"magenta",    "Magenta dye",   {dye=1, basecolor_magenta=1, excolor_red_violet=1,unicolor_red_violet=1}},
-	{"pink",       "Pink dye",      {dye=1, basecolor_red=1,     excolor_red=1,       unicolor_light_red=1}},
+local dyes = {
+	{"white",      "White dye",      {dye=1, basecolor_white=1,   excolor_white=1,      unicolor_white=1}},
+	{"grey",       "Grey dye",       {dye=1, basecolor_grey=1,    excolor_grey=1,       unicolor_grey=1}},
+	{"dark_grey",  "Dark grey dye",  {dye=1, basecolor_grey=1,    excolor_darkgrey=1,   unicolor_darkgrey=1}},
+	{"black",      "Black dye",      {dye=1, basecolor_black=1,   excolor_black=1,      unicolor_black=1}},
+	{"violet",     "Violet dye",     {dye=1, basecolor_magenta=1, excolor_violet=1,     unicolor_violet=1}},
+	{"blue",       "Blue dye",       {dye=1, basecolor_blue=1,    excolor_blue=1,       unicolor_blue=1}},
+	{"cyan",       "Cyan dye",       {dye=1, basecolor_cyan=1,    excolor_cyan=1,       unicolor_cyan=1}},
+	{"dark_green", "Dark green dye", {dye=1, basecolor_green=1,   excolor_green=1,      unicolor_dark_green=1}},
+	{"green",      "Green dye",      {dye=1, basecolor_green=1,   excolor_green=1,      unicolor_green=1}},
+	{"yellow",     "Yellow dye",     {dye=1, basecolor_yellow=1,  excolor_yellow=1,     unicolor_yellow=1}},
+	{"brown",      "Brown dye",      {dye=1, basecolor_brown=1,   excolor_orange=1,     unicolor_dark_orange=1}},
+	{"orange",     "Orange dye",     {dye=1, basecolor_orange=1,  excolor_orange=1,     unicolor_orange=1}},
+	{"red",        "Red dye",        {dye=1, basecolor_red=1,     excolor_red=1,        unicolor_red=1}},
+	{"magenta",    "Magenta dye",    {dye=1, basecolor_magenta=1, excolor_red_violet=1, unicolor_red_violet=1}},
+	{"pink",       "Pink dye",       {dye=1, basecolor_red=1,     excolor_red=1,        unicolor_light_red=1}},
 }
 
 -- Define items
-for _, row in ipairs(dyelocal.dyes) do
+
+for _, row in ipairs(dyes) do
 	local name = row[1]
 	local description = row[2]
 	local groups = row[3]
-	local item_name = "dye:"..name
-	local item_image = "dye_"..name..".png"
+	local item_name = "dye:" .. name
+	local item_image = "dye_" .. name .. ".png"
 	minetest.register_craftitem(item_name, {
 		inventory_image = item_image,
 		description = description,
@@ -41,11 +39,13 @@ for _, row in ipairs(dyelocal.dyes) do
 	})
 	minetest.register_craft({
 		type = "shapeless",
-		output = item_name.." 4",
-		recipe = {"group:flower,color_"..name},
+		output = item_name .. " 4",
+		recipe = {"group:flower,color_" .. name},
 	})
 end
--- manually add coal->black dye
+
+-- Manually add coal->black dye
+
 minetest.register_craft({
 	type = "shapeless",
 	output = "dye:black 4",
@@ -55,33 +55,34 @@ minetest.register_craft({
 -- Mix recipes
 -- Just mix everything to everything somehow sanely
 
-dyelocal.mixbases = {"magenta", "red", "orange", "brown", "yellow", "green", "dark_green", "cyan", "blue", "violet", "black", "dark_grey", "grey", "white"}
+local mixbases = {"pink", "magenta", "red", "orange", "brown", "yellow", "green", "dark_green", "cyan", "blue", "violet", "black", "dark_grey", "grey", "white"}
 
-dyelocal.mixes = {
-	--       magenta,  red,    orange,   brown,    yellow,  green,  dark_green, cyan,    blue,   violet,   black,  dark_grey,  grey,   white
-	white = {"pink",  "pink", "orange", "orange", "yellow", "green", "green",  "grey",  "cyan", "violet",  "grey",  "grey",   "white", "white"},
-	grey  = {"pink",  "pink", "orange", "orange", "yellow", "green", "green",  "grey",  "cyan",  "pink",  "dark_grey","grey", "grey"},
-	dark_grey={"brown","brown", "brown", "brown", "brown","dark_green","dark_green","blue","blue","violet","black", "black"},
-	black = {"black", "black", "black",  "black", "black",  "black", "black",  "black", "black", "black",  "black"},
-	violet= {"magenta","magenta","red",  "brown", "red",    "cyan",  "brown",  "blue",  "violet","violet"},
-	blue  = {"violet", "magenta","brown","brown","dark_green","cyan","cyan",   "cyan",  "blue"},
-	cyan  = {"blue","brown","dark_green","dark_grey","green","cyan","dark_green","cyan"},
-	dark_green={"brown","brown","brown", "brown", "green",  "green", "dark_green"},
-	green = {"brown", "yellow","yellow","dark_green","green","green"},
-	yellow= {"red",  "orange", "yellow","orange", "yellow"},
-	brown = {"brown", "brown","orange", "brown"},
-	orange= {"red",  "orange","orange"},
-	red   = {"magenta","red"},
-	magenta={"magenta"},
+local mixes = {
+	--             pink,     magenta,  red,      orange,      brown,       yellow,      green,       dark_green,  cyan,   blue,    violet,  black,      dark_grey,  grey,  white
+	white      = {"pink",   "pink",   "pink",   "orange",    "orange",    "yellow",    "green",     "green",     "grey", "cyan",  "violet","grey",     "grey",     "grey","white"},
+	grey       = {"pink",   "pink",   "pink",   "orange",    "orange",    "yellow",    "green",     "green",     "grey", "cyan",  "violet","dark_grey","grey",     "grey"},
+	dark_grey  = {"brown",  "brown",  "brown",  "brown",     "brown",     "brown",     "dark_green","dark_green","blue", "blue",  "violet","black",    "dark_grey"},
+	black      = {"black",  "black",  "black",  "black",     "black",     "black",     "black",     "black",     "black","black", "black", "black"},
+	violet     = {"magenta","magenta","magenta","red",       "brown",     "red",       "cyan",      "brown",     "blue", "violet","violet"},
+	blue       = {"violet", "violet", "magenta","brown",     "brown",     "dark_green","cyan",      "cyan",      "cyan", "blue"},
+	cyan       = {"brown",  "blue",   "brown",  "dark_green","dark_grey", "green",     "cyan",      "dark_green","cyan"},
+	dark_green = {"brown",  "brown",  "brown",  "brown",     "brown",     "green",     "green",     "dark_green"},
+	green      = {"yellow", "brown",  "yellow", "yellow",    "dark_green","green",     "green"},
+	yellow     = {"orange", "red",    "orange", "yellow",    "orange",    "yellow"},
+	brown      = {"brown",  "brown",  "brown",  "orange",    "brown"},
+	orange     = {"orange", "red",    "orange", "orange"},
+	red        = {"pink",   "magenta","red"},
+	magenta    = {"magenta","magenta"},
+	pink       = {"pink"},
 }
 
-for one,results in pairs(dyelocal.mixes) do
-	for i,result in ipairs(results) do
-		local another = dyelocal.mixbases[i]
+for one, results in pairs(mixes) do
+	for i, result in ipairs(results) do
+		local another = mixbases[i]
 		minetest.register_craft({
 			type = "shapeless",
-			output = 'dye:'..result..' 2',
-			recipe = {'dye:'..one, 'dye:'..another},
+			output = 'dye:' .. result .. ' 2',
+			recipe = {'dye:' .. one, 'dye:' .. another},
 		})
 	end
 end


### PR DESCRIPTION
Commit 1:
Correct a few inconsistent mixes
Clean up code style and vertically align mix table
Commit 2:
Dye: Add global table of dye names and descriptions
//////////////////////////////////

Still need to test.

Fixes issue #781 and replaces PR #689 
Pink dye mixes are very similar to red dye mixes but with a few differences.
The inconsistent mixes were:
1) Every dye mixed with itself resulted in itself (obviously), except dark grey. Now fixed.
2) All colours gave the same result when mixed with either white or light grey, except violet.
Now violet acts in the same way.

Does the global table need more information?