### PR TITLE
Default: Make Book with Text a furnace fuel

### DIFF
--- a/mods/default/crafting.lua
+++ b/mods/default/crafting.lua
@@ -1077,6 +1077,12 @@ minetest.register_craft({
 
 minetest.register_craft({
 	type = "fuel",
+	recipe = "default:book_written",
+	burntime = 3,
+})
+
+minetest.register_craft({
+	type = "fuel",
 	recipe = "default:dry_shrub",
 	burntime = 2,
 })


### PR DESCRIPTION
The book is already a fuel, so it seems only consequent to make the book with text (`default:book_written`) a furnace fuel as well.

Burning time: 3 (just like the normal book (`default:book`).