### PR TITLE
Sounds: Edit some sound gains, mostly footsteps

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -18,7 +18,7 @@ end
 function default.node_sound_stone_defaults(table)
 	table = table or {}
 	table.footstep = table.footstep or
-			{name = "default_hard_footstep", gain = 0.5}
+			{name = "default_hard_footstep", gain = 0.3}
 	table.dug = table.dug or
 			{name = "default_hard_footstep", gain = 1.0}
 	default.node_sound_defaults(table)
@@ -28,9 +28,9 @@ end
 function default.node_sound_dirt_defaults(table)
 	table = table or {}
 	table.footstep = table.footstep or
-			{name = "default_dirt_footstep", gain = 1.0}
+			{name = "default_dirt_footstep", gain = 0.4}
 	table.dug = table.dug or
-			{name = "default_dirt_footstep", gain = 1.5}
+			{name = "default_dirt_footstep", gain = 1.0}
 	table.place = table.place or
 			{name = "default_place_node", gain = 1.0}
 	default.node_sound_defaults(table)
@@ -52,7 +52,7 @@ end
 function default.node_sound_gravel_defaults(table)
 	table = table or {}
 	table.footstep = table.footstep or
-			{name = "default_gravel_footstep", gain = 0.5}
+			{name = "default_gravel_footstep", gain = 0.4}
 	table.dug = table.dug or
 			{name = "default_gravel_footstep", gain = 1.0}
 	table.place = table.place or
@@ -64,7 +64,7 @@ end
 function default.node_sound_wood_defaults(table)
 	table = table or {}
 	table.footstep = table.footstep or
-			{name = "default_wood_footstep", gain = 0.5}
+			{name = "default_wood_footstep", gain = 0.3}
 	table.dug = table.dug or
 			{name = "default_wood_footstep", gain = 1.0}
 	default.node_sound_defaults(table)
@@ -74,7 +74,7 @@ end
 function default.node_sound_leaves_defaults(table)
 	table = table or {}
 	table.footstep = table.footstep or
-			{name = "default_grass_footstep", gain = 0.35}
+			{name = "default_grass_footstep", gain = 0.45}
 	table.dug = table.dug or
 			{name = "default_grass_footstep", gain = 0.7}
 	table.dig = table.dig or
@@ -88,9 +88,9 @@ end
 function default.node_sound_glass_defaults(table)
 	table = table or {}
 	table.footstep = table.footstep or
-			{name = "default_glass_footstep", gain = 0.25}
+			{name = "default_glass_footstep", gain = 0.3}
 	table.dig = table.dig or
-			{name = "default_glass_footstep", gain = 0.45}
+			{name = "default_glass_footstep", gain = 0.5}
 	table.dug = table.dug or
 			{name = "default_break_glass", gain = 1.0}
 	default.node_sound_defaults(table)
@@ -100,7 +100,7 @@ end
 function default.node_sound_metal_defaults(table)
 	table = table or {}
 	table.footstep = table.footstep or
-			{name = "default_metal_footstep", gain = 0.5}
+			{name = "default_metal_footstep", gain = 0.4}
 	table.dig = table.dig or
 			{name = "default_dig_metal", gain = 0.5}
 	table.dug = table.dug or


### PR DESCRIPTION
I recently made glass footstep and dig gains too low, raise slightly.
Change dirt dug gain from above-maximum 1.5 to maximum 1.0.
Reduce gain of footsteps: stone, dirt, gravel, wood, metal
Raise gain of leaves footstep.
///////////////////////////////////////////////

![screenshot_20161215_080014](https://cloud.githubusercontent.com/assets/3686677/21216725/54f2e5dc-c2a0-11e6-808e-0eccffb85c8b.png)

^ My test setup with stone around dirt to stop grass spread

I set a couple of glass sounds too quiet in a recent commit 55a16cd2c6c56e2b15b495fc5311e8cdc4ef8e47 this corrects that.

I was hoping some other changes can be done during freeze since changing sound gains is harmless.
Many footstep sounds are too loud, noticeable on servers with the excessive sound of other player's footsteps.
The relative levels don't make much sense.
Dirt was extremely loud for walking on soil.
Stone and wood footsteps were too loud.
Gravel and metal footsteps were slightly too loud.
The dirt dug sound didn't seem to distort at 1.5 but sounds identical at 1.0, it may be hitting a limit, or perhaps gain is limited to 1.0.
The leaves footstep is raised slightly to distinguish from grass footstep, and to be more suitable for walking around on rustling leaves.

We have a few sounds already at gain = 1.0, which i suspect is a maximum, so to balance levels we need to be reducing gains more than raising them.