### PR TITLE
decrease the value of gunpowder for trails

### DIFF
--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -498,7 +498,7 @@ minetest.register_node("tnt:gunpowder_burning", {
 })
 
 minetest.register_craft({
-	output = "tnt:gunpowder",
+	output = "tnt:gunpowder 5",
 	type = "shapeless",
 	recipe = {"default:coal_lump", "default:gravel"}
 })
@@ -507,9 +507,9 @@ if enable_tnt then
 	minetest.register_craft({
 		output = "tnt:tnt",
 		recipe = {
-			{"",           "group:wood",    ""},
-			{"group:wood", "tnt:gunpowder", "group:wood"},
-			{"",           "group:wood",    ""}
+			{"tnt:gunpowder", "group:wood",    "tnt:gunpowder"},
+			{"group:wood",    "tnt:gunpowder", "group:wood"},
+			{"tnt:gunpowder", "group:wood",    "tnt:gunpowder"}
 		}
 	})
 

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -507,9 +507,9 @@ if enable_tnt then
 	minetest.register_craft({
 		output = "tnt:tnt",
 		recipe = {
-			{"tnt:gunpowder", "group:wood",    "tnt:gunpowder"},
 			{"group:wood",    "tnt:gunpowder", "group:wood"},
-			{"tnt:gunpowder", "group:wood",    "tnt:gunpowder"}
+			{"tnt:gunpowder", "tnt:gunpowder", "tnt:gunpowder"},
+			{"group:wood",    "tnt:gunpowder", "group:wood"}
 		}
 	})
 


### PR DESCRIPTION
at now nobody uses gunpowder for trails because for every gunpowder you could have one tnt explosion
this edits the crafting recipes so, that you get 5 gunpowder instead of one and need 5 for one tnt, so, that the player doesnt think he would waste that much