### PR TITLE
Remove un-needed group overrides

### DIFF
--- a/mods/farming/nodes.lua
+++ b/mods/farming/nodes.lua
@@ -1,5 +1,4 @@
 minetest.override_item("default:dirt", {
-	groups = {crumbly=3, soil=1},
 	soil = {
 		base = "default:dirt",
 		dry = "farming:soil",
@@ -8,7 +7,6 @@ minetest.override_item("default:dirt", {
 })
 
 minetest.override_item("default:dirt_with_grass", {
-	groups = {crumbly=3, soil=1},
 	soil = {
 		base = "default:dirt_with_grass",
 		dry = "farming:soil",
@@ -17,7 +15,6 @@ minetest.override_item("default:dirt_with_grass", {
 })
 
 minetest.override_item("default:dirt_with_dry_grass", {
-	groups = {crumbly=3, soil=1},
 	soil = {
 		base = "default:dirt_with_dry_grass",
 		dry = "farming:soil",


### PR DESCRIPTION
This removes the group overrides for dirt, dirt_with_grass and dirt_with_dry_grass which aren't needed and interfere with new grass spreading changes: https://github.com/minetest/minetest_game/pull/1286