### PR TITLE
use the new resize texture modifier instead of the current way to fix…

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -235,8 +235,8 @@ function default.register_fence(name, def)
 		}
 	})
 
-	local fence_texture = "default_fence_overlay.png^" .. def.texture ..
-			"^default_fence_overlay.png^[makealpha:255,126,126"
+	local fence_texture = def.texture ..
+			"^[resize:16x16^default_fence_overlay.png^[makealpha:255,126,126"
 	-- Allow almost everything to be overridden
 	local default_fields = {
 		paramtype = "light",


### PR DESCRIPTION
… fence inventory images if the node texture has a different texture than the overlay

contra: disallows using overlays bigger than 16x16