### PR TITLE
Add placer's player name to tnt node metadata

### DIFF
--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -266,8 +266,8 @@ function tnt.burn(pos, nodename)
 	elseif def.on_ignite then
 		def.on_ignite(pos)
 	elseif minetest.get_item_group(name, "tnt") > 0 then
-		minetest.sound_play("tnt_ignite", {pos = pos})
 		minetest.swap_node(pos, {name = name .. "_burning"})
+		minetest.sound_play("tnt_ignite", {pos = pos})
 		minetest.get_node_timer(pos):start(1)
 	end
 end
@@ -376,7 +376,7 @@ local function tnt_explode(pos, radius, ignore_protection, ignore_on_blast, owne
 	end
 
 	minetest.log("action", "TNT owned by " .. owner .. " detonated at " ..
-		minetest.pos_to_string(pos) .. " radius " .. radius)
+		minetest.pos_to_string(pos) .. " with radius " .. radius)
 
 	return drops, radius
 end
@@ -592,10 +592,8 @@ function tnt.register_tnt(def)
 			end,
 			on_punch = function(pos, node, puncher)
 				if puncher:get_wielded_item():get_name() == "default:torch" then
-					local meta = minetest.get_meta(pos)
-					local owner = meta:get_string("owner")
-					minetest.set_node(pos, {name = name .. "_burning"})
-					meta:set_string("owner", owner)
+					minetest.swap_node(pos, {name = name .. "_burning"})
+					minetest.registered_nodes[name .. "_burning"].on_construct(pos)
 					minetest.log("action", puncher:get_player_name() ..
 						" ignites " .. node.name .. " at " ..
 						minetest.pos_to_string(pos))
@@ -614,10 +612,12 @@ function tnt.register_tnt(def)
 				}
 			},
 			on_burn = function(pos)
-				minetest.set_node(pos, {name = name .. "_burning"})
+				minetest.swap_node(pos, {name = name .. "_burning"})
+				minetest.registered_nodes[name .. "_burning"].on_construct(pos)
 			end,
 			on_ignite = function(pos, igniter)
-				minetest.set_node(pos, {name = name .. "_burning"})
+				minetest.swap_node(pos, {name = name .. "_burning"})
+				minetest.registered_nodes[name .. "_burning"].on_construct(pos)
 			end,
 		})
 	end

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -86,8 +86,8 @@ end
 local basic_flame_on_construct -- cached value
 local function destroy(drops, npos, cid, c_air, c_fire,
 		on_blast_queue, on_construct_queue,
-		ignore_protection, ignore_on_blast)
-	if not ignore_protection and minetest.is_protected(npos, "") then
+		ignore_protection, ignore_on_blast, owner)
+	if not ignore_protection and minetest.is_protected(npos, owner) then
 		return cid
 	end
 
@@ -267,12 +267,12 @@ function tnt.burn(pos, nodename)
 		def.on_ignite(pos)
 	elseif minetest.get_item_group(name, "tnt") > 0 then
 		minetest.sound_play("tnt_ignite", {pos = pos})
-		minetest.set_node(pos, {name = name .. "_burning"})
+		minetest.swap_node(pos, {name = name .. "_burning"})
 		minetest.get_node_timer(pos):start(1)
 	end
 end
 
-local function tnt_explode(pos, radius, ignore_protection, ignore_on_blast)
+local function tnt_explode(pos, radius, ignore_protection, ignore_on_blast, owner)
 	pos = vector.round(pos)
 	-- scan for adjacent TNT nodes first, and enlarge the explosion
 	local vm1 = VoxelManip()
@@ -333,7 +333,7 @@ local function tnt_explode(pos, radius, ignore_protection, ignore_on_blast)
 			if cid ~= c_air then
 				data[vi] = destroy(drops, p, cid, c_air, c_fire,
 					on_blast_queue, on_construct_queue,
-					ignore_protection, ignore_on_blast)
+					ignore_protection, ignore_on_blast, owner)
 			end
 		end
 		vi = vi + 1
@@ -375,14 +375,19 @@ local function tnt_explode(pos, radius, ignore_protection, ignore_on_blast)
 		queued_data.fn(queued_data.pos)
 	end
 
+	minetest.log("action", "TNT owned by " .. owner .. " detonated at " ..
+		minetest.pos_to_string(pos) .. " radius " .. radius)
+
 	return drops, radius
 end
 
 function tnt.boom(pos, def)
+	local meta = minetest.get_meta(pos)
+	local owner = meta:get_string("owner")
 	minetest.sound_play("tnt_explode", {pos = pos, gain = 1.5, max_hear_distance = 2*64})
 	minetest.set_node(pos, {name = "tnt:boom"})
 	local drops, radius = tnt_explode(pos, def.radius, def.ignore_protection,
-			def.ignore_on_blast)
+			def.ignore_on_blast, owner)
 	-- append entity drops
 	local damage_radius = (radius / def.radius) * def.damage_radius
 	entity_physics(pos, damage_radius, drops)
@@ -579,9 +584,18 @@ function tnt.register_tnt(def)
 			is_ground_content = false,
 			groups = {dig_immediate = 2, mesecon = 2, tnt = 1, flammable = 5},
 			sounds = default.node_sound_wood_defaults(),
+			after_place_node = function(pos, placer)
+				if placer:is_player() then
+					local meta = minetest.get_meta(pos)
+					meta:set_string("owner", placer:get_player_name())
+				end
+			end,
 			on_punch = function(pos, node, puncher)
 				if puncher:get_wielded_item():get_name() == "default:torch" then
+					local meta = minetest.get_meta(pos)
+					local owner = meta:get_string("owner")
 					minetest.set_node(pos, {name = name .. "_burning"})
+					meta:set_string("owner", owner)
 					minetest.log("action", puncher:get_player_name() ..
 						" ignites " .. node.name .. " at " ..
 						minetest.pos_to_string(pos))


### PR DESCRIPTION
It is useful for protection mods to know who caused a tnt block
to explode. tnt can be ignited in the following ways:
- punched by player holding torch
- adjacent to:
  - tnt:gunpowder_burning
  - fire:basic_flame,
  - default:lava_source,
  - default:lava_flowing

It can also be caused to explode immediatly by the following:
- blast from another tnt explosion
- turned on by mesecons

For the punching and gunpowder ignition methods, this commit adds
an igniter key to the node's node metadata to track the player's
playername, and passes this name to the minetest protection check.
This node metadata is not available if the tnt node falls before
exploding (bug #4087). Considering each of the other methods: it
is difficult to determine the player responsible for adjacent
fire, or lava; the on_blast callback doesn't provide any information
on the source of a blast; and mesecons could be activated by a
variety of non-player sources; so in those cases, no igniter
information is available or passed on to protection checks.

Thoughts and/or suggestions will be appreciated.
