### PR TITLE
Sounds: Remove 'default_dig_crumbly' from leaves defaults table

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -77,8 +77,6 @@ function default.node_sound_leaves_defaults(table)
 			{name = "default_grass_footstep", gain = 0.45}
 	table.dug = table.dug or
 			{name = "default_grass_footstep", gain = 0.7}
-	table.dig = table.dig or
-			{name = "default_dig_crumbly", gain = 0.4}
 	table.place = table.place or
 			{name = "default_place_node", gain = 1.0}
 	default.node_sound_defaults(table)


### PR DESCRIPTION
Now that the missing 'default_dig_snappy' sound has been added we can
remove the dirt dig sound from the table. All nodes that use the
leaves defaults table have group 'snappy' so 'default_dig_snappy' now
becomes their default dig sound.
/////////////////////////////////////////////////////

Now finally we can stop using a dirt dig sound for plant nodes using the 'node sounds leaves default' table. These nodes now use the new 'default dig snappy' sound instead.

Tested.