### PR TITLE
Bed respawn coords saves with tidy output

### DIFF
--- a/mods/beds/spawns.lua
+++ b/mods/beds/spawns.lua
@@ -41,10 +41,12 @@ function beds.save_spawns()
 	if not beds.spawn then
 		return
 	end
+	local data = {}
 	local output = io.open(org_file, "w")
-	for i, v in pairs(beds.spawn) do
-		output:write(v.x .. " " .. v.y .. " " .. v.z .. " " .. i .. "\n")
+	for k, v in pairs(beds.spawn) do
+		table.insert(data, string.format("%.1f %.1f %.1f %s\n", v.x, v.y, v.z, k))
 	end
+	output:write(table.concat(data))
 	io.close(output)
 end
 


### PR DESCRIPTION
Tweaked the beds.save_spawns() function to compile list then output to file with shortened coords containing 1 decimal place.