### PR TITLE
TNT: Fix multiple explosions erasing drops

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -258,6 +258,28 @@ parameter, and drops is not reinitialized so you can call it several
 times in a row to add more inventory items to it.
 
 
+`on_blast` callbacks:
+
+Both nodedefs and entitydefs can provide an `on_blast()` callback
+
+`nodedef.on_blast(pos, intensity)`
+^ Allow drop and node removal overriding
+* `pos` - node position
+* `intensity` - TNT explosion measure. larger or equal to 1.0
+^ Should return a list of drops (e.g. {"default:stone"})
+^ Should perform node removal itself. If callback exists in the nodedef
+^ then the TNT code will not destroy this node.
+
+`entitydef.on_blast(luaobj, damage)`
+^ Allow TNT effects on entities to be overridden
+* `luaobj` - LuaEntityRef of the entity
+* `damage` - suggested HP damage value
+^ Should return a list of (bool do_damage, bool do_knockback, table drops)
+* `do_damage` - if true then TNT mod wil damage the entity
+* `do_knockback` - if true then TNT mod will knock the entity away
+* `drops` - a list of drops, e.g. {"wool:red"}
+
+
 Screwdriver API
 ---------------
 

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -160,10 +160,12 @@ local function entity_physics(pos, radius)
 			local obj_vel = obj:getvelocity()
 			obj:setvelocity(calc_velocity(pos, obj_pos,
 					obj_vel, radius * 10))
-			obj:punch(obj, 1.0, {
-				full_punch_interval = 1.0,
-				damage_groups = {fleshy = damage},
-			}, nil)
+			if not obj:get_armor_groups().immortal then
+				obj:punch(obj, 1.0, {
+					full_punch_interval = 1.0,
+					damage_groups = {fleshy = damage},
+				}, nil)
+			end
 		end
 	end
 end


### PR DESCRIPTION
Any second explosion near a first TNT explosion will punch all
entities found nearby, including item drops. This causes the
item pickup code to think the item was picked up, but by
a `nil` player, thus removing the item.

We query for the immortal entity group, and if the item is in
the immortal group, do not punch the item.