### PR TITLE
Give Initial Stuff: Localize 'items' and some tweaks

### DIFF
--- a/mods/give_initial_stuff/init.lua
+++ b/mods/give_initial_stuff/init.lua
@@ -31,7 +31,10 @@ function give_initial_stuff.add_from_csv(str)
 end
 
 function give_initial_stuff.set_list(list)
-	items = list
+	give_initial_stuff.clear()
+	for _, stack in ipairs(list) do
+		give_initial_stuff.add(stack)
+	end
 end
 
 function give_initial_stuff.get_list()

--- a/mods/give_initial_stuff/init.lua
+++ b/mods/give_initial_stuff/init.lua
@@ -35,7 +35,11 @@ function give_initial_stuff.set_list(list)
 end
 
 function give_initial_stuff.get_list()
-	return items
+	local copied = {}
+	for _, stack in ipairs(items) do
+		copied[#copied + 1] = ItemStack(stack)
+	end
+	return copied
 end
 
 give_initial_stuff.add_from_csv(stuff_string)

--- a/mods/give_initial_stuff/init.lua
+++ b/mods/give_initial_stuff/init.lua
@@ -2,40 +2,40 @@ local stuff_string = minetest.setting_get("initial_stuff") or
 		"default:pick_steel,default:axe_steel,default:shovel_steel," ..
 		"default:torch 99,default:cobble 99"
 
-give_initial_stuff = {
-	items = {}
-}
+local items = {}
+
+give_initial_stuff = {}
 
 function give_initial_stuff.give(player)
 	minetest.log("action",
 			"Giving initial stuff to player " .. player:get_player_name())
 	local inv = player:get_inventory()
-	for _, stack in ipairs(give_initial_stuff.items) do
+	for _, stack in ipairs(items) do
 		inv:add_item("main", stack)
 	end
 end
 
 function give_initial_stuff.add(stack)
-	give_initial_stuff.items[#give_initial_stuff.items + 1] = ItemStack(stack)
+	items[#items + 1] = ItemStack(stack)
 end
 
 function give_initial_stuff.clear()
-	give_initial_stuff.items = {}
+	items = {}
 end
 
 function give_initial_stuff.add_from_csv(str)
-	local items = str:split(",")
-	for _, itemname in ipairs(items) do
+	local add_items = str:split(",")
+	for _, itemname in ipairs(add_items) do
 		give_initial_stuff.add(itemname)
 	end
 end
 
 function give_initial_stuff.set_list(list)
-	give_initial_stuff.items = list
+	items = list
 end
 
 function give_initial_stuff.get_list()
-	return give_initial_stuff.items
+	return items
 end
 
 give_initial_stuff.add_from_csv(stuff_string)


### PR DESCRIPTION
Reason of localizing 'items': The list should be changed by only API.

(set_list) Copying an argument is needed for blocking this:
```lua
local items = {"default:stone"}
give_initial_stuff.set_list(items)

items[1] = "default:diamondblock 99"

local list = give_initial_stuff.get_list()
print(list[1]) -- -> It's diamond block. Besides, it's not ItemStack, it's a string.
```


(get_list) Copying a return value is needed for blocking this:
```lua
local list = give_initial_stuff.get_list()

list[1] = "default:diamondblock 99"

local list2 = give_initial_stuff.get_list()
print(list2[1]) -- -> It's diamond block. Besides, it's not ItemStack, it's a string.
```