### PR TITLE
Fix sapling placement handling of on_rightclick and CONTENT_IGNORE

### DIFF
--- a/mods/default/trees.lua
+++ b/mods/default/trees.lua
@@ -435,12 +435,17 @@ function default.sapling_on_place(itemstack, placer, pointed_thing,
 		sapling_name, minp_relative, maxp_relative, interval)
 	-- Position of sapling
 	local pos = pointed_thing.under
-	local node = minetest.get_node(pos)
-	local pdef = minetest.registered_nodes[node.name]
+	local node = minetest.get_node_or_nil(pos)
+	local pdef = node and minetest.registered_nodes[node.name]
+
+	if pdef and pdef.on_rightclick and not placer:get_player_control().sneak then
+		return pdef.on_rightclick(pos, node, placer, itemstack, pointed_thing)
+	end
+
 	if not pdef or not pdef.buildable_to then
 		pos = pointed_thing.above
-		node = minetest.get_node(pos)
-		pdef = minetest.registered_nodes[node.name]
+		node = minetest.get_node_or_nil(pos)
+		pdef = node and minetest.registered_nodes[node.name]
 		if not pdef or not pdef.buildable_to then
 			return itemstack
 		end


### PR DESCRIPTION
Fixes #1304, as well as https://github.com/minetest-mods/xdecor/issues/60 and https://github.com/minetest/minetest/issues/4562 for saplings.

Seed fixes weren't included yet, as the entire placement there should be updated/replaced, which shouldn't delay this here.