### PR TITLE
Doors: Allow schematic placement of wooden doors.

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -132,9 +132,18 @@ local transform = {
 
 function _doors.door_toggle(pos, clicker)
 	local meta = minetest.get_meta(pos)
-	local state = meta:get_int("state")
 	local def = minetest.registered_nodes[minetest.get_node(pos).name]
 	local name = def.door.name
+
+	local state = meta:get_string("state")
+	if state == "" then
+		-- fix up lvm-placed right-hinged doors, default closed
+		if minetest.get_node(pos).name:sub(-2) == "_b" then
+			state = 2
+		end
+	else
+		state = tonumber(state)
+	end
 
 	if clicker and not minetest.check_player_privs(clicker, "protection_bypass") then
 		local owner = meta:get_string("doors_owner")


### PR DESCRIPTION
If LVM or some other nonmetadata method is used to place a door,
then metadata is missing that tells us whether the door is left
or right-hinged.

However, we can detect that nodemeta is missing and see if the node
name is _a or _b. In the case of _a, nothing needs to be done and we
can just open the door. In the case of _b we assume the door is right
hinged, and tune the state nodemeta value so that the door opens the
right way. This all of course assumes that the schematic method places
the doors *closed* by default, which is reasonable.