### PR TITLE
Doors: Allow the screwdriver to rotate doors around y-axis.

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -348,7 +348,7 @@ To use it, add the `on_screwdriver` function to the node definition.
  * `new_param2` the new value of param2 that would have been set if on_rotate wasn't there
  * return value: false to disallow rotation, nil to keep default behaviour, true to allow
  	it but to indicate that changed have already been made (so the screwdriver will wear out)
- * use `on_rotate = screwdriver.disallow` to always disallow rotation
+ * use `on_rotate = false` to always disallow rotation
  * use `on_rotate = screwdriver.rotate_simple` to allow only face rotation
 
 

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -374,9 +374,7 @@ function doors.register(name, def)
 		minetest.remove_node({x = pos.x, y = pos.y + 1, z = pos.z})
 		nodeupdate({x = pos.x, y = pos.y + 1, z = pos.z})
 	end
-	def.on_rotate = function(pos, node, user, mode, new_param2)
-		return false
-	end
+	def.on_rotate = screwdriver and screwdriver.rotate_simple or false
 
 	if def.protected then
 		def.can_dig = can_dig_door

--- a/mods/screwdriver/init.lua
+++ b/mods/screwdriver/init.lua
@@ -64,6 +64,7 @@ screwdriver.handler = function(itemstack, user, pointed_thing, mode, uses)
 		end
 	else
 		if not ndef or not ndef.paramtype2 == "facedir" or
+				ndef.on_rotate == false or
 				(ndef.drawtype == "nodebox" and
 				not ndef.node_box.type == "fixed") or
 				node.param2 == nil then


### PR DESCRIPTION
This is a trivial fix for #904, as suggested by @kilbith, which is also used by homedecor/xdecor for a while already.

@sofar mentioned plans to maybe support all the axis' in the future, but because he is currently busy, this trivial fix can help players with simple y-axis rotation in the meantime.

Other axis' stay disabled until then, because it would leave the placeholder node irremovable to players. Its open/close behavior would likely not work as expected either.