### PR TITLE
Fire: Use 'enable fire' setting instead of 'disable fire'

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -20,9 +20,9 @@
 # 0 to disable. By default it is "share_bones_time" divide by four.
 #share_bones_time_early = 300
 
-# Whether standard fire should be disabled ('basic flame' nodes will disappear)
-# 'permanent flame' nodes will remain with either setting
-#disable_fire = false
+# Whether fire should be enabled. If disabled, 'basic flame' nodes will disappear.
+# 'permanent flame' nodes will remain with either setting.
+#enable_fire = true
 
 # Whether the stuff in initial_stuff should be given to new players
 #give_initial_stuff = false

--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -235,9 +235,16 @@ minetest.register_abm({
 })
 
 
--- Enable the following ABMs according to 'disable fire' setting
+-- Enable the following ABMs according to 'enable fire' setting
 
-if minetest.setting_getbool("disable_fire") then
+local fire_enabled = minetest.setting_getbool("enable_fire")
+if fire_enabled == nil then
+	-- New setting not specified, check for old setting.
+	-- If old setting is also not specified, 'not nil' is true.
+	fire_enabled = not minetest.setting_getbool("disable_fire")
+end
+
+if not fire_enabled then
 
 	-- Remove basic flames only
 
@@ -250,7 +257,7 @@ if minetest.setting_getbool("disable_fire") then
 		action = minetest.remove_node,
 	})
 
-else
+else -- Fire enabled
 
 	-- Ignite neighboring nodes, add basic flames
 


### PR DESCRIPTION
Resubmission of part of #709 as PilzAdam is absent and this needs rebase and splitting from the settingtypes work.
Note that mtgame .conf is kept empty, so the absence of a setting should result in the default of that setting being chosen. This code ensures this as well as working with the old setting.