### PR TITLE
Ores: Add silver sand blob ore, relocate other blob ores 

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -45,11 +45,11 @@ minetest.register_alias("mapgen_stair_sandstonebrick", "stairs:stair_sandstonebr
 
 function default.register_ores()
 	minetest.clear_registered_ores()
+
 	-- Blob ores
 	-- These first to avoid other ores in blobs
 
 	-- Clay
-	-- This first to avoid clay in sand blobs
 
 	minetest.register_ore({
 		ore_type        = "blob",
@@ -70,17 +70,16 @@ function default.register_ores()
 		},
 	})
 
-	-- Sand
+	-- Silver sand
 
 	minetest.register_ore({
 		ore_type        = "blob",
-		ore             = "default:sand",
-		wherein         = {"default:stone", "default:sandstone",
-			"default:desert_stone"},
+		ore             = "default:silver_sand",
+		wherein         = {"default:stone"},
 		clust_scarcity  = 16 * 16 * 16,
 		clust_size      = 5,
-		y_min           = -31,
-		y_max           = 0,
+		y_min           = -31000,
+		y_max           = 31000,
 		noise_threshold = 0.0,
 		noise_params    = {
 			offset = 0.5,
@@ -90,6 +89,13 @@ function default.register_ores()
 			octaves = 1,
 			persist = 0.0
 		},
+		biomes = {"icesheet_ocean", "tundra", "tundra_beach", "tundra_ocean",
+			"taiga", "taiga_ocean", "snowy_grassland", "snowy_grassland_ocean",
+			"grassland", "grassland_dunes", "grassland_ocean", "coniferous_forest",
+			"coniferous_forest_dunes", "coniferous_forest_ocean", "deciduous_forest",
+			"deciduous_forest_shore", "deciduous_forest_ocean", "cold_desert",
+			"cold_desert_ocean", "savanna", "savanna_shore", "savanna_ocean",
+			"rainforest", "rainforest_swamp", "rainforest_ocean", "underground"}
 	})
 
 	-- Dirt
@@ -112,7 +118,8 @@ function default.register_ores()
 			persist = 0.0
 		},
 		biomes = {"taiga", "snowy_grassland", "grassland", "coniferous_forest",
-			"deciduous_forest", "savanna", "rainforest"}
+			"deciduous_forest", "deciduous_forest_shore", "savanna", "savanna_shore",
+			"rainforest", "rainforest_swamp"}
 	})
 
 	-- Gravel
@@ -134,6 +141,13 @@ function default.register_ores()
 			octaves = 1,
 			persist = 0.0
 		},
+		biomes = {"icesheet_ocean", "tundra", "tundra_beach", "tundra_ocean",
+			"taiga", "taiga_ocean", "snowy_grassland", "snowy_grassland_ocean",
+			"grassland", "grassland_dunes", "grassland_ocean", "coniferous_forest",
+			"coniferous_forest_dunes", "coniferous_forest_ocean", "deciduous_forest",
+			"deciduous_forest_shore", "deciduous_forest_ocean", "cold_desert",
+			"cold_desert_ocean", "savanna", "savanna_shore", "savanna_ocean",
+			"rainforest", "rainforest_swamp", "rainforest_ocean", "underground"}
 	})
 
 	-- Scatter ores


### PR DESCRIPTION
The original mgv5 had dirt, sand and gravel blobs throughout the world.
Classic mgv6 had gravel throughout the world but dirt and sand blobs only near sea level.
Current mapgens all have the same blob ore distribution which is gravel throughout, dirt from sea level upwards (because dirt will be present in floatlands) and sand only near sea level (because yellow sand is only found in lakes, beaches and dunes).

Adding sand resources underground is very useful for crafting glass for underground constructions and the meselamps needed for underground farming.

////////////////////////////////////////

Yellow sand blob ore is removed and replaced by silver sand blob ore, which is considered to be a further breakdown in the sequence stone -> gravel -> silver sand, therefore it can be placed throughout the world where-ever stone is, adding sand (and therefore glass) resources underground and in any floatlands. Currently sand is not found underground or in any floatlands.

The biome locations of dirt blobs is corrected, a few biomes were left out.

Biome locations for gravel are added to limit the blobs to where grey stone is, the same biome list is used for silver sand blobs.

These changes mean we lose yellow sand blob ore, but this was only ever found between y = 0 and y = -32, and yellow sand is still found nearby at chunk borders in tunnels and of course in huge amounts in lakes.