### PR TITLE
Fix bug in dropped item counting

### DIFF
--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -51,7 +51,7 @@ local function eject_drops(drops, pos, radius)
 		local count = item:get_count()
 		while count > 0 do
 			local take = math.max(1,math.min(radius * radius,
-					item:get_count(),
+					count,
 					item:get_stack_max()))
 			rand_pos(pos, drop_pos, radius)
 			local dropitem = ItemStack(item)


### PR DESCRIPTION
Found a bug while experimenting with the new TNT (btw, I love the new TNT).  It's possible for more items to be dropped than were destroyed by the blast. 100% reproducible. Build 10 blocks of mese and destroy them all with a single TNT; 2 stacks of 9 mese each will be dropped. This is a simple fix.