### PR TITLE
Remove composed shelf side.

### DIFF
--- a/mods/vessels/init.lua
+++ b/mods/vessels/init.lua
@@ -15,7 +15,7 @@ local vessels_shelf_formspec =
 
 minetest.register_node("vessels:shelf", {
 	description = "Vessels shelf",
-	tiles = {"default_wood.png", "default_wood.png", "default_wood.png^vessels_shelf.png"},
+	tiles = {"default_wood.png", "default_wood.png", "vessels_shelf.png"},
 	is_ground_content = false,
 	groups = {choppy=3,oddly_breakable_by_hand=2,flammable=3},
 	sounds = default.node_sound_wood_defaults(),


### PR DESCRIPTION
Don't compose the shelf side texture. The texture isn't transparent,
and unlikely to be in any case.