### PR TITLE
Update .gitignore to ignore additional ide/editors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,22 @@
-## Generic ignorable patterns and files
-*~
-.*.swp
-*bak*
-tags
-*.vim
-
 ## Files related to minetest development cycle
-*.patch
+/*.patch
+# GNU Patch reject file
+*.rej
+
+## Editors and Development environments
+*~
+*.swp
+*.bak*
+*.orig
+# Vim
+*.vim
+# Kate
+.*.kate-swp
+.swp.*
+# Eclipse (LDT)
+.project
+.settings/
+.buildpath
+.metadata
+# Idea IDE
+.idea/*


### PR DESCRIPTION
Reopened and updated version of #1151 

Ignored are files of various Editors and Development Environments, that can also be found in minetest/minetest's .gitignore, in the same sorting, but filtered for Lua instead of C/C++