### PR TITLE
Doors: fix crash for placing under unknown nodes, and on nil-player

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -273,8 +273,10 @@ function doors.register(name, def)
 			end
 
 			local above = {x = pos.x, y = pos.y + 1, z = pos.z}
-			if not minetest.registered_nodes[
-				minetest.get_node(above).name].buildable_to then
+			local top_node = minetest.get_node_or_nil(above)
+			local topdef = top_node and minetest.registered_nodes[top_node.name]
+
+			if not topdef or not topdef.buildable_to then
 				return itemstack
 			end
 


### PR DESCRIPTION
First commit should fix a more frequent crash, because converted doors from old worlds spawned unknown nodes for the top node of the door.
When a new door would be placed underneath, this crash would be triggered.

Second commit moves both `can_dig`s out of the registration functions and only sets them for protected doors.
It also prevents a crash on `nil`-player and replaces `minetest.check_player_privs` with the more direct

```lua
minetest.get_player_privs(clicker_name).protection_bypass
```

This spares us a set->list conversion, because we only check a single priv and are not interested in getting a list returned.
(That's also why i didn't fix this in https://github.com/minetest/minetest/pull/4296)