### PR TITLE
Option to disable bone drops

### DIFF
--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -1,28 +1,29 @@
 -- Minetest 0.4 mod: bones
--- See README.txt for licensing and other information. 
+-- See README.txt for licensing and other information.
 
 bones = {}
+bones.enable = true -- enabled by default, can be changed by mods
 
 local function is_owner(pos, name)
 	local owner = minetest.get_meta(pos):get_string("owner")
-	if owner == "" or owner == name or minetest.check_player_privs(placer, "protection_bypass") then
+	if owner == "" or owner == name then
 		return true
 	end
 	return false
 end
 
 bones.bones_formspec =
-	"size[8,9]"..
-	default.gui_bg..
-	default.gui_bg_img..
-	default.gui_slots..
-	"list[current_name;main;0,0.3;8,4;]"..
-	"list[current_player;main;0,4.85;8,1;]"..
-	"list[current_player;main;0,6.08;8,3;8]"..
+	"size[8,9]" ..
+	default.gui_bg ..
+	default.gui_bg_img ..
+	default.gui_slots ..
+	"list[current_name;main;0,0.3;8,4;]" ..
+	"list[current_player;main;0,4.85;8,1;]" ..
+	"list[current_player;main;0,6.08;8,3;8]" ..
 	default.get_hotbar_bg(0,4.85)
 
 local share_bones_time = tonumber(minetest.setting_get("share_bones_time") or 1200)
