### PR TITLE
Trees: Add 'snowy' group for pine sapling snow detection

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -378,7 +378,7 @@ minetest.register_node("default:dirt_with_snow", {
 	tiles = {"default_snow.png", "default_dirt.png",
 		{name = "default_dirt.png^default_snow_side.png",
 			tileable_vertical = false}},
-	groups = {crumbly = 3, soil = 1, spreading_dirt_type = 1},
+	groups = {crumbly = 3, soil = 1, spreading_dirt_type = 1, snowy = 1},
 	drop = 'default:dirt',
 	sounds = default.node_sound_dirt_defaults({
 		footstep = {name = "default_snow_footstep", gain = 0.15},
@@ -445,7 +445,7 @@ minetest.register_node("default:snow", {
 			{-0.5, -0.5, -0.5, 0.5, -0.25, 0.5},
 		},
 	},
-	groups = {crumbly = 3, falling_node = 1, puts_out_fire = 1},
+	groups = {crumbly = 3, falling_node = 1, puts_out_fire = 1, snowy = 1},
 	sounds = default.node_sound_dirt_defaults({
 		footstep = {name = "default_snow_footstep", gain = 0.15},
 		dug = {name = "default_snow_footstep", gain = 0.2},
@@ -463,7 +463,7 @@ minetest.register_node("default:snow", {
 minetest.register_node("default:snowblock", {
 	description = "Snow Block",
 	tiles = {"default_snow.png"},
-	groups = {crumbly = 3, puts_out_fire = 1, cools_lava = 1},
+	groups = {crumbly = 3, puts_out_fire = 1, cools_lava = 1, snowy = 1},
 	sounds = default.node_sound_dirt_defaults({
 		footstep = {name = "default_snow_footstep", gain = 0.15},
 		dug = {name = "default_snow_footstep", gain = 0.2},

--- a/mods/default/trees.lua
+++ b/mods/default/trees.lua
@@ -27,8 +27,7 @@ end
 -- 'is snow nearby' function
 
 local function is_snow_nearby(pos)
-	return minetest.find_node_near(pos, 1,
-		{"default:snow", "default:snowblock", "default:dirt_with_snow"})
+	return minetest.find_node_near(pos, 1, {"group:snowy"})
 end
 
 


### PR DESCRIPTION
Use the 'snowy' group in the 'is snow nearby' function instead of
default nodes. Often snow nodes are not from the default mod.
//////////////////////////////////////////////////

Addresses #1537 
Pine saplings look for snowy nodes nearby to decide whether they grow into snowy pines or not.
Tested.
@sfan5 