### PR TITLE
Allow digging of protected doors with "protection_bypass"

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -287,6 +287,9 @@ function doors.register(name, def)
 		if not def.protected then
 			return true
 		end
+		if minetest.check_player_privs(digger, "protection_bypass") then
+			return true
+		end
 		local meta = minetest.get_meta(pos)
 		local name = ""
 		if digger then


### PR DESCRIPTION
This was probably lost in either the API rewrite or a merge/rebase.

Fixes #929