### PR TITLE
Stairs/default: Make sandstone(brick) groups consistent

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -246,7 +246,7 @@ minetest.register_node("default:desert_stonebrick", {
 minetest.register_node("default:sandstone", {
 	description = "Sandstone",
 	tiles = {"default_sandstone.png"},
-	groups = {crumbly = 2, cracky = 3},
+	groups = {crumbly = 1, cracky = 3},
 	sounds = default.node_sound_stone_defaults(),
 })
 

--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -339,14 +339,14 @@ stairs.register_stair_and_slab("desert_stonebrick", "default:desert_stonebrick",
 		default.node_sound_stone_defaults())
 
 stairs.register_stair_and_slab("sandstone", "default:sandstone",
-		{crumbly = 2, cracky = 2},
+		{crumbly = 1, cracky = 3},
 		{"default_sandstone.png"},
 		"Sandstone Stair",
 		"Sandstone Slab",
 		default.node_sound_stone_defaults())
 		
 stairs.register_stair_and_slab("sandstonebrick", "default:sandstonebrick",
-		{crumbly = 2, cracky = 2},
+		{cracky = 2},
 		{"default_sandstone_brick.png"},
 		"Sandstone Brick Stair",
 		"Sandstone Brick Slab",


### PR DESCRIPTION
Sandstone is crumbly = 1 cracky = 3 to be slowly diggable by hand
Sandstonebrick(stair/slab) is cracky = 2
////////////////////////////////

Fix for #1071 