### PR TITLE
Carts: Increase power rail acceleration to help climbs

### DIFF
--- a/mods/carts/rails.lua
+++ b/mods/carts/rails.lua
@@ -20,6 +20,7 @@ minetest.register_craft({
 
 minetest.register_alias("default:rail", "carts:rail")
 
+
 carts:register_rail("carts:powerrail", {
 	description = "Powered rail",
 	tiles = {
@@ -27,7 +28,7 @@ carts:register_rail("carts:powerrail", {
 		"carts_rail_t_junction_pwr.png", "carts_rail_crossing_pwr.png"
 	},
 	groups = carts:get_rail_groups(),
-}, {acceleration = 4})
+}, {acceleration = 5})
 
 minetest.register_craft({
 	output = "carts:powerrail 8",
@@ -38,6 +39,7 @@ minetest.register_craft({
 	}
 })
 
+
 carts:register_rail("carts:brakerail", {
 	description = "Brake rail",
 	tiles = {
@@ -46,7 +48,6 @@ carts:register_rail("carts:brakerail", {
 	},
 	groups = carts:get_rail_groups(),
 }, {acceleration = -3})
-
 
 minetest.register_craft({
 	output = "carts:brakerail 8",


### PR DESCRIPTION
This is partly a workaround for a bug.
Climbs with continuous power rails were failing often due to
unexplained losses of speed leading to a reversal of direction.
The lack of acceleration on climbs meant that lost speed was not
regained.
Keeping cart speed at maximum on climbs helps reduce the chance of
reversals.

This also allows players to slowly accelerate up to full speed on a
climb without needing a horizontal run-up to reach full speed first.
It may not be possible to build the horizontal sections needed, or,
if players are replacing a previous carts mod their track
constructions, bridges, tunnels etc. will often not have the
horizontal sections needed.
Players will also sometimes need to place and enter a cart on a slope
and be able to climb.
//////////////////////////////////////////////////////

Partly a workaround for a bug #1407 
@rubenwardy @SmallJoker 