### PR TITLE
Stairs: Stair recipe returns 8 stairs not 6

### DIFF
--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -89,7 +89,7 @@ function stairs.register_stair(subname, recipeitem, groups, images, description,
 
 	if recipeitem then
 		minetest.register_craft({
-			output = 'stairs:stair_' .. subname .. ' 6',
+			output = 'stairs:stair_' .. subname .. ' 8',
 			recipe = {
 				{recipeitem, "", ""},
 				{recipeitem, recipeitem, ""},
@@ -99,7 +99,7 @@ function stairs.register_stair(subname, recipeitem, groups, images, description,
 
 		-- Flipped recipe for the silly minecrafters
 		minetest.register_craft({
-			output = 'stairs:stair_' .. subname .. ' 6',
+			output = 'stairs:stair_' .. subname .. ' 8',
 			recipe = {
 				{"", "", recipeitem},
 				{"", recipeitem, recipeitem},


### PR DESCRIPTION
Make it consistent with the slab recipe which conserves volume
//////////////////////////////////////////////////

6 recipeitems = 6 * 4 = 24 quarter nodes.
A stair is 3 quarter nodes, 24 / 3 = 8.
Will merge as trivial.