### PR TITLE
Fix Uninitialized State Variable

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -140,6 +140,8 @@ function _doors.door_toggle(pos, clicker)
 		-- fix up lvm-placed right-hinged doors, default closed
 		if minetest.get_node(pos).name:sub(-2) == "_b" then
 			state = 2
+		else
+			state = 0
 		end
 	else
 		state = tonumber(state)


### PR DESCRIPTION
This can crash the game if the metadata is not there. (Yes, it should be there, but there's no excuse for a crash.) State needs a sane (numeric) default regardless of what the metadata says.