### PR TITLE
Default: Remove mese crystal to mese block crafting

### DIFF
--- a/mods/default/crafting.lua
+++ b/mods/default/crafting.lua
@@ -588,15 +588,6 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-	output = 'default:mese',
-	recipe = {
-		{'default:mese_crystal', 'default:mese_crystal', 'default:mese_crystal'},
-		{'default:mese_crystal', 'default:mese_crystal', 'default:mese_crystal'},
-		{'default:mese_crystal', 'default:mese_crystal', 'default:mese_crystal'},
-	}
-})
-
-minetest.register_craft({
 	output = 'default:mese_crystal 9',
 	recipe = {
 		{'default:mese'},


### PR DESCRIPTION
See #1171 

"Although this will cause some updating to be done i feel it's worth it.

Mese block is something found at y = -1024, so a mod using these in a recipe but as something crafted from mese crystals is strange, just use mese crystal in the recipe instead. Mese crystal is essentially the drop-in replacement for the old mese block, and has the same value as it. Mese block therefore was multiplied in value and made deeper and rarer, it became a new high-value material, which is exactly what Minetest needed, but then this good idea was undermined  by making it craftable from crystals.

The fact is, if a mese block is in a recipe you are, in a way, asking for something from y = -1024.
I think it would be a good thing to force some mods to update their weird recipes.

What happened to mese years ago was a bit of a mess and it's time to put it right."

For less disruption i decided to not touch crafting of mese crystal fragments into mese crystals, or obsidian shards into obsidian.