-local share_bones_time_early = tonumber(minetest.setting_get("share_bones_time_early") or (share_bones_time/4))
+local share_bones_time_early = tonumber(minetest.setting_get("share_bones_time_early") or (share_bones_time / 4))
 
 minetest.register_node("bones:bones", {
 	description = "Bones",
@@ -35,60 +36,56 @@ minetest.register_node("bones:bones", {
 		"bones_front.png"
 	},
 	paramtype2 = "facedir",
-	groups = {dig_immediate=2},
+	groups = {dig_immediate = 2},
 	sounds = default.node_sound_dirt_defaults({
-		footstep = {name="default_gravel_footstep", gain=0.5},
-		dug = {name="default_gravel_footstep", gain=1.0},
+		footstep = {name="default_gravel_footstep", gain = 0.5},
+		dug = {name="default_gravel_footstep", gain = 1.0},
 	}),
-	
+
 	can_dig = function(pos, player)
 		local inv = minetest.get_meta(pos):get_inventory()
-		local name = ""
-		if player then
-			name = player:get_player_name()
-		end
-		return is_owner(pos, name) and inv:is_empty("main")
+		return is_owner(pos, player:get_player_name()) and inv:is_empty("main")
 	end,
-	
+
 	allow_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)
 		if is_owner(pos, player:get_player_name()) then
 			return count
 		end
 		return 0
 	end,
-	
+
 	allow_metadata_inventory_put = function(pos, listname, index, stack, player)
 		return 0
 	end,
-	
+
 	allow_metadata_inventory_take = function(pos, listname, index, stack, player)
 		if is_owner(pos, player:get_player_name()) then
 			return stack:get_count()
 		end
 		return 0
 	end,
-	
+
 	on_metadata_inventory_take = function(pos, listname, index, stack, player)
 		local meta = minetest.get_meta(pos)
 		if meta:get_inventory():is_empty("main") then
 			minetest.remove_node(pos)
 		end
 	end,
-	
+
 	on_punch = function(pos, node, player)
-		if(not is_owner(pos, player:get_player_name())) then
+		if not is_owner(pos, player:get_player_name()) then
 			return
 		end
-		
-		if(minetest.get_meta(pos):get_string("infotext") == "") then
+
+		if minetest.get_meta(pos):get_string("infotext") == "" then
 			return
 		end
-		
+
 		local inv = minetest.get_meta(pos):get_inventory()
 		local player_inv = player:get_inventory()
 		local has_space = true
-		
-		for i=1,inv:get_size("main") do
+
+		for i = 1, inv:get_size("main") do
 			local stk = inv:get_stack("main", i)
 			if player_inv:room_for_item("main", stk) then
 				inv:set_stack("main", i, nil)
@@ -98,7 +95,7 @@ minetest.register_node("bones:bones", {
 				break
 			end
 		end
-		
+
 		-- remove bones if player emptied them
 		if has_space then
 			if player_inv:room_for_item("main", {name = "bones:bones"}) then
@@ -109,12 +106,12 @@ minetest.register_node("bones:bones", {
 			minetest.remove_node(pos)
 		end
 	end,
-	
+
 	on_timer = function(pos, elapsed)
 		local meta = minetest.get_meta(pos)
 		local time = meta:get_int("time") + elapsed
 		if time >= share_bones_time then
-			meta:set_string("infotext", meta:get_string("owner").."'s old bones")
+			meta:set_string("infotext", meta:get_string("owner") .. "'s old bones")
 			meta:set_string("owner", "")
 		else
 			meta:set_int("time", time)
@@ -153,11 +150,17 @@ local function may_replace(pos, player)
 	return node_definition.buildable_to and not minetest.is_protected(pos, player:get_player_name())
 end
 
+if minetest.setting_getbool("creative_mode") == true then
+	return
+end
+
 minetest.register_on_dieplayer(function(player)
-	if minetest.setting_getbool("creative_mode") then
+
+	-- are bones enabled?
+	if bones.enable ~= true then
 		return
 	end
-	
+
 	local player_inv = player:get_inventory()
 	if player_inv:is_empty("main") and
 		player_inv:is_empty("craft") then
@@ -165,25 +168,26 @@ minetest.register_on_dieplayer(function(player)
 	end
 
 	local pos = player:getpos()
-	pos.x = math.floor(pos.x+0.5)
-	pos.y = math.floor(pos.y+0.5)
-	pos.z = math.floor(pos.z+0.5)
+	pos.x = math.floor(pos.x + 0.5)
+	pos.y = math.floor(pos.y + 0.5)
+	pos.z = math.floor(pos.z + 0.5)
 	local param2 = minetest.dir_to_facedir(player:get_look_dir())
 	local player_name = player:get_player_name()
 	local player_inv = player:get_inventory()
 
 	if (not may_replace(pos, player)) then
-		if (may_replace({x=pos.x, y=pos.y+1, z=pos.z}, player)) then
+		if (may_replace({x = pos.x, y = pos.y + 1, z = pos.z}, player)) then
 			-- drop one node above if there's space
-			-- this should solve most cases of protection related deaths in which players dig straight down
+			-- this should solve most cases of protection related deaths
+			-- in which players dig straight down
 			-- yet keeps the bones reachable
-			pos.y = pos.y+1
+			pos.y = pos.y + 1
 		else
 			-- drop items instead of delete
-			for i=1,player_inv:get_size("main") do
+			for i = 1, player_inv:get_size("main") do
 				minetest.add_item(pos, player_inv:get_stack("main", i))
 			end
-			for i=1,player_inv:get_size("craft") do
+			for i = 1, player_inv:get_size("craft") do
 				minetest.add_item(pos, player_inv:get_stack("craft", i))
 			end
 			-- empty lists main and craft
@@ -194,12 +198,12 @@ minetest.register_on_dieplayer(function(player)
 	end
 	
 	minetest.set_node(pos, {name="bones:bones", param2=param2})
-	
+
 	local meta = minetest.get_meta(pos)
 	local inv = meta:get_inventory()
-	inv:set_size("main", 8*4)
+	inv:set_size("main", 8 * 4)
 	inv:set_list("main", player_inv:get_list("main"))
-	
+
 	for i=1,player_inv:get_size("craft") do
 		local stack = player_inv:get_stack("craft", i)
 		if inv:room_for_item("main", stack) then
@@ -209,15 +213,15 @@ minetest.register_on_dieplayer(function(player)
 			minetest.add_item(pos, stack)
 		end
 	end
-	
+
 	player_inv:set_list("main", {})
 	player_inv:set_list("craft", {})
-	
+
 	meta:set_string("formspec", bones.bones_formspec)
 	meta:set_string("owner", player_name)
-	
+
 	if share_bones_time ~= 0 then
-		meta:set_string("infotext", player_name.."'s fresh bones")
+		meta:set_string("infotext", player_name .. "'s fresh bones")
 
 		if share_bones_time_early == 0 or not minetest.is_protected(pos, player_name) then
 			meta:set_int("time", 0)


### PR DESCRIPTION
I've added the option to disable bone drops by adding 'bones.enable = true' which can easily be set to false inside other mods like DropOnDie.  Also some code cleanup.