### PR TITLE
Always return the leftover ItemStack for on_place and on_rightclick

### DIFF
--- a/mods/beds/api.lua
+++ b/mods/beds/api.lua
@@ -91,8 +91,9 @@ function beds.register_bed(name, def)
 			destruct_bed(pos, 1)
 		end,
 
-		on_rightclick = function(pos, node, clicker)
+		on_rightclick = function(pos, node, clicker, itemstack, pointed_thing)
 			beds.on_rightclick(pos, clicker)
+			return itemstack
 		end,
 
 		on_rotate = function(pos, node, user, mode, new_param2)

--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -224,10 +224,10 @@ minetest.register_craftitem("boats:boat", {
 
 	on_place = function(itemstack, placer, pointed_thing)
 		if pointed_thing.type ~= "node" then
-			return
+			return itemstack
 		end
 		if not is_water(pointed_thing.under) then
-			return
+			return itemstack
 		end
 		pointed_thing.under.y = pointed_thing.under.y + 0.5
 		minetest.add_entity(pointed_thing.under, "boats:boat")

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1612,7 +1612,7 @@ minetest.register_node("default:chest_locked", {
 			" takes " .. stack:get_name()  ..
 			" from locked chest at " .. minetest.pos_to_string(pos))
 	end,
-	on_rightclick = function(pos, node, clicker)
+	on_rightclick = function(pos, node, clicker, itemstack, pointed_thing)
 		local meta = minetest.get_meta(pos)
 		if has_locked_chest_privilege(meta, clicker) then
 			minetest.show_formspec(
@@ -1621,6 +1621,7 @@ minetest.register_node("default:chest_locked", {
 				get_locked_chest_formspec(pos)
 			)
 		end
+		return itemstack
 	end,
 	on_blast = function() end,
 })

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -373,8 +373,9 @@ function doors.register(name, def)
 		sounds = { def.sound_close, def.sound_open },
 	}
 
-	def.on_rightclick = function(pos, node, clicker)
+	def.on_rightclick = function(pos, node, clicker, itemstack, pointed_thing)
 		_doors.door_toggle(pos, clicker)
+		return itemstack
 	end
 	def.after_dig_node = function(pos, node, meta, digger)
 		minetest.remove_node({x = pos.x, y = pos.y + 1, z = pos.z})
@@ -547,8 +548,9 @@ function doors.register_trapdoor(name, def)
 		return meta:get_string("doors_owner") == pn
 	end
 
-	def.on_rightclick = function(pos, node, clicker)
+	def.on_rightclick = function(pos, node, clicker, itemstack, pointed_thing)
 		_doors.trapdoor_toggle(pos, clicker)
+		return itemstack
 	end
 
 	-- Common trapdoor configuration
@@ -681,12 +683,13 @@ function doors.register_fencegate(name, def)
 		connect_sides = {"left", "right"},
 		groups = def.groups,
 		sounds = def.sounds,
-		on_rightclick = function(pos, clicker)
+		on_rightclick = function(pos, node, clicker, itemstack, pointed_thing)
 			local node = minetest.get_node(pos)
 			local node_def = minetest.registered_nodes[node.name]
 			minetest.swap_node(pos, {name = node_def.gate, param2 = node.param2})
 			minetest.sound_play(node_def.sound, {pos = pos, gain = 0.3,
 				max_hear_distance = 8})
+			return itemstack
 		end,
 		selection_box = {
 			type = "fixed",

--- a/mods/farming/api.lua
+++ b/mods/farming/api.lua
@@ -133,10 +133,10 @@ farming.place_seed = function(itemstack, placer, pointed_thing, plantname)
 	local pt = pointed_thing
 	-- check if pointing at a node
 	if not pt then
-		return
+		return itemstack
 	end
 	if pt.type ~= "node" then
-		return
+		return itemstack
 	end
 
 	local under = minetest.get_node(pt.under)
@@ -153,25 +153,25 @@ farming.place_seed = function(itemstack, placer, pointed_thing, plantname)
 
 	-- return if any of the nodes is not registered
 	if not minetest.registered_nodes[under.name] then
-		return
+		return itemstack
 	end
 	if not minetest.registered_nodes[above.name] then
-		return
+		return itemstack
 	end
 
 	-- check if pointing at the top of the node
 	if pt.above.y ~= pt.under.y+1 then
-		return
+		return itemstack
 	end
 
 	-- check if you can replace the node above the pointed node
 	if not minetest.registered_nodes[above.name].buildable_to then
-		return
+		return itemstack
 	end
 
 	-- check if pointing at soil
 	if minetest.get_item_group(under.name, "soil") < 2 then
-		return
+		return itemstack
 	end
 
 	-- add the node and remove 1 item from the itemstack

--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -251,8 +251,8 @@ minetest.register_node("flowers:waterlily", {
 			end
 			if not minetest.setting_getbool("creative_mode") then
 				itemstack:take_item()
-				return itemstack
 			end
 		end
+		return itemstack
 	end
 })


### PR DESCRIPTION
This should cover nearly **all** the cases in which `ItemStack`s weren't properly returned, as instructed by the API.

The only exception is the scenario for `on_rightclick` functions, when no itemstack was provided (as is allowed by the api). In that case **`nil`** is passed along, as it came in. I'm not entirely sure if it would be better to return empty `ItemStack(nil)` instead or treat this scenario as the sole exception to the rule, so i left it unchanged.