### PR TITLE
Variable and Value cleanup to prepare CI-Linting

### DIFF
--- a/mods/beds/api.lua
+++ b/mods/beds/api.lua
@@ -59,8 +59,8 @@ function beds.register_bed(name, def)
 				return itemstack
 			end
 
-			local def = minetest.registered_nodes[minetest.get_node(pos).name]
-			if not def or not def.buildable_to then
+			local node_def = minetest.registered_nodes[minetest.get_node(pos).name]
+			if not node_def or not node_def.buildable_to then
 				return itemstack
 			end
 
@@ -113,8 +113,8 @@ function beds.register_bed(name, def)
 			end
 			local newp = vector.add(pos, minetest.facedir_to_dir(new_param2))
 			local node3 = minetest.get_node_or_nil(newp)
-			local def = node3 and minetest.registered_nodes[node3.name]
-			if not def or not def.buildable_to then
+			local node_def = node3 and minetest.registered_nodes[node3.name]
+			if not node_def or not node_def.buildable_to then
 				return false
 			end
 			if minetest.is_protected(newp, user:get_player_name()) then

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -100,7 +100,7 @@ end
 
 local function update_formspecs(finished)
 	local ges = #minetest.get_connected_players()
-	local form_n = ""
+	local form_n
 	local is_majority = (ges / 2) < player_in_bed
 
 	if finished then

--- a/mods/beds/spawns.lua
+++ b/mods/beds/spawns.lua
@@ -32,8 +32,6 @@ function beds.read_spawns()
 		beds.save_spawns()
 		os.rename(file, file .. ".backup")
 		file = org_file
-	else
-		spawns = {}
 	end
 end
 

--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -167,7 +167,7 @@ function boat.on_step(self, dtime)
 
 	local p = self.object:getpos()
 	p.y = p.y - 0.5
-	local new_velo = {x = 0, y = 0, z = 0}
+	local new_velo
 	local new_acce = {x = 0, y = 0, z = 0}
 	if not is_water(p) then
 		local nodedef = minetest.registered_nodes[minetest.get_node(p).name]

