### PR TITLE
Let Travis-CI automatically lint the lua code of the game.

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,17 @@
+unused_args = false
+allow_defined_top = true
+
+read_globals = {
+	"DIR_DELIM",
+	"minetest", "core",
+	"dump",
+	"vector", "nodeupdate",
+	"VoxelManip", "VoxelArea",
+	"PseudoRandom", "ItemStack",
+}
+
+-- Overwrites minetest.handle_node_drops
+files["mods/creative/init.lua"].globals = { "minetest" }
+
+-- Don't report on legacy definitions of globals.
+files["mods/default/legacy.lua"].global = false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: generic
+
+branches:
+  only:
+    - master
+
+sudo: required
+
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install -y luarocks
+  - sudo luarocks install luacheck
+
+script: luacheck --no-color ./mods

--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -149,7 +149,7 @@ local function may_replace(pos, player)
 end
 
 local drop = function(pos, itemstack)
-	local obj = core.add_item(pos, itemstack:take_item(itemstack:get_count()))
+	local obj = minetest.add_item(pos, itemstack:take_item(itemstack:get_count()))
 	if obj then
 		obj:setvelocity({
 			x = math.random(-10, 10) / 9,

--- a/mods/bucket/init.lua
+++ b/mods/bucket/init.lua
@@ -141,7 +141,7 @@ minetest.register_craftitem("bucket:bucket_empty", {
 				else
 					local pos = user:getpos()
 					pos.y = math.floor(pos.y + 0.5)
-					core.add_item(pos, liquiddef.itemname)
+					minetest.add_item(pos, liquiddef.itemname)
 				end
 
 				-- set to return empty buckets minus 1

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -185,7 +185,7 @@ end
 local function on_place_node(place_to, newnode,
 	placer, oldnode, itemstack, pointed_thing)
 	-- Run script hook
-	for _, callback in ipairs(core.registered_on_placenodes) do
+	for _, callback in ipairs(minetest.registered_on_placenodes) do
 		-- Deepcopy pos, node and pointed_thing because callback can modify them
 		local place_to_copy = {x = place_to.x, y = place_to.y, z = place_to.z}
 		local newnode_copy =


### PR DESCRIPTION
The linter was tested successfully locally with the luacheck-configuration.
Travis-CI configuration was carefully crafted and online validated but no actual Travis-CI run was done for the repo, so there might still be some kinks to figure out (but that might require additional repository permissions towards travis+github integration)

This does not cover quite the same as the [smoketests](https://github.com/t4im/shakedown#smoketest), but would assure at least some lua best practices to be enforced before a PR by means of static code analysis (which means, contrary to shakedown's requirements, there is no minetest to be loaded first by travis).

#1164 provides fixes for any issues found (but can be applied independently to this PR), to get the repository to a passing-state.