### PR TITLE
Default: Fix rotation errors for mapgen aspen and sapling jungletree

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -1204,7 +1204,6 @@ function default.register_decorations()
 		y_max = 31000,
 		schematic = minetest.get_modpath("default").."/schematics/aspen_tree.mts",
 		flags = "place_center_x, place_center_z",
-		rotation = "random",
 	})
 
 	minetest.register_decoration({

--- a/mods/default/trees.lua
+++ b/mods/default/trees.lua
@@ -403,7 +403,7 @@ function default.grow_new_jungle_tree(pos)
 	local path = minetest.get_modpath("default") ..
 		"/schematics/jungle_tree_from_sapling.mts"
 	minetest.place_schematic({x = pos.x - 2, y = pos.y - 1, z = pos.z - 2},
-		path, "0", nil, false)
+		path, "random", nil, false)
 end
 
 


### PR DESCRIPTION
Trivial fixes for tree rotation errors.