### PR TITLE
fix tnt bug with huge stacks

### DIFF
--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -47,10 +47,7 @@ end
 local function eject_drops(drops, pos, radius)
 	local drop_pos = vector.new(pos)
 	for _, item in pairs(drops) do
-		local count = item:get_count()
-		if count > 99 then
-			count = 99 -- limit overly large stacks
-		end
+		local count = math.min(item:get_count(), 99)
 		while count > 0 do
 			local take = math.max(1,math.min(radius * radius,
 					count,

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -48,6 +48,9 @@ local function eject_drops(drops, pos, radius)
 	local drop_pos = vector.new(pos)
 	for _, item in pairs(drops) do
 		local count = item:get_count()
+		if count > 99 then
+			count = 99 -- limit overly large stacks
+		end
 		while count > 0 do
 			local take = math.max(1,math.min(radius * radius,
 					count,


### PR DESCRIPTION
This fixes the TNT bug that can crash game when blowing up a container which holds huge stacks above the norm... e.g. give yourself 65535 snow, place in chest, blow up, stalled!