### PR TITLE
Default: Add 'group:cools_lava', add to snowblock and ice 

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -126,7 +126,7 @@ end
 minetest.register_abm({
 	label = "Lava cooling",
 	nodenames = {"default:lava_source", "default:lava_flowing"},
-	neighbors = {"group:water"},
+	neighbors = {"group:cools_lava", "group:water"},
 	interval = 1,
 	chance = 1,
 	catch_up = false,

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -468,7 +468,7 @@ minetest.register_node("default:snow", {
 minetest.register_node("default:snowblock", {
 	description = "Snow Block",
 	tiles = {"default_snow.png"},
-	groups = {crumbly = 3, puts_out_fire = 1},
+	groups = {crumbly = 3, puts_out_fire = 1, cools_lava = 1},
 	sounds = default.node_sound_dirt_defaults({
 		footstep = {name = "default_snow_footstep", gain = 0.15},
 		dug = {name = "default_snow_footstep", gain = 0.2},
@@ -481,7 +481,7 @@ minetest.register_node("default:ice", {
 	tiles = {"default_ice.png"},
 	is_ground_content = false,
 	paramtype = "light",
-	groups = {cracky = 3, puts_out_fire = 1},
+	groups = {cracky = 3, puts_out_fire = 1, cools_lava = 1},
 	sounds = default.node_sound_glass_defaults(),
 })
 
@@ -1345,7 +1345,7 @@ minetest.register_node("default:water_source", {
 	liquid_alternative_source = "default:water_source",
 	liquid_viscosity = 1,
 	post_effect_color = {a = 103, r = 30, g = 60, b = 90},
-	groups = {water = 3, liquid = 3, puts_out_fire = 1},
+	groups = {water = 3, liquid = 3, puts_out_fire = 1, cools_lava = 1},
 })
 
 minetest.register_node("default:water_flowing", {
@@ -1390,7 +1390,7 @@ minetest.register_node("default:water_flowing", {
 	liquid_viscosity = 1,
 	post_effect_color = {a = 103, r = 30, g = 60, b = 90},
 	groups = {water = 3, liquid = 3, puts_out_fire = 1,
-		not_in_creative_inventory = 1},
+		not_in_creative_inventory = 1, cools_lava = 1},
 })
 
 
@@ -1436,7 +1436,7 @@ minetest.register_node("default:river_water_source", {
 	liquid_renewable = false,
 	liquid_range = 2,
 	post_effect_color = {a = 103, r = 30, g = 76, b = 90},
-	groups = {water = 3, liquid = 3, puts_out_fire = 1},
+	groups = {water = 3, liquid = 3, puts_out_fire = 1, cools_lava = 1},
 })
 
 minetest.register_node("default:river_water_flowing", {
@@ -1483,7 +1483,7 @@ minetest.register_node("default:river_water_flowing", {
 	liquid_range = 2,
 	post_effect_color = {a = 103, r = 30, g = 76, b = 90},
 	groups = {water = 3, liquid = 3, puts_out_fire = 1,
-		not_in_creative_inventory = 1},
+		not_in_creative_inventory = 1, cools_lava = 1},
 })
 
 


### PR DESCRIPTION
Make lava cooling ABM use a new group 'group:cools_lava'.
Nodes other than water can cool lava. We assume snowblock and ice melt,
turn to water and cool lava.
Leave 'group:water' present temporarily to not break mod liquids.
////////////////////////////////////////////////////////

See https://github.com/minetest/minetest_game/issues/1005#issuecomment-259122325