### PR TITLE
Update .gitignore to ignore custom minetest.conf and additional ide/editors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,28 @@
-## Generic ignorable patterns and files
-*~
-.*.swp
-*bak*
-tags
-*.vim
-
 ## Files related to minetest development cycle
-*.patch
+/*.patch
+# GNU Patch reject file
+*.rej
+
+## Editors and Development environments
+*~
+*.swp
+*.bak*
+*.orig
+# Vim
+*.vim
+# Kate
+.*.kate-swp
+.swp.*
+# Eclipse (LDT)
+.project
+.settings/
+.buildpath
+.metadata
+# GNU Global
+tags
+!tags/
+gtags.files
+.idea/*
+
+## Custom minetest.conf
+minetest.conf


### PR DESCRIPTION
Similar IDE/Editor set to minetest/minetest (Eclipse CDT is left out, since that is C/C++ only)

The empty minetest.conf is removed and ignored to allow people to set their own game-wide minetest.conf without git registering it as a change.