### PR TITLE
Default: Make snow walkable again

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -442,7 +442,6 @@ minetest.register_node("default:snow", {
 	paramtype = "light",
 	buildable_to = true,
 	floodable = true,
-	walkable = false,
 	drawtype = "nodebox",
 	node_box = {
 		type = "fixed",


### PR DESCRIPTION
Addresses #1271 

I was watching a Minetest video https://youtu.be/Gamxf-soj-Y?t=49 of a biome with snow slabs on bare stone, unlike current MTGame the snow was walkable and made the snow footstep sounds. I realised how essential those sounds were to the whole atmosphere of the biome, and how bad it would be to be hearing stone footsteps there, and we did this just to avoid bumping your head on pinetrees.

I can raise pinetrees by 1 node if it's that much of a problem, this would mean low pinetrees are less common.

It was me who pushed the idea of making snow not walkable and i consider that a big mistake.
@Wuzzy2 's original request to raise the pinetrees was a much better idea.