### PR TITLE
Add fuel slot to furnace listring

### DIFF
--- a/mods/default/furnace.lua
+++ b/mods/default/furnace.lua
@@ -22,6 +22,8 @@ local function active_formspec(fuel_percent, item_percent)
 		"listring[current_player;main]"..
 		"listring[current_name;src]"..
 		"listring[current_player;main]"..
+		"listring[current_name;fuel]"..
+		"listring[current_player;main]"..
 		default.get_hotbar_bg(0, 4.25)
 	return formspec
 end
@@ -41,6 +43,8 @@ local inactive_formspec =
 	"listring[current_name;dst]"..
 	"listring[current_player;main]"..
 	"listring[current_name;src]"..
+	"listring[current_player;main]"..
+	"listring[current_name;fuel]"..
 	"listring[current_player;main]"..
 	default.get_hotbar_bg(0, 4.25)
 


### PR DESCRIPTION
This PR extends the listring of the furnace.
It allows the player to shift-click on the fuel slot to insta-move items from the fuel slot back to the player inventory.
