### PR TITLE
Find space for bones to appear

### DIFF
--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -180,9 +180,12 @@ minetest.register_on_dieplayer(function(player)
 	local pos = vector.round(player:getpos())
 	local player_name = player:get_player_name()
 
-	-- check if it's possible to place bones, if not go 1 higher
+	-- check if it's possible to place bones, if not go find space near player
 	if bones_mode == "bones" and not may_replace(pos, player) then
-		pos.y = pos.y + 1
+		local air = minetest.find_node_near(pos, 1, {"air"})
+		if air then
+			pos = air
+		end
 	end
 
 	-- still cannot place bones? change mode to 'drop'

--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -180,17 +180,14 @@ minetest.register_on_dieplayer(function(player)
 	local pos = vector.round(player:getpos())
 	local player_name = player:get_player_name()
 
-	-- check if it's possible to place bones, if not go find space near player
+	-- check if it's possible to place bones, if not find space near player
 	if bones_mode == "bones" and not may_replace(pos, player) then
 		local air = minetest.find_node_near(pos, 1, {"air"})
-		if air then
+		if air and not minetest.is_protected(air, player:get_player_name()) then
 			pos = air
+		else
+			bones_mode = "drop"
 		end
-	end
-
-	-- still cannot place bones? change mode to 'drop'
-	if bones_mode == "bones" and not may_replace(pos, player) then
-		bones_mode = "drop"
 	end
 
 	if bones_mode == "drop" then

--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -183,7 +183,7 @@ minetest.register_on_dieplayer(function(player)
 	-- check if it's possible to place bones, if not find space near player
 	if bones_mode == "bones" and not may_replace(pos, player) then
 		local air = minetest.find_node_near(pos, 1, {"air"})
-		if air and not minetest.is_protected(air, player:get_player_name()) then
+		if air and not minetest.is_protected(air, player_name) then
 			pos = air
 		else
 			bones_mode = "drop"


### PR DESCRIPTION
When a player dies on ladders or rope then a space can not be found at or above player, so this change looks around player for a space to place bones.