### PR TITLE
Fix bug rotating unknown node

### DIFF
--- a/mods/screwdriver/init.lua
+++ b/mods/screwdriver/init.lua
@@ -36,7 +36,7 @@ local function screwdriver_handler(itemstack, user, pointed_thing, mode)
 	local node = minetest.get_node(pos)
 	local ndef = minetest.registered_nodes[node.name]
 	-- verify node is facedir (expected to be rotatable)
-	if ndef.paramtype2 ~= "facedir" then
+	if not ndef or ndef.paramtype2 ~= "facedir" then
 		return
 	end
 	-- Compute param2


### PR DESCRIPTION
This fixes a bug that crashes the game when rotating an unknown node.