### PR TITLE
Add support for custom bed sounds

### DIFF
--- a/mods/beds/api.lua
+++ b/mods/beds/api.lua
@@ -34,7 +34,7 @@ function beds.register_bed(name, def)
 		is_ground_content = false,
 		stack_max = 1,
 		groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 3, bed = 1},
-		sounds = default.node_sound_wood_defaults(),
+		sounds = def.sounds or default.node_sound_wood_defaults(),
 		node_box = {
 			type = "fixed",
 			fixed = def.nodebox.bottom,
@@ -138,7 +138,7 @@ function beds.register_bed(name, def)
 		is_ground_content = false,
 		pointable = false,
 		groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 3, bed = 2},
-		sounds = default.node_sound_wood_defaults(),
+		sounds = def.sounds or default.node_sound_wood_defaults(),
 		drop = name .. "_bottom",
 		node_box = {
 			type = "fixed",


### PR DESCRIPTION
I was creating a mod adding a new type of bed made out of straw and noticed the bed api didn't support changing the default bed nodes sounds, it is a bit of a problem for beds made out of other materials than wood so I changed that.
