### PR TITLE
Make furnaces work when unloaded.

### DIFF
--- a/mods/default/furnace.lua
+++ b/mods/default/furnace.lua
@@ -113,62 +113,70 @@ local function furnace_node_timer(pos, elapsed)
 	local fuel_totaltime = meta:get_float("fuel_totaltime") or 0
 
 	local inv = meta:get_inventory()
-	local srclist = inv:get_list("src")
-	local fuellist = inv:get_list("fuel")
+	local srclist, fuellist
 
-	--
-	-- Cooking
-	--
+	local cookable, cooked
 
-	-- Check if we have cookable content
-	local cooked, aftercooked = minetest.get_craft_result({method = "cooking", width = 1, items = srclist})
-	local cookable = true
+	local update = true
+	while update do
+		update = false
 
-	if cooked.time == 0 then
-		cookable = false
-	end
+		srclist = inv:get_list("src")
+		fuellist = inv:get_list("fuel")
 
-	-- Check if we have enough fuel to burn
-	if fuel_time < fuel_totaltime then
-		-- The furnace is currently active and has enough fuel
-		fuel_time = fuel_time + 1
+		--
+		-- Cooking
+		--
 
-		-- If there is a cookable item then check if it is ready yet
-		if cookable then
-			src_time = src_time + 1
-			if src_time >= cooked.time then
-				-- Place result in dst list if possible
-				if inv:room_for_item("dst", cooked.item) then
-					inv:add_item("dst", cooked.item)
-					inv:set_stack("src", 1, aftercooked.items[1])
-					src_time = 0
+		-- Check if we have cookable content
+		local aftercooked
+		cooked, aftercooked = minetest.get_craft_result({method = "cooking", width = 1, items = srclist})
+		cookable = cooked.time ~= 0
+
+		-- Check if we have enough fuel to burn
+		if fuel_time < fuel_totaltime then
+			-- The furnace is currently active and has enough fuel
+			fuel_time = fuel_time + elapsed
+			-- If there is a cookable item then check if it is ready yet
+			if cookable then
+				src_time = src_time + elapsed
+				if src_time >= cooked.time then
+					-- Place result in dst list if possible
+					if inv:room_for_item("dst", cooked.item) then
+						inv:add_item("dst", cooked.item)
+						inv:set_stack("src", 1, aftercooked.items[1])
+						src_time = src_time - cooked.time
+						update = true
+					end
 				end
 			end
-		end
-	else
-		-- Furnace ran out of fuel
-		if cookable then
-			-- We need to get new fuel
-			local fuel, afterfuel = minetest.get_craft_result({method = "fuel", width = 1, items = fuellist})
-
-			if fuel.time == 0 then
-				-- No valid fuel in fuel list
-				fuel_totaltime = 0
-				fuel_time = 0
-				src_time = 0
-			else
-				-- Take fuel from fuel list
-				inv:set_stack("fuel", 1, afterfuel.items[1])
-
-				fuel_totaltime = fuel.time
-				fuel_time = 0
-			end
 		else
-			-- We don't need to get new fuel since there is no cookable item
-			fuel_totaltime = 0
+			-- Furnace ran out of fuel
+			if cookable then
+				-- We need to get new fuel
+				local fuel, afterfuel = minetest.get_craft_result({method = "fuel", width = 1, items = fuellist})
+
+				if fuel.time == 0 then
+					-- No valid fuel in fuel list
+					fuel_totaltime = 0
+					src_time = 0
+				else
+					-- Take fuel from fuel list
+					inv:set_stack("fuel", 1, afterfuel.items[1])
+					update = true
+
+					fuel_totaltime = fuel.time + (fuel_time - fuel_totaltime)
+					src_time = src_time + elapsed
+				end
+			else
+				-- We don't need to get new fuel since there is no cookable item
+				fuel_totaltime = 0
+				src_time = 0
+			end
 			fuel_time = 0
-			src_time = 0
 		end
+
+		elapsed = 0
 	end
 
 	--
@@ -196,7 +204,7 @@ local function furnace_node_timer(pos, elapsed)
 	local active = "inactive "
 	local result = false
 
-	if fuel_time <= fuel_totaltime and fuel_totaltime ~= 0 then
+	if fuel_totaltime ~= 0 then
 		active = "active "
 		local fuel_percent = math.floor(fuel_time / fuel_totaltime * 100)
 		fuel_state = fuel_percent .. "%"
@@ -210,8 +218,7 @@ local function furnace_node_timer(pos, elapsed)
 		end
 		swap_node(pos, "default:furnace")
 		-- stop timer on the inactive furnace
-		local timer = minetest.get_node_timer(pos)
-		timer:stop()
+		minetest.get_node_timer(pos):stop()
 	end
 
 	local infotext = "Furnace " .. active .. "(Item: " .. item_state .. "; Fuel: " .. fuel_state .. ")"
@@ -259,13 +266,11 @@ minetest.register_node("default:furnace", {
 	end,
 
 	on_metadata_inventory_move = function(pos)
-		local timer = minetest.get_node_timer(pos)
-		timer:start(1.0)
+		minetest.get_node_timer(pos):start(1.0)
 	end,
 	on_metadata_inventory_put = function(pos)
 		-- start timer function, it will sort out whether furnace can burn or not.
-		local timer = minetest.get_node_timer(pos)
-		timer:start(1.0)
+		minetest.get_node_timer(pos):start(1.0)
 	end,
 	on_blast = function(pos)
 		local drops = {}


### PR DESCRIPTION
This is slightly modified after #1279 - the setting for furnace
timer was removed and hardcoded to 1.0s, which is the old furnace
timer interval.