### PR TITLE
Ores: Clean up. Simplify. Add ores for upper realms

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -141,6 +141,17 @@ function default.register_ores()
 		ore            = "default:stone_with_coal",
 		wherein        = "default:stone",
 		clust_scarcity = 8 * 8 * 8,
+		clust_num_ores = 9,
+		clust_size     = 3,
+		y_min          = 1025,
+		y_max          = 31000,
+	})
+
+	minetest.register_ore({
+		ore_type       = "scatter",
+		ore            = "default:stone_with_coal",
+		wherein        = "default:stone",
+		clust_scarcity = 8 * 8 * 8,
 		clust_num_ores = 8,
 		clust_size     = 3,
 		y_min          = -31000,
@@ -159,6 +170,17 @@ function default.register_ores()
 	})
 
 	-- Iron
+
+	minetest.register_ore({
+		ore_type       = "scatter",
+		ore            = "default:stone_with_iron",
+		wherein        = "default:stone",
+		clust_scarcity = 9 * 9 * 9,
+		clust_num_ores = 12,
+		clust_size     = 3,
+		y_min          = 1025,
+		y_max          = 31000,
+	})
 
 	minetest.register_ore({
 		ore_type       = "scatter",
@@ -210,6 +232,17 @@ function default.register_ores()
 		ore_type       = "scatter",
 		ore            = "default:stone_with_copper",
 		wherein        = "default:stone",
+		clust_scarcity = 9 * 9 * 9,
+		clust_num_ores = 5,
+		clust_size     = 3,
+		y_min          = 1025,
+		y_max          = 31000,
+	})
+
+	minetest.register_ore({
+		ore_type       = "scatter",
+		ore            = "default:stone_with_copper",
+		wherein        = "default:stone",
 		clust_scarcity = 12 * 12 * 12,
 		clust_num_ores = 4,
 		clust_size     = 3,
@@ -229,6 +262,17 @@ function default.register_ores()
 	})
 
 	-- Gold
+
+	minetest.register_ore({
+		ore_type       = "scatter",
+		ore            = "default:stone_with_gold",
+		wherein        = "default:stone",
+		clust_scarcity = 13 * 13 * 13,
+		clust_num_ores = 5,
+		clust_size     = 3,
+		y_min          = 1025,
+		y_max          = 31000,
+	})
 
 	minetest.register_ore({
 		ore_type       = "scatter",
@@ -258,6 +302,17 @@ function default.register_ores()
 		ore_type       = "scatter",
 		ore            = "default:stone_with_mese",
 		wherein        = "default:stone",
+		clust_scarcity = 14 * 14 * 14,
+		clust_num_ores = 5,
+		clust_size     = 3,
+		y_min          = 1025,
+		y_max          = 31000,
+	})
+
+	minetest.register_ore({
+		ore_type       = "scatter",
+		ore            = "default:stone_with_mese",
+		wherein        = "default:stone",
 		clust_scarcity = 18 * 18 * 18,
 		clust_num_ores = 3,
 		clust_size     = 2,
@@ -282,6 +337,17 @@ function default.register_ores()
 		ore_type       = "scatter",
 		ore            = "default:stone_with_diamond",
 		wherein        = "default:stone",
+		clust_scarcity = 15 * 15 * 15,
+		clust_num_ores = 4,
+		clust_size     = 3,
+		y_min          = 1025,
+		y_max          = 31000,
+	})
+
+	minetest.register_ore({
+		ore_type       = "scatter",
+		ore            = "default:stone_with_diamond",
+		wherein        = "default:stone",
 		clust_scarcity = 17 * 17 * 17,
 		clust_num_ores = 4,
 		clust_size     = 3,
@@ -301,6 +367,17 @@ function default.register_ores()
 	})
 
 	-- Mese block
