### PR TITLE
Dynamic Dirt to Grass changes

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -347,7 +347,7 @@ minetest.register_abm({
 minetest.register_abm({
 	label = "Grass spread",
 	nodenames = {"default:dirt"},
-	neighbors = {"group:grassy_dirt"},
+	neighbors = {"air"},
 	interval = 6,
 	chance = 67,
 	catch_up = false,

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -372,10 +372,12 @@ minetest.register_abm({
 			return
 		end
 
-		local curr_max, curr_type, num  = 0, ""
-
+		local curr_max = 0
+		local curr_type = ""
+		local num
+	
 		-- find all grass types around dirt
-		local positions, grasses = minetest.find_nodes_in_area(
+		local _, grasses = minetest.find_nodes_in_area(
 			{x = pos.x - 1, y = pos.y - 2, z = pos.z - 1},
 			{x = pos.x + 1, y = pos.y + 2, z = pos.z + 1},
 			default.dirt_types)

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -376,10 +376,15 @@ minetest.register_abm({
 		local curr_type = ""
 
 		-- Find all grass types around dirt
-		local _, grasses = minetest.find_nodes_in_area(
+		local positions, grasses = minetest.find_nodes_in_area(
 			{x = pos.x - 1, y = pos.y - 1, z = pos.z - 1},
 			{x = pos.x + 1, y = pos.y + 1, z = pos.z + 1},
 			default.dirt_types)
+
+		-- No grass nearby, keep as dirt
+		if #positions == 0 then
+			return
+		end
 
 		-- Select most common grass
 		for n = 1, #default.dirt_types do
@@ -388,11 +393,6 @@ minetest.register_abm({
 				curr_max = num
 				curr_type = default.dirt_types[n]
 			end
-		end
-
-		-- No grass nearby? then keep as dirt
-		if curr_type == "" then
-			return
 		end
 
 		minetest.set_node(pos, {name = curr_type})

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -378,8 +378,8 @@ minetest.register_abm({
 	
 		-- Find all grass types around dirt
 		local _, grasses = minetest.find_nodes_in_area(
-			{x = pos.x - 1, y = pos.y - 2, z = pos.z - 1},
-			{x = pos.x + 1, y = pos.y + 2, z = pos.z + 1},
+			{x = pos.x - 1, y = pos.y - 1, z = pos.z - 1},
+			{x = pos.x + 1, y = pos.y + 1, z = pos.z + 1},
 			default.dirt_types)
 
 		-- Select most common grass

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -374,8 +374,7 @@ minetest.register_abm({
 
 		local curr_max = 0
 		local curr_type = ""
-		local num
-	
+
 		-- Find all grass types around dirt
 		local _, grasses = minetest.find_nodes_in_area(
 			{x = pos.x - 1, y = pos.y - 1, z = pos.z - 1},
@@ -384,7 +383,7 @@ minetest.register_abm({
 
 		-- Select most common grass
 		for n = 1, #default.dirt_types do
-			num = grasses[ default.dirt_types[n] ] or 0
+			local num = grasses[ default.dirt_types[n] ] or 0
 			if num > curr_max then
 				curr_max = num
 				curr_type = default.dirt_types[n]

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -358,13 +358,13 @@ minetest.register_abm({
 	chance = 67,
 	catch_up = false,
 	action = function(pos, node)
-		-- not enough light
+		-- Check for enough light above
 		local above = {x = pos.x, y = pos.y + 1, z = pos.z}
 		if (minetest.get_node_light(above) or 0) < 13 then
 			return
 		end
 
-		-- water above grass
+		-- Is water above dirt?
 		local name = minetest.get_node(above).name
 		local def = minetest.registered_nodes[name]
 
@@ -376,13 +376,13 @@ minetest.register_abm({
 		local curr_type = ""
 		local num
 	
-		-- find all grass types around dirt
+		-- Find all grass types around dirt
 		local _, grasses = minetest.find_nodes_in_area(
 			{x = pos.x - 1, y = pos.y - 2, z = pos.z - 1},
 			{x = pos.x + 1, y = pos.y + 2, z = pos.z + 1},
 			default.dirt_types)
 
-		-- find most common grass
+		-- Select most common grass
 		for n = 1, #default.dirt_types do
 			num = grasses[ default.dirt_types[n] ] or 0
 			if num > curr_max then
@@ -391,7 +391,7 @@ minetest.register_abm({
 			end
 		end
 
-		-- no grass nearby, keep as dirt
+		-- No grass nearby? then keep as dirt
 		if curr_type == "" then
 			return
 		end

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -344,16 +344,10 @@ minetest.register_abm({
 -- Convert dirt to something that fits the environment
 --
 
-default.dirt_types = {
-	"default:dirt_with_grass",
-	"default:dirt_with_dry_grass",
-	"default:dirt_with_snow"
-}
-
 minetest.register_abm({
 	label = "Grass spread",
 	nodenames = {"default:dirt"},
-	neighbors = {"air"},
+	neighbors = {"group:grassy_dirt"},
 	interval = 6,
 	chance = 67,
 	catch_up = false,
@@ -379,7 +373,7 @@ minetest.register_abm({
 		local positions, grasses = minetest.find_nodes_in_area(
 			{x = pos.x - 1, y = pos.y - 1, z = pos.z - 1},
 			{x = pos.x + 1, y = pos.y + 1, z = pos.z + 1},
-			default.dirt_types)
+			{"group:grassy_dirt"})
 
 		-- No grass nearby, keep as dirt
 		if #positions == 0 then
@@ -387,11 +381,10 @@ minetest.register_abm({
 		end
 
 		-- Select most common grass
-		for n = 1, #default.dirt_types do
-			local num = grasses[ default.dirt_types[n] ] or 0
-			if num > curr_max then
-				curr_max = num
-				curr_type = default.dirt_types[n]
+		for n, c in pairs(grasses) do
+			if c and c > curr_max then
+				curr_max = c
+				curr_type = n
 			end
 		end
 


### PR DESCRIPTION
This new function simplifies grass spreading to dirt blocks by looking for 'grassy_dirt' group nodes beside the dirt block and changing the dirt to the most common grass block nearby.  If none of these blocks are found then the dirt block remains the same.  Dirt will not change to grass if light levels are under 13 or underwater, but will spread fine under fences, gates etc.