### PR TITLE
Default: Remove unnecessary infotexts for chests and signs

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1447,7 +1447,6 @@ minetest.register_node("default:chest", {
 	on_construct = function(pos)
 		local meta = minetest.get_meta(pos)
 		meta:set_string("formspec", chest_formspec)
-		meta:set_string("infotext", "Chest")
 		local inv = meta:get_inventory()
 		inv:set_size("main", 8*4)
 	end,
@@ -1498,7 +1497,6 @@ minetest.register_node("default:chest_locked", {
 	end,
 	on_construct = function(pos)
 		local meta = minetest.get_meta(pos)
-		meta:set_string("infotext", "Locked Chest")
 		meta:set_string("owner", "")
 		local inv = meta:get_inventory()
 		inv:set_size("main", 8 * 4)
@@ -1636,7 +1634,6 @@ local function register_sign(material, desc, def)
 			--local n = minetest.get_node(pos)
 			local meta = minetest.get_meta(pos)
 			meta:set_string("formspec", "field[text;;${text}]")
-			meta:set_string("infotext", "\"\"")
 		end,
 		on_receive_fields = function(pos, formname, fields, sender)
 			--print("Sign at "..minetest.pos_to_string(pos).." got "..dump(fields))


### PR DESCRIPTION
Behaviour with this commit:

![screenshot_20160517_022204](https://cloud.githubusercontent.com/assets/3686677/15308526/78d8a700-1bd6-11e6-9980-e3cf1d9b2eec.png)

![screenshot_20160517_021911](https://cloud.githubusercontent.com/assets/3686677/15308529/7f23e192-1bd6-11e6-841e-7f0cfa276ef0.png)

^ Locked chests still show useful owner infotext when placed by a player, but will not show infotext if 'constructed' and therefore without an owner.

![screenshot_20160517_022010](https://cloud.githubusercontent.com/assets/3686677/15308532/8402810a-1bd6-11e6-89ee-c09300182bea.png)

^ A non-written sign will not show "". It's obvious the sign is unwritten so "" is not needed. Useful if signs are used for decoration or left unwritten for some reason.

![screenshot_20160517_022114](https://cloud.githubusercontent.com/assets/3686677/15308537/8798c428-1bd6-11e6-8125-a7e4792e7b17.png)

^ The sign text only shows once written.

Current behaviour is shown below:

![screenshot_20160517_022806](https://cloud.githubusercontent.com/assets/3686677/15308617/2bb0f0f8-1bd7-11e6-823b-af908ce53243.png)

![screenshot_20160517_022729](https://cloud.githubusercontent.com/assets/3686677/15308618/2f0576ca-1bd7-11e6-898f-c95159e3492a.png)

^ Note the "" at upper-left.