### PR TITLE
Furnace: indicate dst full.

### DIFF
--- a/mods/default/furnace.lua
+++ b/mods/default/furnace.lua
@@ -175,7 +175,11 @@ local function furnace_node_timer(pos, elapsed)
 	local item_percent = 0
 	if cookable then
 		item_percent = math.floor(src_time / cooked.time * 100)
-		item_state = item_percent .. "%"
+		if item_percent > 100 then
+			item_state = "100% (output full)"
+		else
+			item_state = item_percent .. "%"
+		end
 	else
 		if srclist[1]:is_empty() then
 			item_state = "Empty"


### PR DESCRIPTION
Indicate in the infotext when a furnace has filled up `dst` but still
has fuel. The info text shows the item as 100% with added "(dst full)"
text, indicating that while it can cook the item, there is no place
for it in the `dst`. Emptying the `dst` should make the item cook
immediately and furnace resume normal operation.