### PR TITLE
Doors: Remove ability to rotate doors with screwdrivers

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -366,7 +366,7 @@ function doors.register(name, def)
 		minetest.remove_node({x = pos.x, y = pos.y + 1, z = pos.z})
 		nodeupdate({x = pos.x, y = pos.y + 1, z = pos.z})
 	end
-	def.on_rotate = screwdriver and screwdriver.rotate_simple or false
+	def.on_rotate = false
 
 	if def.protected then
 		def.can_dig = can_dig_door


### PR DESCRIPTION
Rotating doors with screwdrivers causes too many issues to be worth it.
///////////////////////////////////////////////////////

See issues #1290 #1297 
Workaround for #1290 
Suggested by sofar so assuming approval.