### PR TITLE
Make trapdoor textures work as expected.

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -600,8 +600,10 @@ function doors.register_trapdoor(name, def)
 		type = "fixed",
 		fixed = {-0.5, -0.5, -0.5, 0.5, -6/16, 0.5}
 	}
-	def_closed.tiles = {def.tile_front, def.tile_front, def.tile_side, def.tile_side,
-		def.tile_side, def.tile_side}
+	def_closed.tiles = {def.tile_front,
+			def.tile_front .. '^[transformFY',
+			def.tile_side, def.tile_side,
+			def.tile_side, def.tile_side}
 
 	def_opened.node_box = {
 		type = "fixed",
@@ -614,7 +616,8 @@ function doors.register_trapdoor(name, def)
 	def_opened.tiles = {def.tile_side, def.tile_side,
 			def.tile_side .. '^[transform3',
 			def.tile_side .. '^[transform1',
-			def.tile_front, def.tile_front}
+			def.tile_front .. '^[transform46',
+			def.tile_front .. '^[transform6'}
 
 	def_opened.drop = name_closed
 	def_opened.groups.not_in_creative_inventory = 1


### PR DESCRIPTION
Until now, if the texture was not symmetric, the trapdoor textures looked impossible.
This PR fixes that problem. The top of the texture is now always on the hinge side of the trapdoor.