### PR TITLE
Doors: Trim open fence gate collision box

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -706,7 +706,7 @@ function doors.register_fencegate(name, def)
 	fence_open.collision_box = {
 		type = "fixed",
 		fixed = {{-1/2, -1/2, -1/4, -3/8, 1/2, 1/4},
-			{-5/8, -3/8, -14/16, -3/8, 3/8, 0}},
+			{-5/8, -3/8, -1/2, -3/8, 3/8, 0}},
 	}
 
 	minetest.register_node(":" .. name .. "_closed", fence_closed)


### PR DESCRIPTION
Previously, the collision box extended into an empty node, causing
falling node objects to land on the open gate but not transform
back into normal nodes. Now fallng node objects will fall through and
either side of the end of the open gate and transform back.
///////////////////////////////////////////////////

Fix for issue 1 of #1193 

![screenshot_20160803_014903](https://cloud.githubusercontent.com/assets/3686677/17350304/65a38b62-591d-11e6-967e-19aa3768eb35.png)

![screenshot_20160803_015111](https://cloud.githubusercontent.com/assets/3686677/17350309/6a56cb06-591d-11e6-9e28-31ccaa5be62b.png)

^ With this commit.

This may be temporary, but having loose material falling either side of the gate tip seems and looks reasonable.
Because the gate collision box extends to the node edge the player still collides with the open gate when close to the hinges, so it retains a feel of solidity.