### PR TITLE
Change wheat into # shaped plant.

### DIFF
--- a/mods/farming/api.lua
+++ b/mods/farming/api.lua
@@ -213,7 +213,11 @@ farming.grow_plant = function(pos, elapsed)
 		-- omitted is a check for light, we assume seeds can germinate in the dark.
 		for _, v in pairs(def.fertility) do
 			if minetest.get_item_group(soil_node.name, v) ~= 0 then
-				minetest.swap_node(pos, {name = def.next_plant})
+				local placenode = {name = def.next_plant}
+				if def.place_param2 then
+					placenode.param2 = def.place_param2
+				end
+				minetest.swap_node(pos, placenode)
 				if minetest.registered_nodes[def.next_plant].next_plant then
 					tick(pos)
 					return
@@ -239,7 +243,11 @@ farming.grow_plant = function(pos, elapsed)
 	end
 
 	-- grow
-	minetest.swap_node(pos, {name = def.next_plant})
+	local placenode = {name = def.next_plant}
+	if def.place_param2 then
+		placenode.param2 = def.place_param2
+	end
+	minetest.swap_node(pos, placenode)
 
 	-- new timer needed?
 	if minetest.registered_nodes[def.next_plant].next_plant then
@@ -290,6 +298,7 @@ farming.register_plant = function(name, def)
 		groups = g,
 		paramtype = "light",
 		paramtype2 = "wallmounted",
+		place_param2 = def.place_param2 or nil, -- this isn't actually used for placement
 		walkable = false,
 		sunlight_propagates = true,
 		selection_box = {
@@ -343,6 +352,8 @@ farming.register_plant = function(name, def)
 			waving = 1,
 			tiles = {mname .. "_" .. pname .. "_" .. i .. ".png"},
 			paramtype = "light",
+			paramtype2 = def.paramtype2 or nil,
+			place_param2 = def.place_param2 or nil,
 			walkable = false,
 			buildable_to = true,
 			drop = drop,

--- a/mods/farming/init.lua
+++ b/mods/farming/init.lua
@@ -10,12 +10,14 @@ dofile(farming.path .. "/hoes.lua")
 -- WHEAT
 farming.register_plant("farming:wheat", {
 	description = "Wheat seed",
+	paramtype2 = "meshoptions",
 	inventory_image = "farming_wheat_seed.png",
 	steps = 8,
 	minlight = 13,
 	maxlight = default.LIGHT_MAX,
 	fertility = {"grassland"},
 	groups = {flammable = 4},
+	place_param2 = 3,
 })
 minetest.register_craftitem("farming:flour", {
 	description = "Flour",


### PR DESCRIPTION
This changes the farming API such that any nodedef with paramtype2
and place_param2 are passed through to all the plant stages of the
farming plant.

This allows plants to use an alternative mesh for the plantlike
drawtype, and provide a bit of graphical variation in plants.

We enable this for wheat, using place_param2 = 3, which is the '#'
shaped plant mesh. If you would actually be able to give yourself
this plant in creative or through /give, you would also get the
same '#' shape.