### PR TITLE
sethome.get: Copy a return value

### DIFF
--- a/mods/sethome/init.lua
+++ b/mods/sethome/init.lua
@@ -41,7 +41,12 @@ sethome.set = function(name, pos)
 end
 
 sethome.get = function(name)
-	return homepos[name]
+	local pos = homepos[name]
+	if pos then
+	 	return vector.new(pos)
+	else
+	 	return nil
+	end
 end
 
 sethome.go = function(name)


### PR DESCRIPTION
Currently, the following code works.
```lua
sethome.set("singleplayer", {x=1, y=2, z=3})

local pos = sethome.get("singleplayer")
print(pos.x, pos.y, pos.z) -- 1 2 3

pos.x = 4

local pos2 = sethome.get("singleplayer")
print(pos2.x, pos2.y, pos2.z) -- 4 2 3
```
This PR fixes it.