### PR TITLE
Sethome: Clean up loading I/O.

### DIFF
--- a/mods/sethome/init.lua
+++ b/mods/sethome/init.lua
@@ -2,22 +2,16 @@ local homes_file = minetest.get_worldpath() .. "/homes"
 local homepos = {}
 
 local function loadhomes()
-    local input = io.open(homes_file, "r")
-    if input then
-		repeat
-            local x = input:read("*n")
-            if x == nil then
-            	break
-            end
-            local y = input:read("*n")
-            local z = input:read("*n")
-            local name = input:read("*l")
-            homepos[name:sub(2)] = {x = x, y = y, z = z}
-        until input:read(0) == nil
-        io.close(input)
-    else
-        homepos = {}
-    end
+	local input, err = io.open(homes_file, "r")
+	if not input then
+		return minetest.log("info", "Could not load player homes file: " .. err)
+	end
+
+	-- Iterate over all stored positions in the format "x y z player" each line
+	for pos, name in input:read("*a"):gmatch("(%S+ %S+ %S+)%s([%w_-]+)[\r\n]") do
+		homepos[name] = minetest.string_to_pos(pos)
+	end
+	input:close()
 end
 
 loadhomes()


### PR DESCRIPTION
It's faster and cleaner to read a complete file in and then operate on it via string operations, than having to read it number for number in a loop, causing unnecessary reads.
(The only reason not to read it all at once, would be if the file in question would be too big to fit in memory. But since it's stored there in the end anyway, there is no point to that. Even then you would rather use `io.lines`.)

A single iterated `string.match` per line is enough here.

Errors should never be thrown away, but printed to the log to aid problem solving.