### PR TITLE
Remove constant respawn reads, save respawn pos entering bed

### DIFF
--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -113,7 +113,7 @@ local function update_formspecs(finished)
 		end
 
 		beds.set_spawns() -- save respawn positions when entering bed
-end
+	end
 
 	for name,_ in pairs(beds.player) do
 		minetest.show_formspec(name, "beds_form", form_n)

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -111,7 +111,9 @@ local function update_formspecs(finished)
 		if is_majority and is_night_skip_enabled() then
 			form_n = form_n .. "button_exit[2,8;4,0.75;force;Force night skip]"
 		end
-	end
+
+		beds.set_spawns() -- save respawn positions when entering bed
+end
 
 	for name,_ in pairs(beds.player) do
 		minetest.show_formspec(name, "beds_form", form_n)
@@ -130,7 +132,6 @@ end
 
 function beds.skip_night()
 	minetest.set_timeofday(0.23)
-	beds.set_spawns()
 end
 
 function beds.on_rightclick(pos, player)
@@ -173,10 +174,6 @@ end
 
 
 -- Callbacks
-
-minetest.register_on_joinplayer(function(player)
-	beds.read_spawns()
-end)
 
 -- respawn player at bed if enabled and valid position is found
 minetest.register_on_respawnplayer(function(player)

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -148,6 +148,7 @@ function beds.on_rightclick(pos, player)
 	-- move to bed
 	if not beds.player[name] then
 		lay_down(player, ppos, pos)
+		beds.set_spawns() -- save respawn positions when entering bed
 	else
 		lay_down(player, nil, nil, false)
 	end
@@ -155,8 +156,6 @@ function beds.on_rightclick(pos, player)
 	if not is_sp then
 		update_formspecs(false)
 	end
-
-	beds.set_spawns() -- save respawn positions when entering bed
 
 	-- skip the night and let all players stand up
 	if check_in_beds() then

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -111,8 +111,6 @@ local function update_formspecs(finished)
 		if is_majority and is_night_skip_enabled() then
 			form_n = form_n .. "button_exit[2,8;4,0.75;force;Force night skip]"
 		end
-
-		beds.set_spawns() -- save respawn positions when entering bed
 	end
 
 	for name,_ in pairs(beds.player) do
@@ -157,6 +155,8 @@ function beds.on_rightclick(pos, player)
 	if not is_sp then
 		update_formspecs(false)
 	end
+
+	beds.set_spawns() -- save respawn positions when entering bed
 
 	-- skip the night and let all players stand up
 	if check_in_beds() then

--- a/mods/beds/spawns.lua
+++ b/mods/beds/spawns.lua
@@ -37,6 +37,8 @@ function beds.read_spawns()
 	end
 end
 
+beds.read_spawns()
+
 function beds.save_spawns()
 	if not beds.spawn then
 		return


### PR DESCRIPTION
Save respawn position when entering bed. I also removed the constant beds.read_spawns() calls when a player joins as this is only required once