### PR TITLE
Creative: Cache creative mode setting

### DIFF
--- a/mods/creative/init.lua
+++ b/mods/creative/init.lua
@@ -1,7 +1,9 @@
 creative = {}
 
+local creative_mode_cache = minetest.setting_getbool("creative_mode")
+
 function creative.is_enabled_for(name)
-	return minetest.setting_getbool("creative_mode")
+	return creative_mode_cache
 end
 
 dofile(minetest.get_modpath("creative") .. "/inventory.lua")


### PR DESCRIPTION
Addresses #1534
Partially replaces #1535 
Uses a cache since the setting is currently being fetched on every node placement and node dig.
@rubenwardy is this ok? Should the cache be global and in creative namespace?
Tested.