### PR TITLE
Bushes: Add leafdecay to bush leaves

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1228,7 +1228,7 @@ minetest.register_node("default:bush_stem", {
 	wield_image = "default_bush_stem.png",
 	paramtype = "light",
 	sunlight_propagates = true,
-	groups = {choppy = 2, oddly_breakable_by_hand = 1, flammable = 2},
+	groups = {tree = 1, choppy = 2, oddly_breakable_by_hand = 1, flammable = 2},
 	sounds = default.node_sound_wood_defaults(),
 	selection_box = {
 		type = "fixed",
@@ -1242,8 +1242,10 @@ minetest.register_node("default:bush_leaves", {
 	waving = 1,
 	tiles = {"default_leaves_simple.png"},
 	paramtype = "light",
-	groups = {snappy = 3, flammable = 2, leaves = 1},
+	groups = {snappy = 3, leafdecay = 1, flammable = 2, leaves = 1},
 	sounds = default.node_sound_leaves_defaults(),
+
+	after_place_node = default.after_place_leaves,
 })
 
 minetest.register_node("default:acacia_bush_stem", {
@@ -1255,7 +1257,7 @@ minetest.register_node("default:acacia_bush_stem", {
 	wield_image = "default_acacia_bush_stem.png",
 	paramtype = "light",
 	sunlight_propagates = true,
-	groups = {choppy = 2, oddly_breakable_by_hand = 1, flammable = 2},
+	groups = {tree = 1, choppy = 2, oddly_breakable_by_hand = 1, flammable = 2},
 	sounds = default.node_sound_wood_defaults(),
 	selection_box = {
 		type = "fixed",
@@ -1269,8 +1271,10 @@ minetest.register_node("default:acacia_bush_leaves", {
 	waving = 1,
 	tiles = {"default_acacia_leaves_simple.png"},
 	paramtype = "light",
-	groups = {snappy = 3, flammable = 2, leaves = 1},
+	groups = {snappy = 3, leafdecay = 1, flammable = 2, leaves = 1},
 	sounds = default.node_sound_leaves_defaults(),
+
+	after_place_node = default.after_place_leaves,
 })
 
 


### PR DESCRIPTION
Addresses #1531 
Lightweight because ABM radius is 1 node.
'after place leaves' is called when players place, just like tree leaves, so these can continue to be used as hedges etc. with no stems nearby.