### PR TITLE
Don't auto-grant home priv to singleplayer

### DIFF
--- a/mods/sethome/init.lua
+++ b/mods/sethome/init.lua
@@ -53,7 +53,10 @@ sethome.go = function(name)
 	return false
 end
 
-minetest.register_privilege("home", "Can use /sethome and /home")
+minetest.register_privilege("home", {
+	description = "Can use /sethome and /home",
+	give_to_singleplayer = false
+})
 
 minetest.register_chatcommand("home", {
 	description = "Teleport you to your home point",


### PR DESCRIPTION
This PR disables automatically granting the `home` privilege to singleplayer.

This was discussed here: https://github.com/minetest/minetest/issues/4413