### PR TITLE
Fix boat falling through world and grey screen in creative search

### DIFF
--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -34,7 +34,9 @@ end
 
 local boat = {
 	physical = true,
-	collisionbox = {-0.5, -0.35, -0.5, 0.5, 0.15, 0.5},
+	-- Warning: Do not change the position of the collisionbox top surface,
+	-- lowering it causes the boat to fall through the world if underwater
+	collisionbox = {-0.5, -0.35, -0.5, 0.5, 0.3, 0.5},
 	visual = "mesh",
 	mesh = "boats_boat.obj",
 	textures = {"default_wood.png"},

--- a/mods/creative/init.lua
+++ b/mods/creative/init.lua
@@ -124,7 +124,7 @@ creative.set_creative_formspec = function(player, start_i)
 		tooltip[creative_clear;Reset]
 		listring[current_player;main]
 		]] ..
-		"field[0.3,3.5;2.2,1;creative_filter;;" .. inv.filter .. "]" ..
+		"field[0.3,3.5;2.2,1;creative_filter;;" .. minetest.formspec_escape(inv.filter) .. "]" ..
 		"listring[detached:creative_" .. player_name .. ";main]" ..
 		"tabheader[0,0;creative_tabs;Crafting,All,Nodes,Tools,Items;" .. tostring(inv.tab_id) .. ";true;false]" ..
 		"list[detached:creative_" .. player_name .. ";main;0,0;8,3;" .. tostring(start_i) .. "]" ..


### PR DESCRIPTION
2 commits:

Boats: Raise collisionbox top surface to fix boat behaviour
Lowering the top surface to be level with the boat top somehow
causes the boat to fall through world if underwater. Revert to
previous position that is needed for correct behaviour
Fix for #1137 

Creative: Add missing 'formspec_escape' to fix bug
Symbols used in search caused the game to hang with a grey screen,
for example searching for 'diamond;ingot'
Fix for #1136 

Tested.