+
+	minetest.register_ore({
+		ore_type       = "scatter",
+		ore            = "default:mese",
+		wherein        = "default:stone",
+		clust_scarcity = 36 * 36 * 36,
+		clust_num_ores = 3,
+		clust_size     = 2,
+		y_min          = 1025,
+		y_max          = 31000,
+	})
 
 	minetest.register_ore({
 		ore_type       = "scatter",

--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -186,33 +186,11 @@ function default.register_ores()
 		ore_type       = "scatter",
 		ore            = "default:stone_with_iron",
 		wherein        = "default:stone",
-		clust_scarcity = 12 * 12 * 12,
-		clust_num_ores = 3,
-		clust_size     = 2,
-		y_min          = -15,
-		y_max          = 0,
-	})
-
-	minetest.register_ore({
-		ore_type       = "scatter",
-		ore            = "default:stone_with_iron",
-		wherein        = "default:stone",
-		clust_scarcity = 9 * 9 * 9,
-		clust_num_ores = 5,
-		clust_size     = 3,
-		y_min          = -63,
-		y_max          = -16,
-	})
-
-	minetest.register_ore({
-		ore_type       = "scatter",
-		ore            = "default:stone_with_iron",
-		wherein        = "default:stone",
 		clust_scarcity = 7 * 7 * 7,
 		clust_num_ores = 5,
 		clust_size     = 3,
 		y_min          = -31000,
-		y_max          = -64,
+		y_max          = 0,
 	})
 
 	minetest.register_ore({

--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -42,12 +42,12 @@ minetest.register_alias("mapgen_stair_sandstonebrick", "stairs:stair_sandstonebr
 -- Register ores
 --
 
--- All mapgens except singlenode
--- Blob ore first to avoid other ores inside blobs
-
 function default.register_ores()
+	-- Blob ores
+	-- These first to avoid other ores in blobs
 
 	-- Clay
+	-- This first to avoid clay in sand blobs
 
 	minetest.register_ore({ 
 		ore_type        = "blob",
@@ -78,7 +78,7 @@ function default.register_ores()
 		clust_scarcity  = 16 * 16 * 16,
 		clust_size      = 5,
 		y_min           = -31,
-		y_max           = 4,
+		y_max           = 0,
 		noise_threshold = 0.0,
 		noise_params    = {
 			offset = 0.5,
@@ -95,7 +95,7 @@ function default.register_ores()
 	minetest.register_ore({
 		ore_type        = "blob",
 		ore             = "default:dirt",
-		wherein         = {"default:stone", "default:sandstone"},
+		wherein         = {"default:stone"},
 		clust_scarcity  = 16 * 16 * 16,
 		clust_size      = 5,
 		y_min           = -31,
@@ -132,6 +132,8 @@ function default.register_ores()
 		},
 	})
 
+	-- Scatter ores
+
 	-- Coal
 
 	minetest.register_ore({
@@ -166,7 +168,7 @@ function default.register_ores()
 		clust_num_ores = 3,
 		clust_size     = 2,
 		y_min          = -15,
-		y_max          = 2,
+		y_max          = 0,
 	})
 
 	minetest.register_ore({
@@ -202,39 +204,28 @@ function default.register_ores()
 		y_max          = -64,
 	})
 
-	--Mese
+	-- Copper
 
 	minetest.register_ore({
 		ore_type       = "scatter",
-		ore            = "default:stone_with_mese",
+		ore            = "default:stone_with_copper",
 		wherein        = "default:stone",
-		clust_scarcity = 18 * 18 * 18,
-		clust_num_ores = 3,
-		clust_size     = 2,
-		y_min          = -255,
-		y_max          = -64,
+		clust_scarcity = 12 * 12 * 12,
+		clust_num_ores = 4,
+		clust_size     = 3,
+		y_min          = -63,
+		y_max          = -16,
 	})
 
 	minetest.register_ore({
 		ore_type       = "scatter",
-		ore            = "default:stone_with_mese",
+		ore            = "default:stone_with_copper",
 		wherein        = "default:stone",
-		clust_scarcity = 14 * 14 * 14,
+		clust_scarcity = 9 * 9 * 9,
 		clust_num_ores = 5,
 		clust_size     = 3,
 		y_min          = -31000,
-		y_max          = -256,
-	})
-
-	minetest.register_ore({
-		ore_type       = "scatter",
-		ore            = "default:mese",
-		wherein        = "default:stone",
-		clust_scarcity = 36 * 36 * 36,
-		clust_num_ores = 3,
-		clust_size     = 2,
-		y_min          = -31000,
-		y_max          = -1024,
+		y_max          = -64,
 	})
 
 	-- Gold
@@ -255,6 +246,30 @@ function default.register_ores()
 		ore            = "default:stone_with_gold",
 		wherein        = "default:stone",
 		clust_scarcity = 13 * 13 * 13,
+		clust_num_ores = 5,
+		clust_size     = 3,
+		y_min          = -31000,
+		y_max          = -256,
+	})
+
+	-- Mese crystal
+
+	minetest.register_ore({
+		ore_type       = "scatter",
+		ore            = "default:stone_with_mese",
+		wherein        = "default:stone",
+		clust_scarcity = 18 * 18 * 18,
+		clust_num_ores = 3,
+		clust_size     = 2,
+		y_min          = -255,
+		y_max          = -64,
+	})
+
+	minetest.register_ore({
+		ore_type       = "scatter",
+		ore            = "default:stone_with_mese",
+		wherein        = "default:stone",
+		clust_scarcity = 14 * 14 * 14,
 		clust_num_ores = 5,
 		clust_size     = 3,
 		y_min          = -31000,
@@ -285,28 +300,17 @@ function default.register_ores()
 		y_max          = -256,
 	})
 
-	-- Copper
+	-- Mese block
 
 	minetest.register_ore({
 		ore_type       = "scatter",
-		ore            = "default:stone_with_copper",
+		ore            = "default:mese",
 		wherein        = "default:stone",
-		clust_scarcity = 12 * 12 * 12,
-		clust_num_ores = 4,
-		clust_size     = 3,
-		y_min          = -63,
-		y_max          = -16,
-	})
-
-	minetest.register_ore({
-		ore_type       = "scatter",
-		ore            = "default:stone_with_copper",
-		wherein        = "default:stone",
-		clust_scarcity = 9 * 9 * 9,
-		clust_num_ores = 5,
-		clust_size     = 3,
+		clust_scarcity = 36 * 36 * 36,
+		clust_num_ores = 3,
+		clust_size     = 2,
 		y_min          = -31000,
-		y_max          = -64,
+		y_max          = -1024,
 	})
 end
 


### PR DESCRIPTION
1st commit:
Default/mapgen: Clean up ore registrations

Re-order registrations
Add and improve comments
Change sand blob ymax to 0 as sand does not always rise above 0
Remove dirt blobs from sandstone as it is unsuitable for
many sandstone biomes and ugly in stony sandstone desert
Change ymax of first iron region to 0

2nd commit:
Default/mapgen: Add ores above y = 1024

Each ore's rarity is equal to that occuring below y= -1024

3rd commit:
Default/mapgen: Simplify iron ore registrations

Preserve overlapping registrations of large and small clusters
below y = -64 but now extend the small clusters up to y = 0 (the
previous highest iron ore level) in a similar to way to coal
///////////////////////////

New version of #1172 

Where an ore has overlapping registrations below y = -1024 i have calculated the combined density and recreated it exactly above y = 1024 with a single registration.

2 of the iron ore registrations were almost redundant: one only being in effect over 16 vertical nodes, the other being similar to the smaller clusters below y = -64. So the smaller clusters below y = -64 have been extended up to y = 0. The iron registrations are now similar to those of coal as well as being simplified.

Every ore now has no more than 3 registrations: 2 for underground/surface and 1 for upper realms.