### PR TITLE
flint-and-steel: trigger node on_ignite, add it to tnt, gunpowder, coal

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -227,6 +227,14 @@ New node def property:
  * Called when fire attempts to remove a burning node.
  * `pos` Position of the burning node.
 
+ `on_ignite(pos, igniter)`
+
+  * Called when Flint and steel (or a mod defined ignitor) is used on a node.
+    Defining it may prevent the default action (spawning flames) from triggering.
+  * `pos` Position of the ignited node.
+  * `igniter` Player that used the tool, when available.
+
+
 Give Initial Stuff API
 ----------------------
 

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -418,7 +418,10 @@ minetest.register_node("tnt:gunpowder", {
 	end,
 	on_burn = function(pos)
 		minetest.set_node(pos, {name = "tnt:gunpowder_burning"})
-	end
+	end,
+	on_ignite = function(pos, igniter)
+		minetest.set_node(pos, {name = "tnt:gunpowder_burning"})
+	end,
 })
 
 minetest.register_node("tnt:gunpowder_burning", {
@@ -563,7 +566,10 @@ function tnt.register_tnt(def)
 			},
 			on_burn = function(pos)
 				minetest.set_node(pos, {name = name .. "_burning"})
-			end
+			end,
+			on_ignite = function(pos, igniter)
+				minetest.set_node(pos, {name = name .. "_burning"})
+			end,
 		})
 	end
 


### PR DESCRIPTION
This changes the flint-and-steel logic to trigger an `on_ignite` callback from the nodedef, and moves the previous logic to the `on_ignite` of each of the nodes that flint-and-steel acted on: tnt, gunpower and coalblock.

This way flint-and-steel is more flexible and mods will be able to add their own nodes that can be ignited by flint-and-steel without re-implementing the `on_use` of the tool.

~~It also allows the tnt and gunpowder to be set flammable since fire would now ignite them.~~ (see #1348)

One slight change of behavior is that now when creating a permanent flame ~~both the coalblock and the place where the permanent flames will be placed~~ only the coalblock is checked for protection, instead of the place where the flame is placed.
