### PR TITLE
Creative: Optimize some functions

### DIFF
--- a/mods/creative/inventory.lua
+++ b/mods/creative/inventory.lua
@@ -1,5 +1,7 @@
 creative = {}
-local player_inventory = {}
+local creative_mode = minetest.setting_getbool("creative_mode")
+local player_inventory, creative_list, original_list = {}, {}, {}
+local max, floor, ceil, sort = math.max, math.floor, math.ceil, table.sort
 
 function creative.init_creative_inventory(player)
 	local player_name = player:get_player_name()
@@ -11,11 +13,7 @@ function creative.init_creative_inventory(player)
 
 	minetest.create_detached_inventory("creative_" .. player_name, {
 		allow_move = function(inv, from_list, from_index, to_list, to_index, count, player2)
-			if not to_list == "main" then
-				return count
-			else
-				return 0
-			end
+			return to_list ~= "main" and count or 0
 		end,
 		allow_put = function(inv, listname, index, stack, player2)
 			return 0
@@ -29,7 +27,8 @@ function creative.init_creative_inventory(player)
 		end,
 		on_take = function(inv, listname, index, stack, player2)
 			if stack and stack:get_count() > 0 then
-				minetest.log("action", player_name .. " takes " .. stack:get_name().. " from creative inventory")
+				minetest.log("action", player_name .. " takes " ..
+					stack:get_name() .. " from creative inventory")
 			end
 		end,
 	}, player_name)
@@ -38,26 +37,37 @@ function creative.init_creative_inventory(player)
 end
 
 function creative.update_creative_inventory(player_name, tab_content)
-	local creative_list = {}
-	local player_inv = minetest.get_inventory({type = "detached", name = "creative_" .. player_name})
-	local inv = player_inventory[player_name]
-	if not inv then
+	local player_inv = minetest.get_inventory({
+		type = "detached", name = "creative_" .. player_name})
+	local inv = player_inventory[player_name] or
 		creative.init_creative_inventory(minetest.get_player_by_name(player_name))
-	end
 
