### PR TITLE
Boats: Increase maximum velocity to 5n/s

### DIFF
--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -159,8 +159,8 @@ function boat.on_step(self, dtime)
 		self.v = 0
 		return
 	end
-	if math.abs(self.v) > 4.5 then
-		self.v = 4.5 * get_sign(self.v)
+	if math.abs(self.v) > 5 then
+		self.v = 5 * get_sign(self.v)
 	end
 
 	local p = self.object:getpos()
@@ -182,8 +182,8 @@ function boat.on_step(self, dtime)
 		p.y = p.y + 1
 		if is_water(p) then
 			local y = self.object:getvelocity().y
-			if y >= 4.5 then
-				y = 4.5
+			if y >= 5 then
+				y = 5
 			elseif y < 0 then
 				new_acce = {x = 0, y = 20, z = 0}
 			else


### PR DESCRIPTION
Horizontal and vertical maximum velocity is increased from 4.5 to 5n/s.
See issue #1033 
Added to milestone as is simple and useful for the new larger-scale mapgens.
Tested.
Makes a nice vertical rapid transit in water columns.

![screenshot_20160415_110155](https://cloud.githubusercontent.com/assets/3686677/14558346/de911370-02f9-11e6-8540-e836a716ee66.png)