### PR TITLE
Make some nodes floodable, to work with minetest commit b3e3048d3ee6e…

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -246,7 +246,7 @@ minetest.register_node("default:desert_stonebrick", {
 minetest.register_node("default:sandstone", {
 	description = "Sandstone",
 	tiles = {"default_sandstone.png"},
-	groups = {crumbly = 1, cracky = 3},
+	groups = {crumbly = 2, cracky = 3},
 	sounds = default.node_sound_stone_defaults(),
 })
 
@@ -1389,6 +1389,7 @@ minetest.register_node("default:torch", {
 	groups = {choppy = 2, dig_immediate = 3, flammable = 1, attached_node = 1},
 	legacy_wallmounted = true,
 	sounds = default.node_sound_defaults(),
+	floodable = true,
 })
 
 

--- a/mods/farming/api.lua
+++ b/mods/farming/api.lua
@@ -256,6 +256,7 @@ farming.register_plant = function(name, def)
 			walkable = false,
 			buildable_to = true,
 			drop = drop,
+			floodable = true,
 			selection_box = {
 				type = "fixed",
 				fixed = {-0.5, -0.5, -0.5, 0.5, -5/16, 0.5},

--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -45,6 +45,7 @@ local function add_simple_flower(name, desc, box, f_groups)
 		sunlight_propagates = true,
 		paramtype = "light",
 		walkable = false,
+		floodable = true,
 		buildable_to = true,
 		stack_max = 99,
 		groups = f_groups,


### PR DESCRIPTION
… https://github.com/minetest/minetest/pull/4130/commits/b3e3048d3ee6e20991561741fd26c0a4afa460bd

Couldn't do this before, since they'd just get replaced with air. But with the commit to the main engine, they can "safely" be set floodable and all it will do is drop all your torches plunging you into darkness. How fun!