### PR TITLE
Lower boat collision box top.

### DIFF
--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -34,7 +34,7 @@ end
 
 local boat = {
 	physical = true,
-	collisionbox = {-0.5, -0.35, -0.5, 0.5, 0.3, 0.5},
+	collisionbox = {-0.5, -0.35, -0.5, 0.5, 0.15, 0.5},
 	visual = "mesh",
 	mesh = "boats_boat.obj",
 	textures = {"default_wood.png"},


### PR DESCRIPTION
Standing on a boat makes you appear to "hover" over it since this
collision box is way too high. Lower it so that it's low enough
to look normal when walking on top of a boat.