### PR TITLE
Make drop logic work better for non-8-step-plants

### DIFF
--- a/mods/farming/api.lua
+++ b/mods/farming/api.lua
@@ -330,12 +330,16 @@ farming.register_plant = function(name, def)
 
 	-- Register growing steps
 	for i = 1, def.steps do
+		local base_rarity = 1
+		if def.steps ~= 1 then
+			base_rarity =  8 - (i - 1) * 7 / (def.steps - 1)
+		end
 		local drop = {
 			items = {
-				{items = {mname .. ":" .. pname}, rarity = 9 - i},
-				{items = {mname .. ":" .. pname}, rarity= 18 - i * 2},
-				{items = {mname .. ":seed_" .. pname}, rarity = 9 - i},
-				{items = {mname .. ":seed_" .. pname}, rarity = 18 - i * 2},
+				{items = {mname .. ":" .. pname}, rarity = base_rarity},
+				{items = {mname .. ":" .. pname}, rarity = base_rarity * 2},
+				{items = {mname .. ":seed_" .. pname}, rarity = base_rarity},
+				{items = {mname .. ":seed_" .. pname}, rarity = base_rarity * 2},
 			}
 		}
 		local nodegroups = {snappy = 3, flammable = 2, plant = 1, not_in_creative_inventory = 1, attached_node = 1}


### PR DESCRIPTION
Meant as a replacement for #1406 

Now using @paramat's formula:

`base_rarity =  8 - (i - 1) * 7 / (def.steps - 1)`

****
### Old version of this PR
```lua
local base_rarity = 1
if def.steps ~= 1 then
	base_rarity = ( def.steps - 1 ) / ( 0.9 * i + 0.1 * def.steps - 1 )
end
```
Now the drop possibilities result in a linear function with the two fixed points `(1|0.1)` and `(def.steps|1)`.
@paramat What is you opinion about this?