### PR TITLE
Bones: Iterate player inventory lists dynamically.

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -62,6 +62,15 @@ Beds API
 		}
 	}
 
+Bones API
+---------
+
+An ordered list of listnames (default: "main", "craft") of the player inventory,
+that will be placed into bones or dropped on player death can be looked up or changed
+in `bones.player_inventory_lists`.
+
+e.g. `table.insert(bones.player_inventory_lists, "backpack")`
+
 Creative API
 ------------
 


### PR DESCRIPTION
Avoid hard-coded player inventory lists.
Expose `bones.player_inventory_lists` for mods to look up or change,
which player inventory lists are being dropped or placed into bones.

Addresses #1148, but without global callback registrations.
Unless more encapsulation is wanted?
