### PR TITLE
Default: More generous meselamp recipe

### DIFF
--- a/mods/default/crafting.lua
+++ b/mods/default/crafting.lua
@@ -632,10 +632,10 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-	output = 'default:meselamp 1',
+	output = 'default:meselamp',
 	recipe = {
-		{'', 'default:mese_crystal',''},
-		{'default:mese_crystal', 'default:glass', 'default:mese_crystal'},
+		{'default:glass'},
+		{'default:mese_crystal'},
 	}
 })
 


### PR DESCRIPTION
Sorry i missed this for so long, i only just saw that 3 mese crystals are needed for a meselamp, this makes farming in dark areas too expensive (mese ore is less common than coal) and is inconsistent with how torches are made from a single coal lump (one ore node -> one light).

The recipe is made not 'shapeless' to try and avoid recipe conflicts.
I have made it intuitive to remember, think 'glass over a mese crystal'.

This really should be merged to partially address the recent complaints.