### PR TITLE
Doors: Trim open fencegate collison box again

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -696,7 +696,7 @@ function doors.register_fencegate(name, def)
 	fence_open.collision_box = {
 		type = "fixed",
 		fixed = {{-1/2, -1/2, -1/4, -3/8, 1/2, 1/4},
-			{-5/8, -3/8, -1/2, -3/8, 3/8, 0}},
+			{-1/2, -3/8, -1/2, -3/8, 3/8, 0}},
 	}
 
 	minetest.register_node(":" .. name .. "_closed", fence_closed)


### PR DESCRIPTION
The collision box still extended into a neighbouring empty node, causing
falling node objects to collide but not transform back into normal nodes.
Completes the fix started in a previous similar commit.
//////////////////////////////////////////////////////

See https://github.com/minetest/minetest_game/issues/1193#issuecomment-247820654
Completes fix started in #1231 
Tested.