### PR TITLE
Fire: Higher chance of removing flammable nodes 

### DIFF
--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -263,7 +263,7 @@ else
 				minetest.remove_node(p0)
 				return
 			end
-			if math.random(1, 4) == 1 then
+			if math.random(1, 3) == 1 then
 				-- remove flammable nodes around flame
 				local node = minetest.get_node(p)
 				local def = minetest.registered_nodes[node.name]


### PR DESCRIPTION
Flammable nodes burn away quicker
/////////////////////////////

Increased chance of flammable node removal, helping to avoid huge areas being on fire for long periods of time, fire 'travels' more instead of ever-expanding.

Note that due to faster flammable node removal it is more likely that a fire started at the base of a tree will burn out before it can climb to the leaves, this is realistic, try setting fire to the leaves instead, this causes a fast spread as you would expect from leaves and thinner branches.
So don't complain if your fire goes out at the base of a tree, this is a result of the improved behaviour.

Requested in #1015
Adding own approval.
Related #1001