### PR TITLE
Licenses: (Part 4) Remove overlooked WTFPL text. Cleanup

### DIFF
--- a/mods/default/legacy.lua
+++ b/mods/default/legacy.lua
@@ -1,6 +1,6 @@
 -- mods/default/legacy.lua
 
--- Horrible crap to support old code registering falling nodes
+-- Horrible stuff to support old code registering falling nodes
 -- Don't use this and never do what this does, it's completely wrong!
 -- (More specifically, the client and the C++ code doesn't get the group)
 function default.register_falling_node(nodename, texture)

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -1,11 +1,3 @@
---[[
-
-Copyright (C) 2012 PilzAdam
-  modified by BlockMen (added sounds, glassdoors[glass, obsidian glass], trapdoor)
-Copyright (C) 2015 - Auke Kok <sofar@foo-projects.org>
-
---]]
-
 -- our API object
 doors = {}
 

--- a/mods/walls/README.txt
+++ b/mods/walls/README.txt
@@ -4,4 +4,4 @@ See license.txt for license information.
 
 Authors of source code
 ----------------------
-sofar (sofar@foo-projects.org) (LGPL 2.1)
+Auke Kok <sofar@foo-projects.org> (LGPL 2.1)

--- a/mods/walls/init.lua
+++ b/mods/walls/init.lua
@@ -1,18 +1,3 @@
-
---[[
-
-Walls mod for Minetest
-
-Copyright (C) 2015 Auke Kok <sofar@foo-projects.org>
-
-This program is free software. It comes without any warranty, to
-the extent permitted by applicable law. You can redistribute it
-and/or modify it under the terms of the Do What The Fuck You Want
-To Public License, Version 2, as published by Sam Hocevar. See
-http://sam.zoy.org/wtfpl/COPYING for more details.
-
---]]
-
 walls = {}
 
 walls.register = function(wall_name, wall_desc, wall_texture, wall_mat, wall_sounds)

--- a/mods/walls/license.txt
+++ b/mods/walls/license.txt
@@ -2,7 +2,7 @@ License of source code
 ----------------------
 
 GNU Lesser General Public License, version 2.1
-Copyright (C) 2016 sofar (sofar@foo-projects.org)
+Copyright (C) 2015 Auke Kok <sofar@foo-projects.org>
 
 This program is free software; you can redistribute it and/or modify it under the terms
 of the GNU Lesser General Public License as published by the Free Software Foundation;


### PR DESCRIPTION
I checked all MTGame files for any remaining expletives.
The overlooked text in walls init.lua was spotted by a forum member.