### PR TITLE
Make flammable: flowers, grasses and several crafitems

### DIFF
--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -221,6 +221,7 @@ minetest.register_craftitem("boats:boat", {
 	wield_image = "boats_wield.png",
 	wield_scale = {x = 2, y = 2, z = 1},
 	liquids_pointable = true,
+	groups = {flammable = 2},
 
 	on_place = function(itemstack, placer, pointed_thing)
 		if pointed_thing.type ~= "node" then

--- a/mods/default/craftitems.lua
+++ b/mods/default/craftitems.lua
@@ -3,12 +3,13 @@
 minetest.register_craftitem("default:stick", {
 	description = "Stick",
 	inventory_image = "default_stick.png",
-	groups = {stick = 1},
+	groups = {stick = 1, flammable = 2},
 })
 
 minetest.register_craftitem("default:paper", {
 	description = "Paper",
 	inventory_image = "default_paper.png",
+	groups = {flammable = 3},
 })
 
 local lpp = 14 -- Lines per book's page
@@ -132,14 +133,14 @@ end)
 minetest.register_craftitem("default:book", {
 	description = "Book",
 	inventory_image = "default_book.png",
-	groups = {book = 1},
+	groups = {book = 1, flammable = 3},
 	on_use = book_on_use,
 })
 
 minetest.register_craftitem("default:book_written", {
 	description = "Book With Text",
 	inventory_image = "default_book_written.png",
-	groups = {book = 1, not_in_creative_inventory = 1},
+	groups = {book = 1, not_in_creative_inventory = 1, flammable = 3},
 	stack_max = 1,
 	on_use = book_on_use,
 })
@@ -176,7 +177,7 @@ end)
 minetest.register_craftitem("default:coal_lump", {
 	description = "Coal Lump",
 	inventory_image = "default_coal_lump.png",
-	groups = {coal = 1}
+	groups = {coal = 1, flammable = 1}
 })
 
 minetest.register_craftitem("default:iron_lump", {

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1103,7 +1103,7 @@ minetest.register_node("default:junglegrass", {
 	sunlight_propagates = true,
 	walkable = false,
 	buildable_to = true,
-	groups = {snappy = 3, flora = 1, attached_node = 1, grass = 1},
+	groups = {snappy = 3, flora = 1, attached_node = 1, grass = 1, flammable = 1},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
 		type = "fixed",
@@ -1124,7 +1124,7 @@ minetest.register_node("default:grass_1", {
 	sunlight_propagates = true,
 	walkable = false,
 	buildable_to = true,
-	groups = {snappy = 3, flora = 1, attached_node = 1, grass = 1},
+	groups = {snappy = 3, flora = 1, attached_node = 1, grass = 1, flammable = 1},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
 		type = "fixed",
@@ -1154,7 +1154,7 @@ for i = 2, 5 do
 		buildable_to = true,
 		drop = "default:grass_1",
 		groups = {snappy = 3, flora = 1, attached_node = 1,
-			not_in_creative_inventory = 1, grass = 1},
+			not_in_creative_inventory = 1, grass = 1, flammable = 1},
 		sounds = default.node_sound_leaves_defaults(),
 		selection_box = {
 			type = "fixed",

--- a/mods/default/tools.lua
+++ b/mods/default/tools.lua
@@ -32,6 +32,7 @@ minetest.register_tool("default:pick_wood", {
 		},
 		damage_groups = {fleshy=2},
 	},
+	groups = {flammable = 2},
 })
 minetest.register_tool("default:pick_stone", {
 	description = "Stone Pickaxe",
@@ -110,6 +111,7 @@ minetest.register_tool("default:shovel_wood", {
 		},
 		damage_groups = {fleshy=2},
 	},
+	groups = {flammable = 2},
 })
 minetest.register_tool("default:shovel_stone", {
 	description = "Stone Shovel",
@@ -192,6 +194,7 @@ minetest.register_tool("default:axe_wood", {
 		},
 		damage_groups = {fleshy=2},
 	},
+	groups = {flammable = 2},
 })
 minetest.register_tool("default:axe_stone", {
 	description = "Stone Axe",
@@ -268,7 +271,8 @@ minetest.register_tool("default:sword_wood", {
 			snappy={times={[2]=1.6, [3]=0.40}, uses=10, maxlevel=1},
 		},
 		damage_groups = {fleshy=2},
-	}
+	},
+	groups = {flammable = 2},
 })
 minetest.register_tool("default:sword_stone", {
 	description = "Stone Sword",

--- a/mods/farming/api.lua
+++ b/mods/farming/api.lua
@@ -92,7 +92,8 @@ farming.register_hoe = function(name, def)
 		inventory_image = def.inventory_image,
 		on_use = function(itemstack, user, pointed_thing)
 			return farming.hoe_on_use(itemstack, user, pointed_thing, def.max_uses)
-		end
+		end,
+		groups = def.groups,
 	})
 	-- Register its recipe
 	if def.material == nil then
@@ -269,7 +270,7 @@ farming.register_plant = function(name, def)
 
 	-- Register seed
 	local lbm_nodes = {mname .. ":seed_" .. pname}
-	local g = {seed = 1, snappy = 3, attached_node = 1}
+	local g = {seed = 1, snappy = 3, attached_node = 1, flammable = 2}
 	for k, v in pairs(def.fertility) do
 		g[v] = 1
 	end
@@ -307,6 +308,7 @@ farming.register_plant = function(name, def)
 	minetest.register_craftitem(":" .. mname .. ":" .. pname, {
 		description = pname:gsub("^%l", string.upper),
 		inventory_image = mname .. "_" .. pname .. ".png",
+		groups = {flammable = 2},
 	})
 
 	-- Register growing steps

--- a/mods/farming/hoes.lua
+++ b/mods/farming/hoes.lua
@@ -2,7 +2,8 @@ farming.register_hoe(":farming:hoe_wood", {
 	description = "Wooden Hoe",
 	inventory_image = "farming_tool_woodhoe.png",
 	max_uses = 30,
-	material = "group:wood"
+	material = "group:wood",
+	groups = {flammable = 2},
 })
 
 farming.register_hoe(":farming:hoe_stone", {

--- a/mods/farming/init.lua
+++ b/mods/farming/init.lua
@@ -14,17 +14,20 @@ farming.register_plant("farming:wheat", {
 	steps = 8,
 	minlight = 13,
 	maxlight = default.LIGHT_MAX,
-	fertility = {"grassland"}
+	fertility = {"grassland"},
+	groups = {flammable = 4},
 })
 minetest.register_craftitem("farming:flour", {
 	description = "Flour",
 	inventory_image = "farming_flour.png",
+	groups = {flammable = 1},
 })
 
 minetest.register_craftitem("farming:bread", {
 	description = "Bread",
 	inventory_image = "farming_bread.png",
 	on_use = minetest.item_eat(5),
+	groups = {flammable = 2},
 })
 
 minetest.register_craft({
@@ -47,7 +50,8 @@ farming.register_plant("farming:cotton", {
 	steps = 8,
 	minlight = 13,
 	maxlight = default.LIGHT_MAX,
-	fertility = {"grassland", "desert"}
+	fertility = {"grassland", "desert"},
+	groups = {flammable = 4},
 })
 
 minetest.register_alias("farming:string", "farming:cotton")

--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -57,12 +57,12 @@ local function add_simple_flower(name, desc, box, f_groups)
 end
 
 flowers.datas = {
-	{"rose", "Rose", {-0.15, -0.5, -0.15, 0.15, 0.3, 0.15}, {color_red = 1}},
-	{"tulip", "Orange Tulip", {-0.15, -0.5, -0.15, 0.15, 0.2, 0.15}, {color_orange = 1}},
-	{"dandelion_yellow", "Yellow Dandelion", {-0.15, -0.5, -0.15, 0.15, 0.2, 0.15}, {color_yellow = 1}},
-	{"geranium", "Blue Geranium", {-0.15, -0.5, -0.15, 0.15, 0.2, 0.15}, {color_blue = 1}},
-	{"viola", "Viola", {-0.5, -0.5, -0.5, 0.5, -0.2, 0.5}, {color_violet = 1}},
-	{"dandelion_white", "White dandelion", {-0.5, -0.5, -0.5, 0.5, -0.2, 0.5}, {color_white = 1}}
+	{"rose", "Rose", {-0.15, -0.5, -0.15, 0.15, 0.3, 0.15}, {color_red = 1, flammable = 1}},
+	{"tulip", "Orange Tulip", {-0.15, -0.5, -0.15, 0.15, 0.2, 0.15}, {color_orange = 1, flammable = 1}},
+	{"dandelion_yellow", "Yellow Dandelion", {-0.15, -0.5, -0.15, 0.15, 0.2, 0.15}, {color_yellow = 1, flammable = 1}},
+	{"geranium", "Blue Geranium", {-0.15, -0.5, -0.15, 0.15, 0.2, 0.15}, {color_blue = 1, flammable = 1}},
+	{"viola", "Viola", {-0.5, -0.5, -0.5, 0.5, -0.2, 0.5}, {color_violet = 1, flammable = 1}},
+	{"dandelion_white", "White dandelion", {-0.5, -0.5, -0.5, 0.5, -0.2, 0.5}, {color_white = 1, flammable = 1}}
 }
 
 for _,item in pairs(flowers.datas) do
@@ -136,7 +136,7 @@ minetest.register_node("flowers:mushroom_red", {
 	sunlight_propagates = true,
 	walkable = false,
 	buildable_to = true,
-	groups = {snappy = 3, attached_node = 1},
+	groups = {snappy = 3, attached_node = 1, flammable = 1},
 	sounds = default.node_sound_leaves_defaults(),
 	on_use = minetest.item_eat(-5),
 	selection_box = {
@@ -155,7 +155,7 @@ minetest.register_node("flowers:mushroom_brown", {
 	sunlight_propagates = true,
 	walkable = false,
 	buildable_to = true,
-	groups = {snappy = 3, attached_node = 1},
+	groups = {snappy = 3, attached_node = 1, flammable = 1},
 	sounds = default.node_sound_leaves_defaults(),
 	on_use = minetest.item_eat(1),
 	selection_box = {
@@ -229,7 +229,7 @@ minetest.register_node("flowers:waterlily", {
 	buildable_to = true,
 	sunlight_propagates = true,
 	floodable = true,
-	groups = {snappy = 3, flower = 1},
+	groups = {snappy = 3, flower = 1, flammable = 1},
 	sounds = default.node_sound_leaves_defaults(),
 	node_placement_prediction = "",
 	node_box = {


### PR DESCRIPTION
Addresses #1338 and also allows for several items to be destroyed when they fall on lava/fire (after #1285).

This includes boats, sticks, paper, books, coal lump, wooden tools, seeds, wheat, flour, bread and cotton.