### PR TITLE
add group grown and can_grow for grass growing abm

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -384,12 +384,11 @@ minetest.register_abm({
 --
 
 minetest.register_abm({
-	nodenames = {"group:can_grow"},
+	nodenames = {"group:dirt"},
 	neighbors = {
-		"group:grown",
 		"group:grass",
 		"group:dry_grass",
-		"default:snow",
+		"group:snow",
 	},
 	interval = 6,
 	chance = 67,
@@ -401,16 +400,24 @@ minetest.register_abm({
 			return
 		end
 
+		-- Define node_def
+		local node_def = minetest.registered_nodes[node.name]
+
 		-- Look for likely neighbors.
-		local p2 = minetest.find_node_near(pos, 1, {"group:grown"})
+		local p2 = minetest.find_node_near(pos, 1, {"group:grass", "group:dry_grass", "group:snow"})
 		if p2 then
 			-- But the node needs to be under air in this case.
 			local n2 = minetest.get_node(above)
 			if n2 and n2.name == "air" then
 				local n3 = minetest.get_node(p2)
-				local n4 = n3.name:split('_with_')[2]
-				local n5 = minetest.get_node(pos)
-				minetest.set_node(pos, {name = n5.name.."_with_"..n4})
+				local name = n3.name
+				if minetest.get_item_group(name, "grass") ~= 0 and node_def.with_grass then
+					minetest.set_node(pos, {name = node_def.with_grass})
+				elseif minetest.get_item_group(name, "dry_grass") ~= 0 and node_def.with_dry_grass then
+					minetest.set_node(pos, {name = node_def.with_dry_grass})
+				elseif minetest.get_item_group(name, "snow") ~= 0 and node_def.with_snow then
+					minetest.set_node(pos, {name = node_def.with_snow})
+				end
 				return
 			end
 		end
@@ -423,13 +430,13 @@ minetest.register_abm({
 
 		local name = n2.name
 		-- Snow check is cheapest, so comes first.
-		if name == "default:snow" then
-			minetest.set_node(pos, {name = "default:dirt_with_snow"})
+		if name == "default:snow" and node_def.with_snow then
+			minetest.set_node(pos, {name = node_def.with_snow})
 		-- Most likely case first.
-		elseif minetest.get_item_group(name, "grass") ~= 0 then
-			minetest.set_node(pos, {name = "default:dirt_with_grass"})
-		elseif minetest.get_item_group(name, "dry_grass") ~= 0 then
-			minetest.set_node(pos, {name = "default:dirt_with_dry_grass"})
+		elseif minetest.get_item_group(name, "grass") ~= 0 and node_def.with_grass then
+			minetest.set_node(pos, {name = node_def.with_grass})
+		elseif minetest.get_item_group(name, "dry_grass") ~= 0 and node_def.with_dry_grass then
+			minetest.set_node(pos, {name = node_def.with_dry_grass})
 		end
 	end
 })

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -384,11 +384,9 @@ minetest.register_abm({
 --
 
 minetest.register_abm({
-	nodenames = {"default:dirt"},
+	nodenames = {"group:can_grow"},
 	neighbors = {
-		"default:dirt_with_grass",
-		"default:dirt_with_dry_grass",
-		"default:dirt_with_snow",
+		"group:grown",
 		"group:grass",
 		"group:dry_grass",
 		"default:snow",
@@ -404,14 +402,15 @@ minetest.register_abm({
 		end
 
 		-- Look for likely neighbors.
-		local p2 = minetest.find_node_near(pos, 1, {"default:dirt_with_grass",
-				"default:dirt_with_dry_grass", "default:dirt_with_snow"})
+		local p2 = minetest.find_node_near(pos, 1, {"group:grown"})
 		if p2 then
 			-- But the node needs to be under air in this case.
 			local n2 = minetest.get_node(above)
 			if n2 and n2.name == "air" then
 				local n3 = minetest.get_node(p2)
-				minetest.set_node(pos, {name = n3.name})
+				local n4 = n3.name:split('_with_')[2]
+				local n5 = minetest.get_node(pos)
+				minetest.set_node(pos, {name = n5.name.."_with_"..n4})
 				return
 			end
 		end

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -281,7 +281,7 @@ minetest.register_node("default:obsidianbrick", {
 minetest.register_node("default:dirt", {
 	description = "Dirt",
 	tiles = {"default_dirt.png"},
-	groups = {crumbly = 3, soil = 1},
+	groups = {crumbly = 3, soil = 1, can_grow = 1},
 	sounds = default.node_sound_dirt_defaults(),
 })
 
@@ -290,7 +290,7 @@ minetest.register_node("default:dirt_with_grass", {
 	tiles = {"default_grass.png", "default_dirt.png",
 		{name = "default_dirt.png^default_grass_side.png",
 			tileable_vertical = false}},
-	groups = {crumbly = 3, soil = 1},
+	groups = {crumbly = 3, soil = 1, grown = 1},
 	drop = 'default:dirt',
 	sounds = default.node_sound_dirt_defaults({
 		footstep = {name = "default_grass_footstep", gain = 0.25},
@@ -315,7 +315,7 @@ minetest.register_node("default:dirt_with_dry_grass", {
 		"default_dirt.png",
 		{name = "default_dirt.png^default_dry_grass_side.png",
 			tileable_vertical = false}},
-	groups = {crumbly = 3, soil = 1},
+	groups = {crumbly = 3, soil = 1, grown = 1},
 	drop = 'default:dirt',
 	sounds = default.node_sound_dirt_defaults({
 		footstep = {name = "default_grass_footstep", gain = 0.4},
@@ -327,7 +327,7 @@ minetest.register_node("default:dirt_with_snow", {
 	tiles = {"default_snow.png", "default_dirt.png",
 		{name = "default_dirt.png^default_snow_side.png",
 			tileable_vertical = false}},
-	groups = {crumbly = 3, soil = 1},
+	groups = {crumbly = 3, soil = 1, grown = 1},
 	drop = 'default:dirt',
 	sounds = default.node_sound_dirt_defaults({
 		footstep = {name = "default_snow_footstep", gain = 0.15},

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -281,8 +281,11 @@ minetest.register_node("default:obsidianbrick", {
 minetest.register_node("default:dirt", {
 	description = "Dirt",
 	tiles = {"default_dirt.png"},
-	groups = {crumbly = 3, soil = 1, can_grow = 1},
+	groups = {crumbly = 3, soil = 1, dirt = 1},
 	sounds = default.node_sound_dirt_defaults(),
+	with_grass = "default:dirt_with_grass",
+	with_dry_grass = "default:dirt_with_dry_grass",
+	with_snow = "default:dirt_with_snow",
 })
 
 minetest.register_node("default:dirt_with_grass", {
@@ -290,7 +293,7 @@ minetest.register_node("default:dirt_with_grass", {
 	tiles = {"default_grass.png", "default_dirt.png",
 		{name = "default_dirt.png^default_grass_side.png",
 			tileable_vertical = false}},
-	groups = {crumbly = 3, soil = 1, grown = 1},
+	groups = {crumbly = 3, soil = 1, grass = 1},
 	drop = 'default:dirt',
 	sounds = default.node_sound_dirt_defaults({
 		footstep = {name = "default_grass_footstep", gain = 0.25},
@@ -315,7 +318,7 @@ minetest.register_node("default:dirt_with_dry_grass", {
 		"default_dirt.png",
 		{name = "default_dirt.png^default_dry_grass_side.png",
 			tileable_vertical = false}},
-	groups = {crumbly = 3, soil = 1, grown = 1},
+	groups = {crumbly = 3, soil = 1, dry_grass = 1},
 	drop = 'default:dirt',
 	sounds = default.node_sound_dirt_defaults({
 		footstep = {name = "default_grass_footstep", gain = 0.4},
@@ -327,7 +330,7 @@ minetest.register_node("default:dirt_with_snow", {
 	tiles = {"default_snow.png", "default_dirt.png",
 		{name = "default_dirt.png^default_snow_side.png",
 			tileable_vertical = false}},
-	groups = {crumbly = 3, soil = 1, grown = 1},
+	groups = {crumbly = 3, soil = 1, snow = 1},
 	drop = 'default:dirt',
 	sounds = default.node_sound_dirt_defaults({
 		footstep = {name = "default_snow_footstep", gain = 0.15},
@@ -387,7 +390,7 @@ minetest.register_node("default:snow", {
 			{-0.5, -0.5, -0.5, 0.5, -0.25, 0.5},
 		},
 	},
-	groups = {crumbly = 3, falling_node = 1, puts_out_fire = 1},
+	groups = {crumbly = 3, falling_node = 1, puts_out_fire = 1, snow = 1},
 	sounds = default.node_sound_dirt_defaults({
 		footstep = {name = "default_snow_footstep", gain = 0.15},
 		dug = {name = "default_snow_footstep", gain = 0.2},

--- a/mods/farming/nodes.lua
+++ b/mods/farming/nodes.lua
@@ -1,5 +1,5 @@
 minetest.override_item("default:dirt", {
-	groups = {crumbly=3, soil=1},
+	groups = {crumbly=3, soil=1, dirt=1},
 	soil = {
 		base = "default:dirt",
 		dry = "farming:soil",
@@ -8,7 +8,7 @@ minetest.override_item("default:dirt", {
 })
 
 minetest.override_item("default:dirt_with_grass", {
-	groups = {crumbly=3, soil=1},
+	groups = {crumbly=3, soil=1, grass=1},
 	soil = {
 		base = "default:dirt_with_grass",
 		dry = "farming:soil",
@@ -17,7 +17,7 @@ minetest.override_item("default:dirt_with_grass", {
 })
 
 minetest.override_item("default:dirt_with_dry_grass", {
-	groups = {crumbly=3, soil=1},
+	groups = {crumbly=3, soil=1, dry_grass=1},
 	soil = {
 		base = "default:dirt_with_dry_grass",
 		dry = "farming:soil",


### PR DESCRIPTION
Allows one to add new types of dirt that grass can grow on without
editing the ABM.