### PR TITLE
Walls: Don't connect to group:cracky

### DIFF
--- a/mods/walls/init.lua
+++ b/mods/walls/init.lua
@@ -29,7 +29,7 @@ walls.register = function(wall_name, wall_desc, wall_texture, wall_mat, wall_sou
 			connect_back = {{-3/16, -1/2,  1/4,  3/16, 3/8,  1/2}},
 			connect_right = {{ 1/4, -1/2, -3/16,  1/2, 3/8,  3/16}},
 		},
-		connects_to = { "group:cracky", "group:wall", "group:stone" },
+		connects_to = { "group:wall", "group:stone" },
 		paramtype = "light",
 		is_ground_content = false,
 		tiles = { wall_texture, },


### PR DESCRIPTION
the ```group:cracky``` group contains all sorts of odds and ends
nodes that we shouldn't connect to. There are a few nodes that
walls now no longer connect to, that probably should get
```group:stone``` added, or something similar, though.

Fixes #920 