### PR TITLE
Bucket: Add optional 'force-renew' bool to registration 

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -26,7 +26,10 @@ The bucket API allows registering new types of buckets for non-default liquids.
 		"bucket:bucket_lava",    -- name of the new bucket item (or nil if liquid is not takeable)
 		"bucket_lava.png",       -- texture of the new bucket item (ignored if itemname == nil)
 		"Lava Bucket",           -- text description of the bucket item
-		{lava_bucket = 1}        -- groups of the bucket item, OPTIONAL
+		{lava_bucket = 1},       -- groups of the bucket item, OPTIONAL
+		false                    -- force-renew, OPTIONAL. Force the liquid source to renew if it has
+		                         -- a source neighbour, even if defined as 'liquid_renewable = false'.
+		                         -- Needed to avoid creating holes in sloping rivers.
 	)
 
 Beds API


### PR DESCRIPTION
River water needs to be 'liquid_renewable = false' to avoid a mess caused by
spreading of sources, however picking it up with a bucket then creates
a hole in the river. Allow a 'force-renew' of the source node if it has a
source neighbour.
////////////////////////////////////////////////////////

![screenshot_20161011_000631](https://cloud.githubusercontent.com/assets/3686677/19254073/f125caaa-8f47-11e6-9ffa-255e1ce1a966.png)

^ Force-renew requires at least one source neighbour, as is usually the case in rivers. This makes the behaviour closer to that of renewable liquid, and avoids the possibility of an infinite single source node. Now at least there has to be another source nearby.

Addresses #1319 and useful elsewhere, for example 'planet' type mods with spherical oceans.
Additional bool is added as an optional parameter, the absence of which results in normal behaviour, so should be backwards-compatible.
Tested.