### PR TITLE
Same naming for trapdoors as for doors

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -533,6 +533,10 @@ function _doors.trapdoor_toggle(pos, node, clicker)
 end
 
 function doors.register_trapdoor(name, def)
+	if not name:find(":") then
+		name = "doors:" .. name
+	end
+	
 	local name_closed = name
 	local name_opened = name.."_open"
 


### PR DESCRIPTION
This makes the register_trapdoor acting the same like the register_door function. If `name` isn't prefixed, it will be prefixed with "doors:".