### PR TITLE
Snappy group: Remove beds and cactus from group

### DIFF
--- a/mods/beds/api.lua
+++ b/mods/beds/api.lua
@@ -33,7 +33,7 @@ function beds.register_bed(name, def)
 		paramtype2 = "facedir",
 		is_ground_content = false,
 		stack_max = 1,
-		groups = {snappy = 1, choppy = 2, oddly_breakable_by_hand = 2, flammable = 3, bed = 1},
+		groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 3, bed = 1},
 		sounds = default.node_sound_wood_defaults(),
 		node_box = {
 			type = "fixed",
@@ -137,7 +137,7 @@ function beds.register_bed(name, def)
 		paramtype2 = "facedir",
 		is_ground_content = false,
 		pointable = false,
-		groups = {snappy = 1, choppy = 2, oddly_breakable_by_hand = 2, flammable = 3, bed = 2},
+		groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 3, bed = 2},
 		sounds = default.node_sound_wood_defaults(),
 		drop = name .. "_bottom",
 		node_box = {

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1048,7 +1048,7 @@ minetest.register_node("default:cactus", {
 	tiles = {"default_cactus_top.png", "default_cactus_top.png",
 		"default_cactus_side.png"},
 	paramtype2 = "facedir",
-	groups = {snappy = 1, choppy = 3},
+	groups = {choppy = 3},
 	sounds = default.node_sound_wood_defaults(),
 	on_place = minetest.rotate_node,
 })


### PR DESCRIPTION
See #1430 

List of current snappy nodes:
Wool.
All flowers.
Beds.
Saplings.
Leaves.
Bush leaves.
Xpane glass.
Farming crops.
Straw.
Cactus.
Papyrus.
Dry shrub.
Junglegrass.
All grasses.

Snappy is primarily the group for swords.
Beds would require an axe for the frame.
Cacti are 1 metre thick and seem out of place in this list.