### PR TITLE
Default: Bookshelf has 2 openings instead of 4

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1566,7 +1566,9 @@ local bookshelf_formspec =
 
 minetest.register_node("default:bookshelf", {
 	description = "Bookshelf",
-	tiles = {"default_wood.png", "default_wood.png", "default_bookshelf.png"},
+	tiles = {"default_wood.png", "default_wood.png", "default_wood.png",
+		"default_wood.png", "default_bookshelf.png", "default_bookshelf.png"},
+	paramtype2 = "facedir",
 	is_ground_content = false,
 	groups = {choppy = 3, oddly_breakable_by_hand = 2, flammable = 3},
 	sounds = default.node_sound_wood_defaults(),


### PR DESCRIPTION
Make rotatable with 'paramtype2 = facedir'
///////////////////////////////

![screenshot_20160524_053611](https://cloud.githubusercontent.com/assets/3686677/15492284/89027de0-2171-11e6-9497-c8aee1afae96.png)

See #1104 
Has a surprising amount of support in the issue thread.