### PR TITLE
Creative: Make dig times near-identical for nodes of all levels

### DIFF
--- a/mods/creative/init.lua
+++ b/mods/creative/init.lua
@@ -221,8 +221,8 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 end)
 
 if creative_mode then
-	local digtime = 0.5
-	local caps = {times = {digtime, digtime, digtime}, uses = 0, maxlevel = 3}
+	local digtime = 42
+	local caps = {times = {digtime, digtime, digtime}, uses = 0, maxlevel = 256}
 
 	minetest.register_item(":", {
 		type = "none",


### PR DESCRIPTION
Dig time is modified according to difference (leveldiff) between tool
'maxlevel' and node 'level'. Digtime is divided by the larger of leveldiff
and 1. In creative mode, where the hand is redefined to have maxlevel 3,
this results in higher level nodes taking significantly longer to break.

Now, to speed up building, hand 'maxlevel' and 'digtime' have been
increased such that nodes of differing levels have an insignificant
effect on digtime. Dig time for all nodes is now identical to that of, for
example, dirt nodes.
///////////////////////////////////////////////////

Addresses https://github.com/minetest/minetest/issues/4213 and my own irritation with some nodes being slow to break in creative mode.
Related to #1267 and https://github.com/minetest/minetest/issues/4462
Relevant code https://github.com/minetest/minetest/blob/master/src/tool.cpp#L129