### PR TITLE
Default: Create 'grass', 'dry_grass' groups, use in dirt conversion ABM

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -362,16 +362,8 @@ minetest.register_abm({
 		"default:dirt_with_grass",
 		"default:dirt_with_dry_grass",
 		"default:dirt_with_snow",
-		"default:grass_1",
-		"default:grass_2",
-		"default:grass_3",
-		"default:grass_4",
-		"default:grass_5",
-		"default:dry_grass_1",
-		"default:dry_grass_2",
-		"default:dry_grass_3",
-		"default:dry_grass_4",
-		"default:dry_grass_5",
+		"group:grass",
+		"group:dry_grass",
 		"default:snow",
 	},
 	interval = 6,
@@ -408,9 +400,9 @@ minetest.register_abm({
 		if name == "default:snow" then
 			minetest.set_node(pos, {name = "default:dirt_with_snow"})
 		-- Most likely case first.
-		elseif name:sub(1, 13) == "default:grass" then
+		elseif minetest.get_item_group(name, "grass") ~= 0 then
 			minetest.set_node(pos, {name = "default:dirt_with_grass"})
-		elseif name:sub(1, 17) == "default:dry_grass" then
+		elseif minetest.get_item_group(name, "dry_grass") ~= 0 then
 			minetest.set_node(pos, {name = "default:dirt_with_dry_grass"})
 		end
 	end

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -947,7 +947,7 @@ minetest.register_node("default:junglegrass", {
 	sunlight_propagates = true,
 	walkable = false,
 	buildable_to = true,
-	groups = {snappy = 3, flora = 1, attached_node = 1},
+	groups = {snappy = 3, flora = 1, attached_node = 1, grass = 1},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
 		type = "fixed",
@@ -968,7 +968,7 @@ minetest.register_node("default:grass_1", {
 	sunlight_propagates = true,
 	walkable = false,
 	buildable_to = true,
-	groups = {snappy = 3, flora = 1, attached_node = 1},
+	groups = {snappy = 3, flora = 1, attached_node = 1, grass = 1},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
 		type = "fixed",
@@ -998,7 +998,7 @@ for i = 2, 5 do
 		buildable_to = true,
 		drop = "default:grass_1",
 		groups = {snappy = 3, flora = 1, attached_node = 1,
-			not_in_creative_inventory = 1},
+			not_in_creative_inventory = 1, grass = 1},
 		sounds = default.node_sound_leaves_defaults(),
 		selection_box = {
 			type = "fixed",
@@ -1019,7 +1019,8 @@ minetest.register_node("default:dry_grass_1", {
 	sunlight_propagates = true,
 	walkable = false,
 	buildable_to = true,
-	groups = {snappy = 3, flammable = 3, flora = 1, attached_node = 1},
+	groups = {snappy = 3, flammable = 3, flora = 1,
+		attached_node = 1, dry_grass = 1},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
 		type = "fixed",
@@ -1047,8 +1048,8 @@ for i = 2, 5 do
 		sunlight_propagates = true,
 		walkable = false,
 		buildable_to = true,
-		groups = {snappy = 3, flammable = 3, flora = 1,
-			attached_node = 1, not_in_creative_inventory=1},
+		groups = {snappy = 3, flammable = 3, flora = 1, attached_node = 1,
+			not_in_creative_inventory=1, dry_grass = 1},
 		drop = "default:dry_grass_1",
 		sounds = default.node_sound_leaves_defaults(),
 		selection_box = {


### PR DESCRIPTION
Reduces number of entries in ABM 'neighbors', no need for string search, check group instead.
After discussion we included junglegrass in the grass group, it can then be used to turn dirt into dirt with grass, useful in rainforest.

Need to test.