### PR TITLE
Fire: Speed up fire spread and burn out

### DIFF
--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -231,7 +231,7 @@ else
 		nodenames = {"group:flammable"},
 		neighbors = {"group:igniter"},
 		interval = 7,
-		chance = 16,
+		chance = 12,
 		catch_up = false,
 		action = function(p0, node, _, _)
 			-- If there is water or stuff like that around node, don't ignite
@@ -250,7 +250,7 @@ else
 	minetest.register_abm({
 		nodenames = {"fire:basic_flame"},
 		interval = 5,
-		chance = 16,
+		chance = 6,
 		catch_up = false,
 		action = function(p0, node, _, _)
 			-- If there are no flammable nodes around flame, remove flame


### PR DESCRIPTION
Slightly faster fire spread.
Importantly, much faster removal of unfueled flames and flammable nodes.
So fire tends to spread faster and burns out faster, this helps avoid overly large areas of flame that persist for too long, a current problem.
Tested and tuned using a clump of 20 pines.
Adding own approval.