### PR TITLE
Simplify leafdecay function

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -328,8 +328,8 @@ minetest.register_abm({
 		local itemstacks = minetest.get_node_drops(node.name)
 		for _, itemname in pairs(itemstacks) do
 
-			if minetest.get_item_group(node.name, "leafdecay_drop") ~= 0
-			or itemname ~= node.name then
+			if itemname ~= node.name or
+				minetest.get_item_group(node.name, "leafdecay_drop") ~= 0 then
 
 				local p_drop = {
 					x = p0.x - 0.5 + math.random(),

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -283,17 +283,6 @@ end
 -- Leafdecay
 --
 
-default.leafdecay_trunk_cache = {}
-default.leafdecay_enable_cache = true
--- Spread the load of finding trunks
-default.leafdecay_trunk_find_allow_accumulator = 0
-
-minetest.register_globalstep(function(dtime)
-	local finds_per_second = 5000
-	default.leafdecay_trunk_find_allow_accumulator =
-			math.floor(dtime * finds_per_second)
-end)
-
 default.after_place_leaves = function(pos, placer, itemstack, pointed_thing)
 	if placer and not placer:get_player_control().sneak then
 		local node = minetest.get_node(pos)
@@ -303,78 +292,58 @@ default.after_place_leaves = function(pos, placer, itemstack, pointed_thing)
 end
 
 minetest.register_abm({
+	label = "Leaf decay",
 	nodenames = {"group:leafdecay"},
-	neighbors = {"air", "group:liquid"},
+	neighbors = {"air"},
 	-- A low interval and a high inverse chance spreads the load
 	interval = 2,
 	chance = 5,
+	catch_up = false,
 
 	action = function(p0, node, _, _)
 		--print("leafdecay ABM at "..p0.x..", "..p0.y..", "..p0.z..")")
-		local do_preserve = false
+
 		local d = minetest.registered_nodes[node.name].groups.leafdecay
-		if not d or d == 0 then
-			--print("not groups.leafdecay")
+		if d < 1 then
+			--print("groups.leafdecay not set")
 			return
 		end
-		local n0 = minetest.get_node(p0)
-		if n0.param2 ~= 0 then
+
+		if minetest.get_node(p0).param2 ~= 0 then
 			--print("param2 ~= 0")
 			return
 		end
-		local p0_hash = nil
-		if default.leafdecay_enable_cache then
-			p0_hash = minetest.hash_node_position(p0)
-			local trunkp = default.leafdecay_trunk_cache[p0_hash]
-			if trunkp then
-				local n = minetest.get_node(trunkp)
-				local reg = minetest.registered_nodes[n.name]
-				-- Assume ignore is a trunk, to make the thing
-				-- work at the border of the active area
-				if n.name == "ignore" or (reg and reg.groups.tree and
-						reg.groups.tree ~= 0) then
-					--print("cached trunk still exists")
-					return
-				end
-				--print("cached trunk is invalid")
-				-- Cache is invalid
-				table.remove(default.leafdecay_trunk_cache, p0_hash)
-			end
-		end
-		if default.leafdecay_trunk_find_allow_accumulator <= 0 then
-			return
-		end
-		default.leafdecay_trunk_find_allow_accumulator =
-				default.leafdecay_trunk_find_allow_accumulator - 1
+
 		-- Assume ignore is a trunk, to make the thing
 		-- work at the border of the active area
-		local p1 = minetest.find_node_near(p0, d, {"ignore", "group:tree"})
-		if p1 then
-			do_preserve = true
-			if default.leafdecay_enable_cache then
-				--print("caching trunk")
-				-- Cache the trunk
-				default.leafdecay_trunk_cache[p0_hash] = p1
+		if #minetest.find_nodes_in_area(
+			{x = p0.x - d, y = p0.y - d, z = p0.z - d},
+			{x = p0.x + d, y = p0.y + d, z = p0.z + d},
+			{"ignore", "group:tree"}) > 0 then
+
+			return
+		end
+
+		-- Drop stuff other than the node itself
+		local itemstacks = minetest.get_node_drops(node.name)
+		for _, itemname in pairs(itemstacks) do
+
+			if minetest.get_item_group(node.name, "leafdecay_drop") ~= 0
+			or itemname ~= node.name then
+
+				local p_drop = {
+					x = p0.x - 0.5 + math.random(),
+					y = p0.y - 0.5 + math.random(),
+					z = p0.z - 0.5 + math.random(),
+				}
+
+				minetest.add_item(p_drop, itemname)
 			end
 		end
-		if not do_preserve then
-			-- Drop stuff other than the node itself
-			local itemstacks = minetest.get_node_drops(n0.name)
-			for _, itemname in ipairs(itemstacks) do
-				if minetest.get_item_group(n0.name, "leafdecay_drop") ~= 0 or
-						itemname ~= n0.name then
-					local p_drop = {
-						x = p0.x - 0.5 + math.random(),
-						y = p0.y - 0.5 + math.random(),
-						z = p0.z - 0.5 + math.random(),
-					}
-					minetest.add_item(p_drop, itemname)
-				end
-			end
-			-- Remove node
-			minetest.remove_node(p0)
-			nodeupdate(p0)
-		end
+
+		-- Remove node
+		minetest.remove_node(p0)
+		nodeupdate(p0)
 	end
 })
 

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -309,7 +309,7 @@ minetest.register_abm({
 			return
 		end
 
-		if minetest.get_node(p0).param2 ~= 0 then
+		if node.param2 ~= 0 then
 			--print("param2 ~= 0")
 			return
 		end


### PR DESCRIPTION
Simplify Leafdecay function by removing leaf cache and need for math.floor and defining un-needed local variables in the hope of speeding up code.