### PR TITLE
Boats: Avoid crash if boat pos over limit

### DIFF
--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -233,9 +233,11 @@ minetest.register_craftitem("boats:boat", {
 		end
 		pointed_thing.under.y = pointed_thing.under.y + 0.5
 		boat = minetest.add_entity(pointed_thing.under, "boats:boat")
-		boat:setyaw(placer:get_look_horizontal())
-		if not minetest.setting_getbool("creative_mode") then
-			itemstack:take_item()
+		if boat then
+			boat:setyaw(placer:get_look_horizontal())
+			if not minetest.setting_getbool("creative_mode") then
+				itemstack:take_item()
+			end
 		end
 		return itemstack
 	end,


### PR DESCRIPTION
If the boat pos is over limit, 'add entity' will not add an entity,
causing 'boat' to be nil.
///////////////////////////////////////////////

Avoids crashes due to buggy map gen limit code.
See discussion in https://github.com/minetest/minetest/issues/4923
Tested by placing boats over-limit, error is printed to screen, boat is removed but no crash.