### PR TITLE
Shelves: Fix listring functionality + code cleaning

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1574,43 +1574,16 @@ minetest.register_node("default:bookshelf", {
 		inv:set_size("books", 8 * 2)
 	end,
 	can_dig = function(pos,player)
-		local meta = minetest.get_meta(pos);
-		local inv = meta:get_inventory()
+		local inv = minetest.get_meta(pos):get_inventory()
 		return inv:is_empty("books")
 	end,
-
-	allow_metadata_inventory_put = function(pos, listname, index, stack, player)
-		local meta = minetest.get_meta(pos)
-		local inv = meta:get_inventory()
-		local to_stack = inv:get_stack(listname, index)
-		if listname == "books" then
-			if minetest.get_item_group(stack:get_name(), "book") ~= 0
-					and to_stack:is_empty() then
-				return 1
-			else
-				return 0
-			end
+	allow_metadata_inventory_put = function(pos, listname, index, stack)
+		if minetest.get_item_group(stack:get_name(), "book") ~= 0 then
+			return stack:get_count()
 		end
+		return 0
 	end,
-
-	allow_metadata_inventory_move = function(pos, from_list, from_index,
-			to_list, to_index, count, player)
-		local meta = minetest.get_meta(pos)
-		local inv = meta:get_inventory()
-		local stack = inv:get_stack(from_list, from_index)
-		local to_stack = inv:get_stack(to_list, to_index)
-		if to_list == "books" then
-			if minetest.get_item_group(stack:get_name(), "book") ~= 0
-					and to_stack:is_empty() then
-				return 1
-			else
-				return 0
-			end
-		end
-	end,
-
-	on_metadata_inventory_move = function(pos, from_list, from_index,
-			to_list, to_index, count, player)
+	on_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)
 		minetest.log("action", player:get_player_name() ..
 			" moves stuff in bookshelf at " .. minetest.pos_to_string(pos))
 	end,

--- a/mods/vessels/init.lua
+++ b/mods/vessels/init.lua
@@ -24,54 +24,29 @@ minetest.register_node("vessels:shelf", {
 		local meta = minetest.get_meta(pos)
 		meta:set_string("formspec", vessels_shelf_formspec)
 		local inv = meta:get_inventory()
-		inv:set_size("vessels", 8*2)
+		inv:set_size("vessels", 8 * 2)
 	end,
 	can_dig = function(pos,player)
-		local meta = minetest.get_meta(pos);
-		local inv = meta:get_inventory()
+		local inv = minetest.get_meta(pos):get_inventory()
 		return inv:is_empty("vessels")
 	end,
-
 	allow_metadata_inventory_put = function(pos, listname, index, stack, player)
-		local meta = minetest.get_meta(pos)
-		local inv = meta:get_inventory()
-		local to_stack = inv:get_stack(listname, index)
-		if listname == "vessels" then
-			if minetest.get_item_group(stack:get_name(), "vessel") ~= 0
-					and to_stack:is_empty() then
-				return 1
-			else
-				return 0
-			end
+		if minetest.get_item_group(stack:get_name(), "vessel") ~= 0 then
+			return stack:get_count()
 		end
+		return 0
 	end,
-
-	allow_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)
-		local meta = minetest.get_meta(pos)
-		local inv = meta:get_inventory()
-		local stack = inv:get_stack(from_list, from_index)
-		local to_stack = inv:get_stack(to_list, to_index)
-		if to_list == "vessels" then
-			if minetest.get_item_group(stack:get_name(), "vessel") ~= 0 
-					and to_stack:is_empty() then
-				return 1
-			else
-				return 0
-			end
-		end
-	end,
-
 	on_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)
-		minetest.log("action", player:get_player_name()..
-			   " moves stuff in vessels shelf at "..minetest.pos_to_string(pos))
+		minetest.log("action", player:get_player_name() ..
+			   " moves stuff in vessels shelf at ".. minetest.pos_to_string(pos))
 	end,
 	on_metadata_inventory_put = function(pos, listname, index, stack, player)
-		minetest.log("action", player:get_player_name()..
-			   " moves stuff to vessels shelf at "..minetest.pos_to_string(pos))
+		minetest.log("action", player:get_player_name() ..
+			   " moves stuff to vessels shelf at ".. minetest.pos_to_string(pos))
 	end,
 	on_metadata_inventory_take = function(pos, listname, index, stack, player)
-		minetest.log("action", player:get_player_name()..
-			   " takes stuff from vessels shelf at "..minetest.pos_to_string(pos))
+		minetest.log("action", player:get_player_name() ..
+			   " takes stuff from vessels shelf at ".. minetest.pos_to_string(pos))
 	end,
 })
 


### PR DESCRIPTION
The metadata callbacks for the shelves were full of bullshit and broken : 

1. The listring feature (on putting) worked only for the first stack index in the storage list due to checking if the stack of destination is empty. See https://github.com/minetest/minetest_game/issues/972.

2. You couldn't put more than 1 stack per slot (i.e. 1 empty book, not 2) in the shelves and `allow_metadata_inventory_put` checked if you tried to put items in the **only** list of destination where you could put something. Total useless checking.

3.  There was a check inside `allow_metadata_inventory_move` that you moved the right group of items inside the same list. Again, useless callback and checking since that check is already done before inside `allow_metadata_inventory_put`.

Cc: @paramat 