### PR TITLE
Farming: Add quiet sounds to seeds

### DIFF
--- a/mods/farming/api.lua
+++ b/mods/farming/api.lua
@@ -220,9 +220,14 @@ farming.register_plant = function(name, def)
 			fixed = {-0.5, -0.5, -0.5, 0.5, -5/16, 0.5},
 		},
 		fertility = def.fertility,
+		sounds = default.node_sound_dirt_defaults({
+			dug = {name = "default_grass_footstep", gain = 0.2},
+			place = {name = "default_place_node", gain = 0.25},
+		}),
+
 		on_place = function(itemstack, placer, pointed_thing)
 			return farming.place_seed(itemstack, placer, pointed_thing, mname .. ":seed_" .. pname)
-		end
+		end,
 	})
 
 	-- Register harvest


### PR DESCRIPTION
New version of PR #1000 to fix issue #997 
Not high priority but simple and nice to have in release, so added milestone.
Sounds are defined as 'dirt defaults' to enable a dirt footstep, as seeds can only be placed on farming:soil. 'Dug' and 'place' sounds are as soft as possible while still being noticeable.
Tested.