--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -174,7 +174,6 @@ minetest.register_on_dieplayer(function(player)
 	pos.z = math.floor(pos.z+0.5)
 	local param2 = minetest.dir_to_facedir(player:get_look_dir())
 	local player_name = player:get_player_name()
-	local player_inv = player:get_inventory()
 
 	if (not may_replace(pos, player)) then
 		if (may_replace({x=pos.x, y=pos.y+1, z=pos.z}, player)) then

--- a/mods/bucket/init.lua
+++ b/mods/bucket/init.lua
@@ -80,8 +80,9 @@ function bucket.register_liquid(source, flowing, itemname, inventory_image, name
 				else
 					-- not buildable to; place the liquid above
 					-- check if the node above can be replaced
+
 					lpos = pointed_thing.above
-					local node = minetest.get_node_or_nil(lpos)
+					node = minetest.get_node_or_nil(lpos)
 					local above_ndef = node and minetest.registered_nodes[node.name]
 
 					if not above_ndef or not above_ndef.buildable_to then

--- a/mods/creative/init.lua
+++ b/mods/creative/init.lua
@@ -197,7 +197,6 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		creative.update_creative_inventory(player_name)
 		creative.set_creative_formspec(player, 0)
 	else
-		local formspec = player:get_inventory_formspec()
 		local start_i = player_inventory[player_name].start_i or 0
 
 		if fields.creative_prev then

--- a/mods/creative/init.lua
+++ b/mods/creative/init.lua
@@ -5,15 +5,16 @@ local player_inventory = {}
 local creative_mode = minetest.setting_getbool("creative_mode")
 
 -- Create detached creative inventory after loading all mods
-creative.init_creative_inventory = function(player)
-	local player_name = player:get_player_name()
-	player_inventory[player_name] = {}
-	player_inventory[player_name].size = 0
-	player_inventory[player_name].filter = ""
-	player_inventory[player_name].start_i = 1
-	player_inventory[player_name].tab_id = 2
+creative.init_creative_inventory = function(owner)
+	local owner_name = owner:get_player_name()
+	player_inventory[owner_name] = {
+		size = 0,
+		filter = "",
+		start_i = 1,
+		tab_id = 2,
+	}
 
-	minetest.create_detached_inventory("creative_" .. player_name, {
+	minetest.create_detached_inventory("creative_" .. owner_name, {
 		allow_move = function(inv, from_list, from_index, to_list, to_index, count, player)
 			if creative_mode and not to_list == "main" then
 				return count
@@ -45,7 +46,7 @@ creative.init_creative_inventory = function(player)
 		end,
 	})
 
-	creative.update_creative_inventory(player_name)
+	creative.update_creative_inventory(owner_name)
 	--print("creative inventory size: " .. player_inventory[player_name].size)
 end
 

--- a/mods/default/craftitems.lua
+++ b/mods/default/craftitems.lua
@@ -15,7 +15,7 @@ local lpp = 14 -- Lines per book's page
 local function book_on_use(itemstack, user)
 	local player_name = user:get_player_name()
 	local data = minetest.deserialize(itemstack:get_metadata())
-	local formspec, title, text, owner = "", "", "", player_name
+	local title, text, owner = "", "", player_name
 	local page, page_max, lines, string = 1, 1, {}, ""
 
 	if data then
@@ -38,6 +38,7 @@ local function book_on_use(itemstack, user)
 		end
 	end
 
+	local formspec
 	if owner == player_name then
 		formspec = "size[8,8]" .. default.gui_bg ..
 			default.gui_bg_img ..
@@ -152,7 +153,6 @@ minetest.register_on_craft(function(itemstack, player, old_craft_grid, craft_inv
 		return
 	end
 
-	local copy = ItemStack("default:book_written")
 	local original
 	local index
 	for i = 1, player:get_inventory():get_size("craft") do

--- a/mods/default/furnace.lua
+++ b/mods/default/furnace.lua
@@ -111,7 +111,6 @@ local function furnace_node_timer(pos, elapsed)
 	local inv = meta:get_inventory()
 	local srclist = inv:get_list("src")
 	local fuellist = inv:get_list("fuel")
-	local dstlist = inv:get_list("dst")
 
 	--
 	-- Cooking
@@ -172,7 +171,7 @@ local function furnace_node_timer(pos, elapsed)
 	-- Update formspec, infotext and node
 	--
 	local formspec = inactive_formspec
-	local item_state = ""
+	local item_state
 	local item_percent = 0
 	if cookable then
 		item_percent = math.floor(src_time / cooked.time * 100)

--- a/mods/default/trees.lua
+++ b/mods/default/trees.lua
@@ -176,8 +176,8 @@ function default.grow_tree(pos, is_apple_tree, bad)
 
 	local vm = minetest.get_voxel_manip()
 	local minp, maxp = vm:read_from_map(
-		{x = pos.x - 2, y = pos.y, z = pos.z - 2},
-		{x = pos.x + 2, y = pos.y + height + 1, z = pos.z + 2}
+		{x = x - 2, y = y, z = z - 2},
+		{x = x + 2, y = y + height + 1, z = z + 2}
 	)
 	local a = VoxelArea:new({MinEdge = minp, MaxEdge = maxp})
 	local data = vm:get_data()
@@ -211,8 +211,8 @@ function default.grow_jungle_tree(pos, bad)
 
 	local vm = minetest.get_voxel_manip()
 	local minp, maxp = vm:read_from_map(
-		{x = pos.x - 3, y = pos.y - 1, z = pos.z - 3},
-		{x = pos.x + 3, y = pos.y + height + 1, z = pos.z + 3}
+		{x = x - 3, y = y - 1, z = z - 3},
+		{x = x + 3, y = y + height + 1, z = z + 3}
 	)
 	local a = VoxelArea:new({MinEdge = minp, MaxEdge = maxp})
 	local data = vm:get_data()
@@ -331,7 +331,7 @@ function default.grow_pine_tree(pos, snow)
 		end
 	end
 
-	local dev = 2
+	dev = 2
 	for yy = my + 1, my + 2 do
 		for zz = z - dev, z + dev do
 			local vi = a:index(x - dev, yy, zz)

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -344,11 +344,11 @@ function doors.register(name, def)
 			return true
 		end
 		local meta = minetest.get_meta(pos)
-		local name
+		local owner_name
 		if digger then
-			name = digger:get_player_name()
+			owner_name = digger:get_player_name()
 		end
-		return meta:get_string("doors_owner") == name
+		return meta:get_string("doors_owner") == owner_name
 	end
 
 	if not def.sounds then

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -156,7 +156,6 @@ function _doors.door_toggle(pos, node, clicker)
 		end
 	end
 
-	local old = state
 	-- until Lua-5.2 we have no bitwise operators :(
 	if state % 2 == 1 then
 		state = state - 1
@@ -186,7 +185,6 @@ end
 local function on_place_node(place_to, newnode,
 	placer, oldnode, itemstack, pointed_thing)
 	-- Run script hook
-	local _, callback
 	for _, callback in ipairs(core.registered_on_placenodes) do
 		-- Deepcopy pos, node and pointed_thing because callback can modify them
 		local place_to_copy = {x = place_to.x, y = place_to.y, z = place_to.z}
@@ -250,7 +248,7 @@ function doors.register(name, def)
 		inventory_image = def.inventory_image,
 
 		on_place = function(itemstack, placer, pointed_thing)
-			local pos = nil
+			local pos
 
 			if not pointed_thing.type == "node" then
 				return itemstack
@@ -314,7 +312,6 @@ function doors.register(name, def)
 			meta:set_int("state", state)
 
 			if def.protected then
-				local pn = placer:get_player_name()
 				meta:set_string("doors_owner", pn)
 				meta:set_string("infotext", "Owned by " .. pn)
 			end
@@ -347,7 +344,7 @@ function doors.register(name, def)
 			return true
 		end
 		local meta = minetest.get_meta(pos)
-		local name = ""
+		local name
 		if digger then
 			name = digger:get_player_name()
 		end

--- a/mods/farming/api.lua
+++ b/mods/farming/api.lua
@@ -319,11 +319,9 @@ farming.register_plant = function(name, def)
 		nodegroups[pname] = i
 
 		local next_plant = nil
-		local on_timer = nil
 
 		if i < def.steps then
 			next_plant = mname .. ":" .. pname .. "_" .. (i + 1)
-			on_timer = farming.grow_plant
 			lbm_nodes[#lbm_nodes + 1] = mname .. ":" .. pname .. "_" .. i
 		end
 

--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -284,8 +284,8 @@ else
 			local p = minetest.find_node_near(p0, 1, {"group:flammable"})
 			if p then
 				-- remove flammable nodes around flame
-				local node = minetest.get_node(p)
-				local def = minetest.registered_nodes[node.name]
+				local flammable_node = minetest.get_node(p)
+				local def = minetest.registered_nodes[flammable_node.name]
 				if def.on_burn then
 					def.on_burn(p)
 				else

--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -226,10 +226,10 @@ minetest.register_abm({
 	interval = 3,
 	chance = 1,
 	catch_up = false,
-	action = function(p0, node, _, _)
-		minetest.remove_node(p0)
+	action = function(pos, node, active_object_count, active_object_count_wider)
+		minetest.remove_node(pos)
 		minetest.sound_play("fire_extinguish_flame",
-			{pos = p0, max_hear_distance = 16, gain = 0.25})
+			{pos = pos, max_hear_distance = 16, gain = 0.25})
 	end,
 })
 
@@ -245,9 +245,7 @@ if minetest.setting_getbool("disable_fire") then
 		interval = 7,
 		chance = 1,
 		catch_up = false,
-		action = function(p0, node, _, _)
-			minetest.remove_node(p0)
-		end,
+		action = minetest.remove_node,
 	})
 
 else
@@ -260,12 +258,12 @@ else
 		interval = 7,
 		chance = 12,
 		catch_up = false,
-		action = function(p0, node, _, _)
+		action = function(pos, node, active_object_count, active_object_count_wider)
 			-- If there is water or stuff like that around node, don't ignite
-			if minetest.find_node_near(p0, 1, {"group:puts_out_fire"}) then
+			if minetest.find_node_near(pos, 1, {"group:puts_out_fire"}) then
 				return
 			end
-			local p = minetest.find_node_near(p0, 1, {"air"})
+			local p = minetest.find_node_near(pos, 1, {"air"})
 			if p then
 				minetest.set_node(p, {name = "fire:basic_flame"})
 			end
@@ -280,8 +278,8 @@ else
 		interval = 5,
 		chance = 18,
 		catch_up = false,
-		action = function(p0, node, _, _)
-			local p = minetest.find_node_near(p0, 1, {"group:flammable"})
+		action = function(pos, node, active_object_count, active_object_count_wider)
+			local p = minetest.find_node_near(pos, 1, {"group:flammable"})
 			if p then
 				-- remove flammable nodes around flame
 				local flammable_node = minetest.get_node(p)
@@ -309,13 +307,13 @@ minetest.register_abm({
 	neighbors = {"air"},
 	interval = 5,
 	chance = 10,
-	action = function(p0, node, _, _)
+	action = function(pos, node, active_object_count, active_object_count_wider)
 		local reg = minetest.registered_nodes[node.name]
 		if not reg or not reg.groups.igniter or reg.groups.igniter < 2 then
 			return
 		end
 		local d = reg.groups.igniter
-		local p = minetest.find_node_near(p0, d, {"group:flammable"})
+		local p = minetest.find_node_near(pos, d, {"group:flammable"})
 		if p then
 			-- If there is water or stuff like that around flame, don't ignite
 			if fire.flame_should_extinguish(p) then

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -12,7 +12,7 @@ local loss_prob = {}
 loss_prob["default:cobble"] = 3
 loss_prob["default:dirt"] = 4
 
-local radius = tonumber(minetest.setting_get("tnt_radius") or 3)
+local tnt_radius = tonumber(minetest.setting_get("tnt_radius") or 3)
 
 -- Fill a list with data for content IDs, after all nodes are registered
 local cid_data = {}
@@ -345,10 +345,10 @@ local function tnt_explode(pos, radius, ignore_protection, ignore_on_blast)
 	end
 	end
 
-	for _, data in ipairs(on_blast_queue) do
-		local dist = math.max(1, vector.distance(data.pos, pos))
+	for _, queued_data in ipairs(on_blast_queue) do
+		local dist = math.max(1, vector.distance(queued_data.pos, pos))
 		local intensity = (radius * radius) / (dist * dist)
-		local node_drops = data.on_blast(data.pos, intensity)
+		local node_drops = queued_data.on_blast(queued_data.pos, intensity)
 		if node_drops then
 			for _, item in ipairs(node_drops) do
 				add_drop(drops, item)
@@ -589,5 +589,5 @@ end
 tnt.register_tnt({
 	name = "tnt:tnt",
 	description = "TNT",
-	radius = radius,
+	radius = tnt_radius,
 })

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -153,7 +153,7 @@ local function entity_physics(pos, radius, drops)
 			local dir = vector.normalize(vector.subtract(obj_pos, pos))
 			local moveoff = vector.multiply(dir, dist + 1.0)
 			local newpos = vector.add(pos, moveoff)
-			local newpos = vector.add(newpos, {x = 0, y = 0.2, z = 0})
+			newpos = vector.add(newpos, {x = 0, y = 0.2, z = 0})
 			obj:setpos(newpos)
 
 			obj:set_hp(obj:get_hp() - damage)
@@ -261,7 +261,7 @@ function tnt.burn(pos)
 end
 
 local function tnt_explode(pos, radius, ignore_protection, ignore_on_blast)
-	local pos = vector.round(pos)
+	pos = vector.round(pos)
 	-- scan for adjacent TNT nodes first, and enlarge the explosion
 	local vm1 = VoxelManip()
 	local p1 = vector.subtract(pos, 2)
@@ -298,11 +298,11 @@ local function tnt_explode(pos, radius, ignore_protection, ignore_on_blast)
 	-- perform the explosion
 	local vm = VoxelManip()
 	local pr = PseudoRandom(os.time())
-	local p1 = vector.subtract(pos, radius)
-	local p2 = vector.add(pos, radius)
-	local minp, maxp = vm:read_from_map(p1, p2)
-	local a = VoxelArea:new({MinEdge = minp, MaxEdge = maxp})
-	local data = vm:get_data()
+	p1 = vector.subtract(pos, radius)
+	p2 = vector.add(pos, radius)
+	minp, maxp = vm:read_from_map(p1, p2)
+	a = VoxelArea:new({MinEdge = minp, MaxEdge = maxp})
+	data = vm:get_data()
 
 	local drops = {}
 	local on_blast_queue = {}
@@ -515,7 +515,7 @@ if enable_tnt then
 end
 
 function tnt.register_tnt(def)
-	local name = ""
+	local name
 	if not def.name:find(':') then
 		name = "tnt:" .. def.name
 	else


### PR DESCRIPTION
The first commit removes unused and cleans up misused variable-value assignments:
* Unused variables
* Unused values (assigned to variables, but overwritten before use)
* Defining already defined variables instead of reassigning to them.

The second (sort of a code style/suspicious construct clean up) removes all upvalue and definition overshadowing (e.g. through renaming). These might lead to and hide bugs, like using another value, as the intended one.

Both prepare `minetest_game` for a CI based lua linting (see #1165)