### PR TITLE
Farming/fire: Add tool break sounds

### DIFF
--- a/mods/farming/api.lua
+++ b/mods/farming/api.lua
@@ -50,7 +50,7 @@ farming.hoe_on_use = function(itemstack, user, pointed_thing, uses)
 		return
 	end
 
-	-- turn the node into soil, wear out item and play sound
+	-- turn the node into soil and play sound
 	minetest.set_node(pt.under, {name = regN[under.name].soil.dry})
 	minetest.sound_play("default_dig_crumbly", {
 		pos = pt.under,
@@ -58,7 +58,13 @@ farming.hoe_on_use = function(itemstack, user, pointed_thing, uses)
 	})
 
 	if not minetest.setting_getbool("creative_mode") then
+		-- wear tool
+		local wdef = itemstack:get_definition()
 		itemstack:add_wear(65535/(uses-1))
+		-- tool break sound
+		if itemstack:get_count() == 0 and wdef.sound and wdef.sound.breaks then
+			minetest.sound_play(wdef.sound.breaks, {pos = pt.above, gain = 0.5})
+		end
 	end
 	return itemstack
 end
@@ -94,6 +100,7 @@ farming.register_hoe = function(name, def)
 			return farming.hoe_on_use(itemstack, user, pointed_thing, def.max_uses)
 		end,
 		groups = def.groups,
+		sound = {breaks = "default_tool_breaks"},
 	})
 	-- Register its recipe
 	if def.material == nil then

--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -86,13 +86,14 @@ minetest.register_node("fire:permanent_flame", {
 minetest.register_tool("fire:flint_and_steel", {
 	description = "Flint and Steel",
 	inventory_image = "fire_flint_steel.png",
+	sound = {breaks = "default_tool_breaks"},
+
 	on_use = function(itemstack, user, pointed_thing)
 		local pt = pointed_thing
 		minetest.sound_play(
 			"fire_flint_and_steel",
-			{pos = pt.above, gain = 0.6, max_hear_distance = 8}
+			{pos = pt.above, gain = 0.5, max_hear_distance = 8}
 		)
-		itemstack:add_wear(1000)
 		if pt.type == "node" then
 			local node_under = minetest.get_node(pt.under).name
 			local nodedef = minetest.registered_nodes[node_under]
@@ -112,6 +113,13 @@ minetest.register_tool("fire:flint_and_steel", {
 			end
 		end
 		if not minetest.setting_getbool("creative_mode") then
+			-- wear tool
+			local wdef = itemstack:get_definition()
+			itemstack:add_wear(1000)
+			-- tool break sound
+			if itemstack:get_count() == 0 and wdef.sound and wdef.sound.breaks then
+				minetest.sound_play(wdef.sound.breaks, {pos = pt.above, gain = 0.5})
+			end
 			return itemstack
 		end
 	end


### PR DESCRIPTION
Add tool break sounds to hoes and flint and steel.
Flint and steel: Reduce gain of use sound and only add tool wear
if not in creative mode.
/////////////////////////////////////////////////

Addresses #1395 