### PR TITLE
Default: Stone drops stone, cobble is crafted

### DIFF
--- a/mods/default/crafting.lua
+++ b/mods/default/crafting.lua
@@ -646,6 +646,13 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
+	output = 'default:cobble',
+	recipe = {
+		{'default:stone'},
+	}
+})
+
+minetest.register_craft({
 	output = 'default:stonebrick 4',
 	recipe = {
 		{'default:stone', 'default:stone'},
@@ -659,6 +666,13 @@ minetest.register_craft({
 		{'default:stone', 'default:stone', 'default:stone'},
 		{'default:stone', 'default:stone', 'default:stone'},
 		{'default:stone', 'default:stone', 'default:stone'},
+	}
+})
+
+minetest.register_craft({
+	output = 'default:desert_cobble',
+	recipe = {
+		{'default:desert_stone'},
 	}
 })
 

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -191,7 +191,6 @@ minetest.register_node("default:stone", {
 	description = "Stone",
 	tiles = {"default_stone.png"},
 	groups = {cracky = 3, stone = 1},
-	drop = 'default:cobble',
 	legacy_mineral = true,
 	sounds = default.node_sound_stone_defaults(),
 })
@@ -235,7 +234,6 @@ minetest.register_node("default:desert_stone", {
 	description = "Desert Stone",
 	tiles = {"default_desert_stone.png"},
 	groups = {cracky = 3, stone = 1},
-	drop = 'default:desert_cobble',
 	legacy_mineral = true,
 	sounds = default.node_sound_stone_defaults(),
 })


### PR DESCRIPTION
With this PR, stone and desert stone drop themselves, and cobble is created by placing a single stone in the crafting grid.

Any recipe conflicts? It can be changed.

Although it may be realistic for stone and desert stone to drop cobble, most nodes drop themselves for playability reasons. I was disappointed to see that when desert cobble was added it was made consistent with stone. Imagine if every node dropped a broken version of itself and it was an effort to restore the node to it's former state, Minetest would become unbearable.

Stone bricks, blocks, stairs and slabs are good building materials but stone is hard work and time-consuming to create using fuel and a furnace.

I watch a lot of Minecraft videos (VintageBeef, Guude, BdoubleO and friends) and there is the familiar problem of how cobble builds up and what to do with it. This was a bad feature that was copied into Minetest.

With this PR we will see less lazy cobble builds and more variety and use of stone in survival mode.
We will also have a fundamental difference and advantage over Minecraft instead of another unquestioning feature copy.