### PR TITLE
Boats / carts: Fix on_punch functions 

### DIFF
--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -109,18 +109,19 @@ function boat.on_punch(self, puncher)
 	end
 	if not self.driver then
 		self.removed = true
+		local inv = puncher:get_inventory()
+		if not minetest.setting_getbool("creative_mode")
+				or not inv:contains_item("main", "boats:boat") then
+			local leftover = inv:add_item("main", "boats:boat")
+			-- if no room in inventory add a replacement boat to the world
+			if not leftover:is_empty() then
+				minetest.add_item(self.object:getpos(), leftover)
+			end
+		end
 		-- delay remove to ensure player is detached
 		minetest.after(0.1, function()
 			self.object:remove()
 		end)
-		if not minetest.setting_getbool("creative_mode") then
-			local inv = puncher:get_inventory()
-			if inv:room_for_item("main", "boats:boat") then
-				inv:add_item("main", "boats:boat")
-			else
-				minetest.add_item(self.object:getpos(), "boats:boat")
-			end
-		end
 	end
 end
 


### PR DESCRIPTION
Boats:
Previously, boats were not added to inventory in creative mode, fix.
In creative mode multiple boats will not be added to inventory.
Add comment.

Carts:
Set speed to 2 if punched by a non-player, to match the effect of a
player punch.
Add comments.
//////////////////////////////////////////////

Addresses #1426 by using the code from carts.
Plus some other fixes and improvements.