### PR TITLE
Add Fuels

### DIFF
--- a/mods/beds/beds.lua
+++ b/mods/beds/beds.lua
@@ -88,3 +88,17 @@ beds.register_bed("beds:bed", {
 
 minetest.register_alias("beds:bed_bottom_red", "beds:bed_bottom")
 minetest.register_alias("beds:bed_top_red", "beds:bed_top")
+
+-- Fuel 
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "beds:fancy_bed_bottom",
+	burntime = 13,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "beds:bed_bottom",
+	burntime = 12,
+})

--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -248,3 +248,9 @@ minetest.register_craft({
 		{"group:wood", "group:wood", "group:wood"},
 	},
 })
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "boats:boat",
+	burntime = 20,
+})

--- a/mods/default/crafting.lua
+++ b/mods/default/crafting.lua
@@ -911,35 +911,34 @@ minetest.register_craft({
 	burntime = 12,
 })
 
-
 minetest.register_craft({
 	type = "fuel",
 	recipe = "default:fence_aspen_wood",
-	burntime = 11,
+	burntime = 5,
 })
 
 minetest.register_craft({
 	type = "fuel",
 	recipe = "default:fence_pine_wood",
-	burntime = 13,
+	burntime = 6,
 })
 
 minetest.register_craft({
 	type = "fuel",
 	recipe = "default:fence_wood",
-	burntime = 15,
+	burntime = 7,
 })
 
 minetest.register_craft({
 	type = "fuel",
 	recipe = "default:fence_acacia_wood",
-	burntime = 17,
+	burntime = 8,
 })
 
 minetest.register_craft({
 	type = "fuel",
 	recipe = "default:fence_junglewood",
-	burntime = 19,
+	burntime = 9,
 })
 
 
@@ -988,7 +987,7 @@ minetest.register_craft({
 minetest.register_craft({
 	type = "fuel",
 	recipe = "default:ladder_wood",
-	burntime = 5,
+	burntime = 2,
 })
 
 minetest.register_craft({
@@ -1050,3 +1049,54 @@ minetest.register_craft({
 	recipe = "default:dry_grass_1",
 	burntime = 2,
 })
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:paper",
+	burntime = 1,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:book",
+	burntime = 3,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:dry_shrub",
+	burntime = 2,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "group:stick",
+	burntime = 1,
+})
+
+-- Tools (crafted with wood nodes but a tool is smaller then a wood node)
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:pick_wood",
+	burntime = 6,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:shovel_wood",
+	burntime = 4,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:axe_wood",
+	burntime = 6,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "default:sword_wood",
+	burntime = 5,
+})
+

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -745,3 +745,47 @@ doors.register_fencegate("doors:gate_aspen_wood", {
 	material = "default:aspen_wood",
 	groups = {choppy = 3, oddly_breakable_by_hand = 2, flammable = 3}
 })
+
+-- Fuel
+minetest.register_craft({
+	type = "fuel",
+	recipe = "doors:trapdoor",
+	burntime = 7,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "doors:door_wood",
+	burntime = 14,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "doors:gate_wood_closed",
+	burntime = 7,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "doors:gate_acacia_wood_closed",
+	burntime = 8,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "doors:gate_junglewood_closed",
+	burntime = 9,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "doors:gate_pine_wood_closed",
+	burntime = 6,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "doors:gate_aspen_wood_closed",
+	burntime = 5,
+})
+

--- a/mods/farming/init.lua
+++ b/mods/farming/init.lua
@@ -80,3 +80,30 @@ minetest.register_craft({
 		{"farming:straw"},
 	}
 })
+
+-- Fuel
+
+-- Straw is combustible but not suitable as fuel.(burntime = 3)
+minetest.register_craft({
+	type = "fuel",
+	recipe = "farming:straw",
+	burntime = 3,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "farming:wheat",
+	burntime = 1,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "farming:cotton",
+	burntime = 1,
+})
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "farming:hoe_wood",
+	burntime = 5,
+})

--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -106,6 +106,20 @@ function stairs.register_stair(subname, recipeitem, groups, images, description,
 				{recipeitem, recipeitem, recipeitem},
 			},
 		})
+		
+		--Fuel
+		local baseburntime = minetest.get_craft_result({
+			method = "fuel",
+			width = 1,
+			items = {recipeitem}
+		}).time
+		if baseburntime > 0 then
+			minetest.register_craft({
+				type = "fuel",
+				recipe = 'stairs:stair_' .. subname,
+				burntime = math.floor(baseburntime * 0.75),
+			})
+		end
 	end
 end
 
@@ -207,6 +221,20 @@ function stairs.register_slab(subname, recipeitem, groups, images, description, 
 				{recipeitem, recipeitem, recipeitem},
 			},
 		})
+		
+		--Fuel
+		local baseburntime = minetest.get_craft_result({
+			method = "fuel",
+			width = 1,
+			items = {recipeitem}
+		}).time
+		if baseburntime > 0 then
+			minetest.register_craft({
+				type = "fuel",
+				recipe = 'stairs:slab_' .. subname,
+				burntime = math.floor(baseburntime * 0.5),
+			})
+		end
 	end
 end
 

--- a/mods/vessels/init.lua
+++ b/mods/vessels/init.lua
@@ -183,3 +183,9 @@ minetest.register_craft( {
 	output = "default:steel_ingot",
 	recipe = "vessels:steel_bottle",
 })
+
+minetest.register_craft({
+	type = "fuel",
+	recipe = "vessels:shelf",
+	burntime = 30,
+})


### PR DESCRIPTION
I think that many fuel recipes are missing and it is unrealistic that wood crafted to fences burn better then normal wood. ( wood burntime = 7; stick burntime = 1; craft 4 wood and 2 sticks to 4 fences; (7x4+1x2)/4 = 7,5 )
It adds fuel recipes for this items ![alt screenshot](http://i.imgur.com/oAzVizc.png)
and new fence fuel recipes.
