### PR TITLE
save respawn entering bed, remove constant read_spawns

### DIFF
--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -111,7 +111,14 @@ local function update_formspecs(finished)
 		if is_majority and is_night_skip_enabled() then
 			form_n = form_n .. "button_exit[2,8;4,0.75;force;Force night skip]"
 		end
-	end
+
+		if not is_sp then
+			minetest.chat_send_all(">> (" .. player_in_bed .. " / "
+				.. ges .. ") players are sleeping!")
+		end
+
+		beds.set_spawns() -- save respawn positions when entering bed
+end
 
 	for name,_ in pairs(beds.player) do
 		minetest.show_formspec(name, "beds_form", form_n)
@@ -130,7 +137,6 @@ end
 
 function beds.skip_night()
 	minetest.set_timeofday(0.23)
-	beds.set_spawns()
 end
 
 function beds.on_rightclick(pos, player)
@@ -173,10 +179,6 @@ end
 
 
 -- Callbacks
-
-minetest.register_on_joinplayer(function(player)
-	beds.read_spawns()
-end)
 
 -- respawn player at bed if enabled and valid position is found
 minetest.register_on_respawnplayer(function(player)

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -112,11 +112,6 @@ local function update_formspecs(finished)
 			form_n = form_n .. "button_exit[2,8;4,0.75;force;Force night skip]"
 		end
 
-		if not is_sp then
-			minetest.chat_send_all(">> (" .. player_in_bed .. " / "
-				.. ges .. ") players are sleeping!")
-		end
-
 		beds.set_spawns() -- save respawn positions when entering bed
 end
 


### PR DESCRIPTION
Save respawn position when entering bed.  I also removed the constant beds.read_spawns() calls when a player joins as this is only required once https://github.com/minetest/minetest_game/pull/1102