### PR TITLE
Fix whitespace errors to silence luacheck.

### DIFF
--- a/mods/beds/beds.lua
+++ b/mods/beds/beds.lua
@@ -66,7 +66,7 @@ beds.register_bed("beds:bed", {
 		},
 		top = {
 			"beds_bed_top_top.png^[transformR90",
-			"default_wood.png", 
+			"default_wood.png",
 			"beds_bed_side_top_r.png",
 			"beds_bed_side_top_r.png^[transformfx",
 			"beds_bed_side_top.png",

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -174,7 +174,7 @@ end
 
 -- Callbacks
 -- Only register respawn callback if respawn enabled
-if enable_respawn then 
+if enable_respawn then
 	-- respawn player at bed if enabled and valid position is found
 	minetest.register_on_respawnplayer(function(player)
 		local name = player:get_player_name()

--- a/mods/default/furnace.lua
+++ b/mods/default/furnace.lua
@@ -4,7 +4,7 @@
 --
 
 local function active_formspec(fuel_percent, item_percent)
-	local formspec = 
+	local formspec =
 		"size[8,8.5]"..
 		default.gui_bg..
 		default.gui_bg_img..

--- a/mods/default/player.lua
+++ b/mods/default/player.lua
@@ -94,7 +94,7 @@ minetest.register_on_joinplayer(function(player)
 	default.player_attached[player:get_player_name()] = false
 	default.player_set_model(player, "character.b3d")
 	player:set_local_animation({x=0, y=79}, {x=168, y=187}, {x=189, y=198}, {x=200, y=219}, 30)
-	
+
 	-- set GUI
 	if not minetest.setting_getbool("creative_mode") then
 		player:set_inventory_formspec(default.gui_survival_form)

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -519,7 +519,7 @@ function doors.register_trapdoor(name, def)
 	if not name:find(":") then
 		name = "doors:" .. name
 	end
-	
+
 	local name_closed = name
 	local name_opened = name.."_open"
 

--- a/mods/farming/nodes.lua
+++ b/mods/farming/nodes.lua
@@ -111,7 +111,7 @@ minetest.register_abm({
 		end
 		local nn_def = minetest.registered_nodes[nn.name] or nil
 		pos.y = pos.y - 1
-		
+
 		if nn_def and nn_def.walkable and minetest.get_item_group(nn.name, "plant") == 0 then
 			minetest.set_node(pos, {name = base})
 			return
@@ -133,7 +133,7 @@ minetest.register_abm({
 					if minetest.get_item_group(nn.name, "plant") == 0 and minetest.get_item_group(nn.name, "seed") == 0 then
 						minetest.set_node(pos, {name = base})
 					end
-					
+
 				-- if its wet turn it back into dry soil
 				elseif wet_lvl == 1 then
 					minetest.set_node(pos, {name = dry})
@@ -144,7 +144,7 @@ minetest.register_abm({
 })
 
 
-for i = 1, 5 do		
+for i = 1, 5 do
 	minetest.override_item("default:grass_"..i, {drop = {
 		max_items = 1,
 		items = {
@@ -153,7 +153,7 @@ for i = 1, 5 do
 		}
 	}})
 end
-	
+
 minetest.override_item("default:junglegrass", {drop = {
 	max_items = 1,
 	items = {

--- a/mods/sethome/init.lua
+++ b/mods/sethome/init.lua
@@ -43,9 +43,9 @@ end
 sethome.get = function(name)
 	local pos = homepos[name]
 	if pos then
-	 	return vector.new(pos)
+		return vector.new(pos)
 	else
-	 	return nil
+		return nil
 	end
 end
 


### PR DESCRIPTION
Currently all minetest_game PR's are failing travis since the
upstream luacheck now also warns about whitespace issues, and
there are a few of those in the code. This fixes all of them
so we can yet again rely on luacheck.