### PR TITLE
Fix bucket crash, but allow placing against unknown nodes instead.

### DIFF
--- a/mods/bucket/init.lua
+++ b/mods/bucket/init.lua
@@ -60,16 +60,10 @@ function bucket.register_liquid(source, flowing, itemname, inventory_image, name
 				end
 
 				local node = minetest.get_node_or_nil(pointed_thing.under)
-				if not node then
-					return
-				end
-				local ndef = minetest.registered_nodes[node.name]
-				if not ndef then
-					return
-				end
+				local ndef = node and minetest.registered_nodes[node.name]
 
 				-- Call on_rightclick if the pointed node defines it
-				if ndef.on_rightclick and
+				if ndef and ndef.on_rightclick and
 				   user and not user:get_player_control().sneak then
 					return ndef.on_rightclick(
 						pointed_thing.under,
@@ -80,7 +74,7 @@ function bucket.register_liquid(source, flowing, itemname, inventory_image, name
 				local lpos
 
 				-- Check if pointing to a buildable node
-				if ndef.buildable_to then
+				if ndef and ndef.buildable_to then
 					-- buildable; replace the node
 					lpos = pointed_thing.under
 				else

--- a/mods/bucket/init.lua
+++ b/mods/bucket/init.lua
@@ -88,10 +88,11 @@ function bucket.register_liquid(source, flowing, itemname, inventory_image, name
 					-- check if the node above can be replaced
 					lpos = pointed_thing.above
 					local node = minetest.get_node_or_nil(lpos)
-					if not node
-					or not minetest.registered_nodes[node.name].buildable_to then
+					local above_ndef = node and minetest.registered_nodes[node.name]
+
+					if not above_ndef or not above_ndef.buildable_to then
 						-- do not remove the bucket with the liquid
-						return
+						return itemstack
 					end
 				end
 


### PR DESCRIPTION
This crashed before, when placing against a solid node (a slab for example) into an unknown node (as pointed_thing.above).

The second commit prevents the function from returning too early, because of an attempt to place against an unknown node (which does need no prevention)