### PR TITLE
Default: Alter sand to sandstone recipe

### DIFF
--- a/mods/default/crafting.lua
+++ b/mods/default/crafting.lua
@@ -495,10 +495,10 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-	output = 'default:sandstone',
+	output = "default:sandstone",
 	recipe = {
-		{'group:sand', 'group:sand'},
-		{'group:sand', 'group:sand'},
+		{"default:sand", "default:sand"},
+		{"default:sand", "default:sand"},
 	}
 })
 


### PR DESCRIPTION
Craft 4 default:sand to default:sandstone.

Previously, 4 group:sand was craftable to sandstone and sandstone was
craftable back into default:sand, allowing silver and desert sands to
be converted into incorrect colour sandstone and yellow sand.
////////////////////////////////////////////////////

Addresses #1498 