### PR TITLE
Added missing aliases for mushrooms from mushroom mod.

### DIFF
--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -208,6 +208,8 @@ minetest.register_alias("flowers:mushroom_spores_brown", "flowers:mushroom_brown
 minetest.register_alias("flowers:mushroom_spores_red", "flowers:mushroom_red")
 minetest.register_alias("flowers:mushroom_fertile_brown", "flowers:mushroom_brown")
 minetest.register_alias("flowers:mushroom_fertile_red", "flowers:mushroom_red")
+minetest.register_alias("mushroom:brown_natural", "flowers:mushroom_brown")
+minetest.register_alias("mushroom:red_natural, ", "flowers:mushroom_red")
 
 
 --

--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -209,7 +209,7 @@ minetest.register_alias("flowers:mushroom_spores_red", "flowers:mushroom_red")
 minetest.register_alias("flowers:mushroom_fertile_brown", "flowers:mushroom_brown")
 minetest.register_alias("flowers:mushroom_fertile_red", "flowers:mushroom_red")
 minetest.register_alias("mushroom:brown_natural", "flowers:mushroom_brown")
-minetest.register_alias("mushroom:red_natural, ", "flowers:mushroom_red")
+minetest.register_alias("mushroom:red_natural", "flowers:mushroom_red")
 
 
 --


### PR DESCRIPTION
minetest.register_alias("mushroom:brown_natural", "flowers:mushroom_brown")
minetest.register_alias("mushroom:red_natural, ", "flowers:mushroom_red")

Fixes https://github.com/minetest/minetest_game/issues/1264