### PR TITLE
Prevent possible nil-crash on invalid book metadata.

### DIFF
--- a/mods/default/craftitems.lua
+++ b/mods/default/craftitems.lua
@@ -105,7 +105,9 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 
 	elseif fields.book_next or fields.book_prev then
 		local data = minetest.deserialize(stack:get_metadata())
-		if not data.page then return end
+		if not data or not data.page then
+			return
+		end
 
 		if fields.book_next then
 			data.page = data.page + 1


### PR DESCRIPTION
Fix for https://github.com/minetest/minetest/issues/4561
`minetest.deserialize` can return `nil` for invalid metadata.