### PR TITLE
Gunpowder (and tnt.burn) will trigger the on_ignite of nodes

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -308,8 +308,10 @@ TNT API
 
 `tnt.burn(position, [nodename])`
 
-^ Ignite TNT at position, nodename isn't required unless already known.
-
+^ Ignite node at position, triggering its `on_ignite` callback (see fire mod).
+If no such callback exists, fallback to turn tnt group nodes to their
+"_burning" variant.
+  nodename isn't required unless already known.
 
 To make dropping items from node inventories easier, you can use the
 following helper function from 'default':

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -250,13 +250,15 @@ end
 
 function tnt.burn(pos, nodename)
 	local name = nodename or minetest.get_node(pos).name
-	local group = minetest.get_item_group(name, "tnt")
-	if group > 0 then
+	local def = minetest.registered_nodes[name]
+	if not def then
+		return
+	elseif def.on_ignite then
+		def.on_ignite(pos)
+	elseif minetest.get_item_group(name, "tnt") > 0 then
 		minetest.sound_play("tnt_ignite", {pos = pos})
 		minetest.set_node(pos, {name = name .. "_burning"})
 		minetest.get_node_timer(pos):start(1)
-	elseif name == "tnt:gunpowder" then
-		minetest.set_node(pos, {name = "tnt:gunpowder_burning"})
 	end
 end
 


### PR DESCRIPTION
This changes `tnt.burn` (used by gunpowder) to trigger the `on_ignite` of the nodedef (see #1340).

The previous behavior (if the node has the tnt group, replace it with a node with "_burning" suffix and set timer to 1 second) is kept as fallback for compatibility, when the `on_ignite` is not defined in the node.

This expands the usefulness of gunpowder, as it will be able to ignite non-tnt related nodes that might do other things than turning into a burning variant. For example, you can make a circuit of gunpowder that will light up multiple coalblocks at once.