### PR TITLE
TNT Performance Tweaks

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -5,7 +5,7 @@ read_globals = {
 	"DIR_DELIM",
 	"minetest", "core",
 	"dump",
-	"vector", "nodeupdate",
+	"vector", "nodeupdate", "nodeupdate_single",
 	"VoxelManip", "VoxelArea",
 	"PseudoRandom", "ItemStack",
 }

--- a/game_api.txt
+++ b/game_api.txt
@@ -290,9 +290,9 @@ TNT API
 * `position` The center of explosion.
 * `definition` The TNT definion as passed to `tnt.register`
 
-`tnt.burn(position)`
+`tnt.burn(position, [nodename])`
 
-^ Ignite TNT at position
+^ Ignite TNT at position, nodename isn't required unless already known.
 
 
 To make dropping items from node inventories easier, you can use the

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -337,7 +337,7 @@ local function tnt_explode(pos, radius, ignore_protection, ignore_on_blast)
 	for z = -radius * 1.5, radius * 1.5 do
 	for x = -radius * 1.5, radius * 1.5 do
 		local s = vector.add(pos, {x = x, y = y, z = z})
-		local r = vector.distance(pos, s)
+		local r = vector.length({x = x, y = y, z = z})
 		if r / radius < 1.4 then
 			nodeupdate_single(s)
 		end

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -333,13 +333,13 @@ local function tnt_explode(pos, radius, ignore_protection, ignore_on_blast)
 	vm:update_liquids()
 
 	-- call nodeupdate for everything within 1.5x blast radius
-	for z = -radius * 1.5, radius * 1.5, 3 do
-	for x = -radius * 1.5, radius * 1.5, 3 do
-	for y = -radius * 1.5, radius * 1.5, 3 do
+	for y = -radius * 1.5, radius * 1.5 do
+	for z = -radius * 1.5, radius * 1.5 do
+	for x = -radius * 1.5, radius * 1.5 do
 		local s = vector.add(pos, {x = x, y = y, z = z})
 		local r = vector.distance(pos, s)
 		if r / radius < 1.4 then
-			nodeupdate(s)
+			nodeupdate_single(s)
 		end
 	end
 	end

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -336,8 +336,9 @@ local function tnt_explode(pos, radius, ignore_protection, ignore_on_blast)
 	for y = -radius * 1.5, radius * 1.5 do
 	for z = -radius * 1.5, radius * 1.5 do
 	for x = -radius * 1.5, radius * 1.5 do
-		local s = vector.add(pos, {x = x, y = y, z = z})
-		local r = vector.length({x = x, y = y, z = z})
+		local rad = {x = x, y = y, z = z}
+		local s = vector.add(pos, rad)
+		local r = vector.length(rad)
 		if r / radius < 1.4 then
 			nodeupdate_single(s)
 		end


### PR DESCRIPTION
This passes nodename to tnt.burn function where possible to reduce the need for get_node and adds a few performance tweaks by switching ipair to pair for for loops.  The blast radius for-loop has been changed to use nodeupdate_single instead of nodeupdate.