### PR TITLE
Farming: Override dirt_with_dry_grass to enable cultivation

### DIFF
--- a/mods/farming/nodes.lua
+++ b/mods/farming/nodes.lua
@@ -1,5 +1,5 @@
 minetest.override_item("default:dirt", {
-	groups = {crumbly=3,soil=1},
+	groups = {crumbly=3, soil=1},
 	soil = {
 		base = "default:dirt",
 		dry = "farming:soil",
@@ -8,9 +8,18 @@ minetest.override_item("default:dirt", {
 })
 
 minetest.override_item("default:dirt_with_grass", {
-	groups = {crumbly=3,soil=1},
+	groups = {crumbly=3, soil=1},
 	soil = {
 		base = "default:dirt_with_grass",
+		dry = "farming:soil",
+		wet = "farming:soil_wet"
+	}
+})
+
+minetest.override_item("default:dirt_with_dry_grass", {
+	groups = {crumbly=3, soil=1},
+	soil = {
+		base = "default:dirt_with_dry_grass",
 		dry = "farming:soil",
 		wet = "farming:soil_wet"
 	}


### PR DESCRIPTION
![screenshot_20160406_230535](https://cloud.githubusercontent.com/assets/3686677/14334399/1da4211a-fc4c-11e5-8172-8c150da9bf2c.png)

Addresses #1018 
When i added dirt with dry grass i didn't edit farming to enable cultivation.
(I considered making dirt with snow cultivable too but these nodes occur in freezing biomes like tundra).
Tested, adding own approval.