### PR TITLE
Make door top node walkable.

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -77,7 +77,7 @@ minetest.register_node("doors:hidden", {
 	drawtype = "airlike",
 	paramtype = "light",
 	sunlight_propagates = true,
-	walkable = false,
+	walkable = true,
 	pointable = false,
 	diggable = false,
 	buildable_to = false,


### PR DESCRIPTION
Prevents ever-falling sand nodes on top of doors. Fixes #923.