### PR TITLE
Default: Vary wood burn times according to wood density

### DIFF
--- a/mods/default/crafting.lua
+++ b/mods/default/crafting.lua
@@ -780,11 +780,154 @@ minetest.register_craft({
 -- Fuels
 --
 
+-- Support use of group:tree
 minetest.register_craft({
 	type = "fuel",
 	recipe = "group:tree",
 	burntime = 30,
 })
+
+-- Burn time for all woods are in order of wood density,
+-- which is also the order of wood colour darkness:
+-- aspen, pine, apple, acacia, jungle
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:aspen_tree",
+	burntime = 22,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:pine_tree",
+	burntime = 26,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:tree",
+	burntime = 30,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:acacia_tree",
+	burntime = 34,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:jungletree",
+	burntime = 38,
+})
+
+
+-- Support use of group:wood
+minetest.register_craft({
+	type = "fuel",
+	recipe = "group:wood",
+	burntime = 7,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:aspen_wood",
+	burntime = 5,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:pine_wood",
+	burntime = 6,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:wood",
+	burntime = 7,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:acacia_wood",
+	burntime = 8,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:junglewood",
+	burntime = 9,
+})
+
+
+-- Support use of group:sapling
+minetest.register_craft({
+	type = "fuel",
+	recipe = "group:sapling",
+	burntime = 10,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:aspen_sapling",
+	burntime = 8,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:pine_sapling",
+	burntime = 9,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:sapling",
+	burntime = 10,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:acacia_sapling",
+	burntime = 11,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:junglesapling",
+	burntime = 12,
+})
+
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:fence_aspen_wood",
+	burntime = 11,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:fence_pine_wood",
+	burntime = 13,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:fence_wood",
+	burntime = 15,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:fence_acacia_wood",
+	burntime = 17,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:fence_junglewood",
+	burntime = 19,
+})
+
 
 minetest.register_craft({
 	type = "fuel",
@@ -818,44 +961,8 @@ minetest.register_craft({
 
 minetest.register_craft({
 	type = "fuel",
-	recipe = "default:fence_wood",
-	burntime = 15,
-})
-
-minetest.register_craft({
-	type = "fuel",
-	recipe = "default:fence_acacia_wood",
-	burntime = 15,
-})
-
-minetest.register_craft({
-	type = "fuel",
-	recipe = "default:fence_junglewood",
-	burntime = 15,
-})
-
-minetest.register_craft({
-	type = "fuel",
-	recipe = "default:fence_pine_wood",
-	burntime = 15,
-})
-
-minetest.register_craft({
-	type = "fuel",
-	recipe = "default:fence_aspen_wood",
-	burntime = 15,
-})
-
-minetest.register_craft({
-	type = "fuel",
 	recipe = "default:ladder_wood",
 	burntime = 5,
-})
-
-minetest.register_craft({
-	type = "fuel",
-	recipe = "group:wood",
-	burntime = 7,
 })
 
 minetest.register_craft({
@@ -886,12 +993,6 @@ minetest.register_craft({
 	type = "fuel",
 	recipe = "default:chest_locked",
 	burntime = 30,
-})
-
-minetest.register_craft({
-	type = "fuel",
-	recipe = "group:sapling",
-	burntime = 10,
 })
 
 minetest.register_craft({


### PR DESCRIPTION
Retain definitions for node groups to support mods.
Burn time is unchanged for applewood, and increases in the order:
aspen, pine, apple, acacia, jungle which is also the order of wood
colour darkness.
//////////////////////////////////////////////////

Rework of part of Wuzzy2's PR #1258 
I started with wood having time 7, and created the progression 5, 6, 7, 8, 9 around that.
For fences and trees the time steps become 2 and 4 to remain proportional.
For saplings the steps are also 1 because 10 is close to 7.
The definitions are re-ordered and group the varied woods at the start.