### PR TITLE
Replace deprecated get_look_yaw/set_look_yaw

### DIFF
--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -70,7 +70,7 @@ local function lay_down(player, pos, bed_pos, state, skip)
 
 		-- physics, eye_offset, etc
 		player:set_eye_offset({x = 0, y = 0, z = 0}, {x = 0, y = 0, z = 0})
-		player:set_look_yaw(math.random(1, 180) / 100)
+		player:set_look_horizontal(math.random(1, 180) / 100)
 		default.player_attached[name] = false
 		player:set_physics_override(1, 1, 1)
 		hud_flags.wielditem = true
@@ -85,7 +85,7 @@ local function lay_down(player, pos, bed_pos, state, skip)
 		-- physics, eye_offset, etc
 		player:set_eye_offset({x = 0, y = -13, z = 0}, {x = 0, y = 0, z = 0})
 		local yaw, param2 = get_look_yaw(bed_pos)
-		player:set_look_yaw(yaw)
+		player:set_look_horizontal(yaw)
 		local dir = minetest.facedir_to_dir(param2)
 		local p = {x = bed_pos.x + dir.x / 2, y = bed_pos.y, z = bed_pos.z + dir.z / 2}
 		player:set_physics_override(0, 0, 0)

--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -79,7 +79,7 @@ function boat.on_rightclick(self, clicker)
 		minetest.after(0.2, function()
 			default.player_set_animation(clicker, "sit" , 30)
 		end)
-		self.object:setyaw(clicker:get_look_yaw() - math.pi / 2)
+		self.object:setyaw(clicker:get_look_horizontal() - math.pi / 2)
 	end
 end
 


### PR DESCRIPTION
@everamzah There is no `get_look_pitch` call in MTG, could it be that another mod must be fixed?
Pull for #1199