### PR TITLE
Default: Reduce sand footstep and dug sound gains

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -40,9 +40,9 @@ end
 function default.node_sound_sand_defaults(table)
 	table = table or {}
 	table.footstep = table.footstep or
-			{name = "default_sand_footstep", gain = 0.2}
+			{name = "default_sand_footstep", gain = 0.12}
 	table.dug = table.dug or
-			{name = "default_sand_footstep", gain = 0.4}
+			{name = "default_sand_footstep", gain = 0.24}
 	table.place = table.place or
 			{name = "default_place_node", gain = 1.0}
 	default.node_sound_defaults(table)


### PR DESCRIPTION
Much needed reduction of sand footstep and dug sound gains.
Balanced to be quiet and similar to grass footstep.
Adding own approval.