### PR TITLE
Allow buckets to run a non-liquid node's on_punch

### DIFF
--- a/mods/bucket/init.lua
+++ b/mods/bucket/init.lua
@@ -119,7 +119,6 @@ minetest.register_craftitem("bucket:bucket_empty", {
 		local node = minetest.get_node(pointed_thing.under)
 		local liquiddef = bucket.liquids[node.name]
 		local item_count = user:get_wielded_item():get_count()
-		local node_def = minetest.registered_nodes[node.name]
 
 		if liquiddef ~= nil
 		and liquiddef.itemname ~= nil
@@ -154,14 +153,17 @@ minetest.register_craftitem("bucket:bucket_empty", {
 			minetest.add_node(pointed_thing.under, {name="air"})
 
 			return ItemStack(giving_back)
-		elseif node_def then
-			-- Buckets will run a node's on_punch function if it is not liquid.
-			if node_def.on_punch then
-				node_def.on_punch(
-						pointed_thing.under,
-						minetest.get_node(pointed_thing.under),
-						user,
-						pointed_thing)
+		else
+			local node_def = minetest.registered_nodes[node.name]
+			if node_def then
+				-- Buckets will run a node's on_punch function if it is not liquid.
+				if node_def.on_punch then
+					node_def.on_punch(
+							pointed_thing.under,
+							minetest.get_node(pointed_thing.under),
+							user,
+							pointed_thing)
+				end
 			end
 		end
 	end,

--- a/mods/bucket/init.lua
+++ b/mods/bucket/init.lua
@@ -162,7 +162,7 @@ minetest.register_craftitem("bucket:bucket_empty", {
 						user,
 						pointed_thing)
 			end
-		end,
+		end
 	end,
 })
 

--- a/mods/bucket/init.lua
+++ b/mods/bucket/init.lua
@@ -153,7 +153,16 @@ minetest.register_craftitem("bucket:bucket_empty", {
 			minetest.add_node(pointed_thing.under, {name="air"})
 
 			return ItemStack(giving_back)
-		end
+		elseif minetest.registered_nodes[node.name] then
+			-- Buckets will run a node's on_punch function if it is not liquid.
+			if minetest.registered_nodes[node.name].on_punch then
+				minetest.registered_nodes[node.name].on_punch(
+						pointed_thing.under,
+						minetest.get_node(pointed_thing.under),
+						user,
+						pointed_thing)
+			end
+		end,
 	end,
 })
 

--- a/mods/bucket/init.lua
+++ b/mods/bucket/init.lua
@@ -119,6 +119,7 @@ minetest.register_craftitem("bucket:bucket_empty", {
 		local node = minetest.get_node(pointed_thing.under)
 		local liquiddef = bucket.liquids[node.name]
 		local item_count = user:get_wielded_item():get_count()
+		local node_def = minetest.registered_nodes[node.name]
 
 		if liquiddef ~= nil
 		and liquiddef.itemname ~= nil
@@ -153,10 +154,10 @@ minetest.register_craftitem("bucket:bucket_empty", {
 			minetest.add_node(pointed_thing.under, {name="air"})
 
 			return ItemStack(giving_back)
-		elseif minetest.registered_nodes[node.name] then
+		elseif node_def then
 			-- Buckets will run a node's on_punch function if it is not liquid.
-			if minetest.registered_nodes[node.name].on_punch then
-				minetest.registered_nodes[node.name].on_punch(
+			if node_def.on_punch then
+				node_def.on_punch(
 						pointed_thing.under,
 						minetest.get_node(pointed_thing.under),
 						user,

--- a/mods/bucket/init.lua
+++ b/mods/bucket/init.lua
@@ -158,11 +158,15 @@ minetest.register_craftitem("bucket:bucket_empty", {
 			if node_def then
 				-- Buckets will run a node's on_punch function if it is not liquid.
 				if node_def.on_punch then
-					node_def.on_punch(
+					giving_back = node_def.on_punch(
 							pointed_thing.under,
 							minetest.get_node(pointed_thing.under),
 							user,
 							pointed_thing)
+					
+					if giving_back ~= nil then
+						return ItemStack(giving_back)
+					end
 				end
 			end
 		end


### PR DESCRIPTION
This is useful for e.g., a tank mod where you punch the tank to add water.

I've tested this in an older copy of minetest_game and it seems to work okay... And there haven't been any changes to the init.lua since then.

I've tried to copy the Lua Code Style guidelines as best as I can. Tell me if I did anything wrong...