### PR TITLE
Revert "Doors: Remove ..." and "Doors: Allow the screwdriver to ..."

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -376,7 +376,9 @@ function doors.register(name, def)
 		minetest.remove_node({x = pos.x, y = pos.y + 1, z = pos.z})
 		minetest.check_for_falling({x = pos.x, y = pos.y + 1, z = pos.z})
 	end
-	def.on_rotate = false
+	def.on_rotate = function(pos, node, user, mode, new_param2)
+		return false
+	end
 
 	if def.protected then
 		def.can_dig = can_dig_door


### PR DESCRIPTION
This reverts commit 5e4a6e8ac68b92c7394b80bb67839b71b4a4a00b, and
             commit 60cf3f85b6e661482ec2705cadbdc1b04e388d19.

The original door API rewrite I posted had all rotation disabled using
the correct on_rotate() handler returning `false`. Two subsequent
changes attempting first to enable simple rotation and second disabling
that again changed the callback handler to a boolean `false`, which
is incorrect use in the screwdriver API, and actually allows rotation.

The proper way to disable rotation for facedir nodes it to use a full
callback handler that does `return false`.