### PR TITLE
Add 'creative' privelage to non-creative game

### DIFF
--- a/mods/creative/init.lua
+++ b/mods/creative/init.lua
@@ -1,11 +1,13 @@
 creative = {}
-creative.mode = minetest.setting_getbool("creative_mode")
 
 minetest.register_privilege("creative", {"Allow player to use creative inventory",
-		give_to_singleplayer = false})
+                give_to_singleplayer = false})
+
+local creative_mode_cache = minetest.setting_getbool("creative_mode")
 
 function creative.is_enabled_for(name)
-	if creative.mode or minetest.check_player_privs(name, {creative = true}) then
+	if creative_mode_cache or
+		        minetest.check_player_privs(name, {creative = true}) then
 		return true
 	end
 	return false
@@ -13,7 +15,7 @@ end
 
 dofile(minetest.get_modpath("creative") .. "/inventory.lua")
 
-if creative.mode then
+if creative_mode_cache then
 	-- Dig time is modified according to difference (leveldiff) between tool
 	-- 'maxlevel' and node 'level'. Digtime is divided by the larger of
 	-- leveldiff and 1.

--- a/mods/creative/init.lua
+++ b/mods/creative/init.lua
@@ -1,12 +1,19 @@
 creative = {}
+creative.mode = minetest.setting_getbool("creative_mode")
+
+minetest.register_privilege("creative", {"Allow player to use creative inventory",
+		give_to_singleplayer = false})
 
 function creative.is_enabled_for(name)
-	return minetest.setting_getbool("creative_mode")
+	if creative.mode or minetest.check_player_privs(name, {creative = true}) then
+		return true
+	end
+	return false
 end
 
 dofile(minetest.get_modpath("creative") .. "/inventory.lua")
 
-if minetest.setting_getbool("creative_mode") then
+if creative.mode then
 	-- Dig time is modified according to difference (leveldiff) between tool
 	-- 'maxlevel' and node 'level'. Digtime is divided by the larger of
 	-- leveldiff and 1.
@@ -52,7 +59,7 @@ function minetest.handle_node_drops(pos, drops, digger)
 	end
 	local inv = digger:get_inventory()
 	if inv then
-		for _, item in ipairs(drops) do
+		for _, item in pairs(drops) do
 			item = ItemStack(item):get_name()
 			if not inv:contains_item("main", item) then
 				inv:add_item("main", item)


### PR DESCRIPTION
This pull adds a 'creative' privelage for players on non-creative servers so that they can access the creative inventory and place nodes without the count going down.