### PR TITLE
Add 'creative' privilege for survival servers

### DIFF
--- a/mods/creative/init.lua
+++ b/mods/creative/init.lua
@@ -1,9 +1,14 @@
 creative = {}
 
+minetest.register_privilege("creative", {
+	description = "Allow player to use creative inventory",
+	give_to_singleplayer = false
+})
+
 local creative_mode_cache = minetest.settings:get_bool("creative_mode")
 
 function creative.is_enabled_for(name)
-	return creative_mode_cache
+	return creative_mode_cache or minetest.check_player_privs(name, {creative = true})
 end
 
 dofile(minetest.get_modpath("creative") .. "/inventory.lua")


### PR DESCRIPTION
This adds a 'creative' privilege to survival servers which Ops can bestow on admin or competent builders to give access to creative features like the item inventory or continuous node placement.