### PR TITLE
Vessels: Make shelf open on 2 sides not 4, code cleanup

### DIFF
--- a/mods/vessels/init.lua
+++ b/mods/vessels/init.lua
@@ -15,7 +15,9 @@ local vessels_shelf_formspec =
 
 minetest.register_node("vessels:shelf", {
 	description = "Vessels shelf",
-	tiles = {"default_wood.png", "default_wood.png", "vessels_shelf.png"},
+	tiles = {"default_wood.png", "default_wood.png", "default_wood.png",
+		"default_wood.png", "vessels_shelf.png", "vessels_shelf.png"},
+	paramtype2 = "facedir",
 	is_ground_content = false,
 	groups = {choppy=3,oddly_breakable_by_hand=2,flammable=3},
 	sounds = default.node_sound_wood_defaults(),

--- a/mods/vessels/init.lua
+++ b/mods/vessels/init.lua
@@ -2,24 +2,24 @@
 -- See README.txt for licensing and other information.
 
 local vessels_shelf_formspec =
-	"size[8,7;]"..
-	default.gui_bg..
-	default.gui_bg_img..
-	default.gui_slots..
-	"list[context;vessels;0,0.3;8,2;]"..
-	"list[current_player;main;0,2.85;8,1;]"..
-	"list[current_player;main;0,4.08;8,3;8]"..
-	"listring[context;vessels]"..
-	"listring[current_player;main]"..
-	default.get_hotbar_bg(0,2.85)
+	"size[8,7;]" ..
+	default.gui_bg ..
+	default.gui_bg_img ..
+	default.gui_slots ..
+	"list[context;vessels;0,0.3;8,2;]" ..
+	"list[current_player;main;0,2.85;8,1;]" ..
+	"list[current_player;main;0,4.08;8,3;8]" ..
+	"listring[context;vessels]" ..
+	"listring[current_player;main]" ..
+	default.get_hotbar_bg(0, 2.85)
 
 minetest.register_node("vessels:shelf", {
-	description = "Vessels shelf",
+	description = "Vessels Shelf",
 	tiles = {"default_wood.png", "default_wood.png", "default_wood.png",
 		"default_wood.png", "vessels_shelf.png", "vessels_shelf.png"},
 	paramtype2 = "facedir",
 	is_ground_content = false,
-	groups = {choppy=3,oddly_breakable_by_hand=2,flammable=3},
+	groups = {choppy = 3, oddly_breakable_by_hand = 2, flammable = 3},
 	sounds = default.node_sound_wood_defaults(),
 
 	on_construct = function(pos)
@@ -53,18 +53,18 @@ minetest.register_node("vessels:shelf", {
 	on_blast = function(pos)
 		local drops = {}
 		default.get_inventory_drops(pos, "vessels", drops)
-		drops[#drops+1] = "vessels:shelf"
+		drops[#drops + 1] = "vessels:shelf"
 		minetest.remove_node(pos)
 		return drops
 	end,
 })
 
 minetest.register_craft({
-	output = 'vessels:shelf',
+	output = "vessels:shelf",
 	recipe = {
-		{'group:wood', 'group:wood', 'group:wood'},
-		{'group:vessel', 'group:vessel', 'group:vessel'},
-		{'group:wood', 'group:wood', 'group:wood'},
+		{"group:wood", "group:wood", "group:wood"},
+		{"group:vessel", "group:vessel", "group:vessel"},
+		{"group:wood", "group:wood", "group:wood"},
 	}
 })
 
@@ -81,16 +81,16 @@ minetest.register_node("vessels:glass_bottle", {
 		type = "fixed",
 		fixed = {-0.25, -0.5, -0.25, 0.25, 0.3, 0.25}
 	},
-	groups = {vessel=1,dig_immediate=3,attached_node=1},
+	groups = {vessel = 1, dig_immediate = 3, attached_node = 1},
 	sounds = default.node_sound_glass_defaults(),
 })
 
 minetest.register_craft( {
 	output = "vessels:glass_bottle 10",
 	recipe = {
-		{ "default:glass", "", "default:glass" },
-		{ "default:glass", "", "default:glass" },
-		{ "", "default:glass", "" }
+		{"default:glass", "", "default:glass"},
+		{"default:glass", "", "default:glass"},
+		{"", "default:glass", ""}
 	}
 })
 
@@ -107,16 +107,16 @@ minetest.register_node("vessels:drinking_glass", {
 		type = "fixed",
 		fixed = {-0.25, -0.5, -0.25, 0.25, 0.3, 0.25}
 	},
-	groups = {vessel=1,dig_immediate=3,attached_node=1},
+	groups = {vessel = 1, dig_immediate = 3, attached_node = 1},
 	sounds = default.node_sound_glass_defaults(),
 })
 
 minetest.register_craft( {
 	output = "vessels:drinking_glass 14",
 	recipe = {
-		{ "default:glass", "", "default:glass" },
-		{ "default:glass", "", "default:glass" },
-		{ "default:glass", "default:glass", "default:glass" }
+		{"default:glass", "", "default:glass"},
+		{"default:glass", "", "default:glass"},
+		{"default:glass", "default:glass", "default:glass"}
 	}
 })
 
@@ -133,21 +133,21 @@ minetest.register_node("vessels:steel_bottle", {
 		type = "fixed",
 		fixed = {-0.25, -0.5, -0.25, 0.25, 0.3, 0.25}
 	},
-	groups = {vessel=1,dig_immediate=3,attached_node=1},
+	groups = {vessel = 1, dig_immediate = 3, attached_node = 1},
 	sounds = default.node_sound_defaults(),
 })
 
 minetest.register_craft( {
 	output = "vessels:steel_bottle 5",
 	recipe = {
-		{ "default:steel_ingot", "", "default:steel_ingot" },
-		{ "default:steel_ingot", "", "default:steel_ingot" },
-		{ "", "default:steel_ingot", "" }
+		{"default:steel_ingot", "", "default:steel_ingot"},
+		{"default:steel_ingot", "", "default:steel_ingot"},
+		{"", "default:steel_ingot", ""}
 	}
 })
 
 
--- Make sure we can recycle them
+-- Glass and steel recycling
 
 minetest.register_craftitem("vessels:glass_fragments", {
 	description = "Pile of Glass Fragments",
@@ -183,4 +183,3 @@ minetest.register_craft( {
 	output = "default:steel_ingot",
 	recipe = "vessels:steel_bottle",
 })
-


### PR DESCRIPTION
Commit 1: Make shelf open on 2 sides not impossible 4 sides
Make shelf facedir rotatable as is now required

Commit 2: Improve code style
///////////////////////

![screenshot_20160521_034033](https://cloud.githubusercontent.com/assets/3686677/15445991/2912ae98-1f08-11e6-8d10-6bca147951f4.png)

^ With this commit. Shelf is open on front and back only. Rotates on placement like chest.

![screenshot_20160521_035454](https://cloud.githubusercontent.com/assets/3686677/15445995/3468618e-1f08-11e6-99d6-3446835d5aa2.png)

^ Currently there are deep shelves (another row of vessels are behind the first) on all 4 sides, impossible and looks wrong.

I realise some players may need to re-place some shelves to the correct rotation but it's worth it.
Vessel shelves are not likely to be present in huge numbers, bookshelves may be large in number in libraries, so doing this improvement for those may be more problematic.