-	for name, def in pairs(tab_content) do
-		if not (def.groups.not_in_creative_inventory == 1) and
-				def.description and def.description ~= "" and
-				(def.name:find(inv.filter, 1, true) or
-					def.description:lower():find(inv.filter, 1, true)) then
-			creative_list[#creative_list+1] = name
+	if not creative_list[tab_content] or inv.filter ~= "" then
+		creative_list[tab_content] = {}
+		local c = 0
+
+		for name, def in pairs(tab_content) do
+			if not (def.groups.not_in_creative_inventory == 1) and
+				def.description and def.description ~= ""  and
+			       (def.name:find(inv.filter, 1, true)	   or
+				def.description:lower():find(inv.filter, 1, true)) then
+
+				c = c + 1
+				creative_list[tab_content][c] = name
+			end
 		end
+		sort(creative_list[tab_content])
 	end
 
-	table.sort(creative_list)
-	player_inv:set_size("main", #creative_list)
-	player_inv:set_list("main", creative_list)
-	inv.size = #creative_list
+	if not original_list[tab_content] and inv.filter == "" then
+		original_list[tab_content] = creative_list[tab_content]
+	end
+	inv.size = (inv.filter == "" and original_list[tab_content]) and
+		#original_list[tab_content] or #creative_list[tab_content]
+
+	player_inv:set_size("main", inv.size)
+	player_inv:set_list("main", inv.filter == "" and
+		original_list[tab_content] or creative_list[tab_content])
 end
 
 -- Create the trash field
@@ -79,17 +89,19 @@ function creative.register_tab(name, title, items)
 	sfinv.register_page("creative:" .. name, {
 		title = title,
 		is_in_nav = function(self, player, context)
-			return minetest.setting_getbool("creative_mode")
+			return creative_mode
 		end,
 		get = function(self, player, context)
 			local player_name = player:get_player_name()
 			creative.update_creative_inventory(player_name, items)
 			local inv = player_inventory[player_name]
 			local start_i = inv.start_i or 0
-			local pagenum = math.floor(start_i / (3*8) + 1)
-			local pagemax = math.ceil(inv.size / (3*8))
+			local pagenum = floor(start_i / (3*8) + 1)
+			local pagemax = ceil(inv.size / (3*8))
+
 			return sfinv.make_formspec(player, context,
-				"label[6.2,3.35;" .. minetest.colorize("#FFFF00", tostring(pagenum)) .. " / " .. tostring(pagemax) .. "]" ..
+				"label[6.2,3.35;" .. minetest.colorize("#FFFF00",
+					tostring(pagenum)) .. " / " .. tostring(pagemax) .. "]" ..
 				[[
 					image[4.06,3.4;0.8,0.8;creative_trash_icon.png]
 					listcolors[#00000069;#5A5A5A;#141318;#30434C;#FFF]
@@ -106,9 +118,11 @@ function creative.register_tab(name, title, items)
 					listring[current_player;main]
 					field_close_on_enter[creative_filter;false]
 				]] ..
-				"field[0.3,3.5;2.2,1;creative_filter;;" .. minetest.formspec_escape(inv.filter) .. "]" ..
+				"field[0.3,3.5;2.2,1;creative_filter;;" ..
+					minetest.formspec_escape(inv.filter) .. "]" ..
 				"listring[detached:creative_" .. player_name .. ";main]" ..
-				"list[detached:creative_" .. player_name .. ";main;0,0;8,3;" .. tostring(start_i) .. "]" ..
+				"list[detached:creative_" .. player_name ..
+					";main;0,0;8,3;" .. tostring(start_i) .. "]" ..
 				default.get_hotbar_bg(0,4.7) ..
 				default.gui_bg .. default.gui_bg_img .. default.gui_slots
 				.. creative.formspec_add, false)
@@ -116,9 +130,7 @@ function creative.register_tab(name, title, items)
 		on_enter = function(self, player, context)
 			local player_name = player:get_player_name()
 			local inv = player_inventory[player_name]
-			if inv then
-				inv.start_i = 0
-			end
+			inv.start_i = inv and 0
 		end,
 		on_player_receive_fields = function(self, player, context, fields)
 			local player_name = player:get_player_name()
@@ -138,13 +150,12 @@ function creative.register_tab(name, title, items)
 				sfinv.set_player_inventory_formspec(player, context)
 			elseif not fields.quit then
 				local start_i = inv.start_i or 0
-
 				if fields.creative_prev then
 					start_i = start_i - 3*8
 					if start_i < 0 then
 						start_i = inv.size - (inv.size % (3*8))
 						if inv.size == start_i then
-							start_i = math.max(0, inv.size - (3*8))
+							start_i = max(0, inv.size - (3*8))
 						end
 					end
 				elseif fields.creative_next then
@@ -172,9 +183,5 @@ creative.register_tab("craftitems", "Items", minetest.registered_craftitems)
 
 local old_homepage_name = sfinv.get_homepage_name
 function sfinv.get_homepage_name(player)
-	if minetest.setting_getbool("creative_mode") then
-		return "creative:all"
-	else
-		return old_homepage_name(player)
-	end
+	return creative_mode and "creative:all" or old_homepage_name(player)
 end


### PR DESCRIPTION
Before, changing of page, changing of (already visited) tab or clearing the filter triggered a lookup over all registered items and performed a table sorting inside the function `update_creative_inventory`.

Now, items are checked and sorted **strictly only when necessary** to minimize the overhead. This means : 

- For all players : no lookup and table reconstruction when changing of tab, if one player already loaded that tab and if filter is empty.
- No lookup and table reconstruction when changing of page.
- Clearing the filter directly invokes and applies the original item list by respective tab (common to all players).

The difference, performance-wise, won't probably be big when using LuaJIT and Minetest Game only. But it can be with lots of mods installed and regular Lua.

This PR comes also with some minor cleanups.