### PR TITLE
Flowers: Make waterlily floodable

### DIFF
--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -224,6 +224,7 @@ minetest.register_node("flowers:waterlily", {
 	walkable = false,
 	buildable_to = true,
 	sunlight_propagates = true,
+	floodable = true,
 	groups = {snappy = 3, flower = 1},
 	sounds = default.node_sound_leaves_defaults(),
 	node_placement_prediction = "",


### PR DESCRIPTION
When waterlilies are placed near river water source make flowing river
water remove waterlilies instead of flowing around them in an ugly way
////////////////////////////////////////////////////////

Fix for #1166 