### PR TITLE
Seeds: use leaf sounds by default.

### DIFF
--- a/mods/farming/api.lua
+++ b/mods/farming/api.lua
@@ -220,9 +220,12 @@ farming.register_plant = function(name, def)
 			fixed = {-0.5, -0.5, -0.5, 0.5, -5/16, 0.5},
 		},
 		fertility = def.fertility,
+		sounds = default.node_sound_leaves_defaults({
+			place = {name = "default_place_node", gain = 0.25}
+		}),
 		on_place = function(itemstack, placer, pointed_thing)
 			return farming.place_seed(itemstack, placer, pointed_thing, mname .. ":seed_" .. pname)
-		end
+		end,
 	})
 
 	-- Register harvest


### PR DESCRIPTION
There were no sounds attached to farming's seeds, causing placement
and digging/walking on them to be silent.