### PR TITLE
 Fire: Ignite tnt, gunpowder, permanent flame above coalblock

### DIFF
--- a/mods/fire/depends.txt
+++ b/mods/fire/depends.txt
@@ -1,0 +1,1 @@
+default


### PR DESCRIPTION
Enable ignition of tnt, gunpowder and permanent
flame above coalblock using flint and steel
Override coalblock to remove flame above when dug
Add depends.txt for default mod
////////////////////////

![screenshot_20160505_014240](https://cloud.githubusercontent.com/assets/3686677/15033450/d7bdbcc4-1262-11e6-9d23-6073be31d9e5.png)

A use for the new fire:permanent_flame node.
Use flint and steel to ignite.
Flame is permanent (like a torch) and silent.
Punch flame or dig coalblock to extinguish flame.
Also enable ignition of tnt and gunpowder with flint and steel.
Protection is checked for in all cases.