### PR TITLE
Default/functions: Tune speed of grass spread ABM

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -354,7 +354,7 @@ minetest.register_abm({
 		"default:snow",
 	},
 	interval = 6,
-	chance = 67,
+	chance = 50,
 	catch_up = false,
 	action = function(pos, node)
 		-- Check for darkness: night, shadow or under a light-blocking node


### PR DESCRIPTION
Through testing the chance is changed to 50 such that grass spread
speed matches that of the previous (0.4.13) ABM version.
///////////////////////////////////////////

I tested using a 8x8 node area of dirt and timed relative speeds of complete coverage:
/////////////////
https://github.com/minetest/minetest_game/tree/e41a411f1c948fa4bb79562ab9bf80a5bd757efe
with int 1 cha 16 8x8 dirt 61s
Latest
with int 1 cha 16 8x8 dirt 80s
16 / (80 / 61) = 12.2

try int 1 cha 12 8x8 dirt 59s fine
with same interval divide chance (67) by 80/61 = 51 let's use 50
///////////////////
We can now increase chance because the latest version of the ABM is much more lightweight than the 2 previous versions.