### PR TITLE
Mossy cobble slab and stairs.

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -343,7 +343,7 @@ delivered with Minetest Game, to keep them compatible with other mods.
 
  * Registers a stair.
  * `subname`: Basically the material name (e.g. cobble) used for the stair name. Nodename pattern: "stairs:stair_subname"
- * `recipeitem`: Item used in the craft recipe, e.g. "default:cobble"
+ * `recipeitem`: Item used in the craft recipe, e.g. "default:cobble", may be `nil`
  * `groups`: see [Known damage and digging time defining groups]
  * `images`: see [Tile definition]
  * `description`: used for the description field in the stair's definition

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -466,12 +466,18 @@ minetest.register_abm({
 --
 
 minetest.register_abm({
-	nodenames = {"default:cobble"},
+	nodenames = {"default:cobble", "stairs:slab_cobble", "stairs:stair_cobble"},
 	neighbors = {"group:water"},
 	interval = 16,
 	chance = 200,
 	catch_up = false,
 	action = function(pos, node)
-		minetest.set_node(pos, {name = "default:mossycobble"})
+		if node.name == "default:cobble" then
+			minetest.set_node(pos, {name = "default:mossycobble"})
+		elseif node.name == "stairs:slab_cobble" then
+			minetest.set_node(pos, {name = "stairs:slab_mossycobble", param2 = node.param2})
+		elseif node.name == "stairs:stair_cobble" then
+			minetest.set_node(pos, {name = "stairs:stair_mossycobble", param2 = node.param2})
+		end
 	end
 })

--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -87,24 +87,26 @@ function stairs.register_stair(subname, recipeitem, groups, images, description,
 		})
 	end
 
-	minetest.register_craft({
-		output = 'stairs:stair_' .. subname .. ' 6',
-		recipe = {
-			{recipeitem, "", ""},
-			{recipeitem, recipeitem, ""},
-			{recipeitem, recipeitem, recipeitem},
-		},
-	})
+	if recipeitem then
+		minetest.register_craft({
+			output = 'stairs:stair_' .. subname .. ' 6',
+			recipe = {
+				{recipeitem, "", ""},
+				{recipeitem, recipeitem, ""},
+				{recipeitem, recipeitem, recipeitem},
+			},
+		})
 
-	-- Flipped recipe for the silly minecrafters
-	minetest.register_craft({
-		output = 'stairs:stair_' .. subname .. ' 6',
-		recipe = {
-			{"", "", recipeitem},
-			{"", recipeitem, recipeitem},
-			{recipeitem, recipeitem, recipeitem},
-		},
-	})
+		-- Flipped recipe for the silly minecrafters
+		minetest.register_craft({
+			output = 'stairs:stair_' .. subname .. ' 6',
+			recipe = {
+				{"", "", recipeitem},
+				{"", recipeitem, recipeitem},
+				{recipeitem, recipeitem, recipeitem},
+			},
+		})
+	end
 end
 
 
@@ -218,12 +220,14 @@ function stairs.register_slab(subname, recipeitem, groups, images, description, 
 		})
 	end
 
-	minetest.register_craft({
-		output = 'stairs:slab_' .. subname .. ' 6',
-		recipe = {
-			{recipeitem, recipeitem, recipeitem},
-		},
-	})
+	if recipeitem then
+		minetest.register_craft({
+			output = 'stairs:slab_' .. subname .. ' 6',
+			recipe = {
+				{recipeitem, recipeitem, recipeitem},
+			},
+		})
+	end
 end
 
 
@@ -308,6 +312,13 @@ stairs.register_stair_and_slab("cobble", "default:cobble",
 		{"default_cobble.png"},
 		"Cobblestone Stair",
 		"Cobblestone Slab",
+		default.node_sound_stone_defaults())
+
+stairs.register_stair_and_slab("mossycobble", nil,
+		{cracky = 3},
+		{"default_mossycobble.png"},
+		"Mossy Cobblestone Stair",
+		"Mossy Cobblestone Slab",
 		default.node_sound_stone_defaults())
 
 stairs.register_stair_and_slab("stonebrick", "default:stonebrick",


### PR DESCRIPTION
Allow water to turn cobble slab and stairs to turn into mossy versions.

There is no crafting recipe for mossy stairs and mossy slabs, the
stair/slab API has been modified to allow for a recipeitem that
is `nil`, which will omit adding a crafting recipe for these two
items. The API documentation is updated.

The slabs and stairs will turn mossy when water is adjacent, just like
cobblestone. You can either farm mossy versions by placing them in
water for a while, then collecting them, or run water over your craft.

Related: #1118