### PR TITLE
Tnt: Avoid divide-by-zero errors in calc_velocity()

### DIFF
--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -110,6 +110,11 @@ end
 
 
 local function calc_velocity(pos1, pos2, old_vel, power)
+	-- Avoid errors caused by a vector of zero length
+	if vector.equals(pos1, pos2) then
+		return old_vel
+	end
+
 	local vel = vector.direction(pos1, pos2)
 	vel = vector.normalize(vel)
 	vel = vector.multiply(vel, power)


### PR DESCRIPTION
Fix for #1073 
PR for HybridDog's fix https://github.com/HybridDog/minetest_game/commit/d785f05397ef35efd1e1fe985deecf8bd8475a92
Approved by PilzAdam http://irc.minetest.ru/minetest-dev/2016-05-08#i_4604830