### PR TITLE
Allow interaction with nodes while wielding these items.

### DIFF
--- a/mods/beds/api.lua
+++ b/mods/beds/api.lua
@@ -46,6 +46,14 @@ function beds.register_bed(name, def)
 
 		on_place = function(itemstack, placer, pointed_thing)
 			local under = pointed_thing.under
+			local node = minetest.get_node(under)
+			local udef = minetest.registered_nodes[node.name]
+			if udef and udef.on_rightclick and
+					not (placer and placer:get_player_control().sneak) then
+				return udef.on_rightclick(under, node, placer, itemstack,
+					pointed_thing) or itemstack
+			end
+
 			local pos
 			if minetest.registered_items[minetest.get_node(under).name].buildable_to then
 				pos = under

--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -225,6 +225,15 @@ minetest.register_craftitem("boats:boat", {
 	groups = {flammable = 2},
 
 	on_place = function(itemstack, placer, pointed_thing)
+		local under = pointed_thing.under
+		local node = minetest.get_node(under)
+		local udef = minetest.registered_nodes[node.name]
+		if udef and udef.on_rightclick and
+				not (placer and placer:get_player_control().sneak) then
+			return udef.on_rightclick(under, node, placer, itemstack,
+				pointed_thing) or itemstack
+		end
+
 		if pointed_thing.type ~= "node" then
 			return itemstack
 		end

--- a/mods/carts/cart_entity.lua
+++ b/mods/carts/cart_entity.lua
@@ -362,6 +362,15 @@ minetest.register_craftitem("carts:cart", {
 	inventory_image = minetest.inventorycube("carts_cart_top.png", "carts_cart_side.png", "carts_cart_side.png"),
 	wield_image = "carts_cart_side.png",
 	on_place = function(itemstack, placer, pointed_thing)
+		local under = pointed_thing.under
+		local node = minetest.get_node(under)
+		local udef = minetest.registered_nodes[node.name]
+		if udef and udef.on_rightclick and
+				not (placer and placer:get_player_control().sneak) then
+			return udef.on_rightclick(under, node, placer, itemstack,
+				pointed_thing) or itemstack
+		end
+
 		if not pointed_thing.type == "node" then
 			return
 		end

--- a/mods/default/tools.lua
+++ b/mods/default/tools.lua
@@ -384,12 +384,21 @@ minetest.register_tool("default:skeleton_key", {
 	inventory_image = "default_key_skeleton.png",
 	groups = {key = 1},
 	on_place = function(itemstack, placer, pointed_thing)
+		local under = pointed_thing.under
+		local node = minetest.get_node(under)
+		local def = minetest.registered_nodes[node.name]
+		if def and def.on_rightclick and
+				not (placer and placer:get_player_control().sneak) then
+			return def.on_rightclick(under, node, placer, itemstack,
+				pointed_thing) or itemstack
+		end
+
 		if pointed_thing.type ~= "node" then
 			return itemstack
 		end
 
 		local pos = pointed_thing.under
-		local node = minetest.get_node(pos)
+		node = minetest.get_node(pos)
 
 		if not node then
 			return itemstack
@@ -427,12 +436,20 @@ minetest.register_tool("default:key", {
 	groups = {key = 1, not_in_creative_inventory = 1},
 	stack_max = 1,
 	on_place = function(itemstack, placer, pointed_thing)
+		local under = pointed_thing.under
+		local node = minetest.get_node(under)
+		local def = minetest.registered_nodes[node.name]
+		if def and def.on_rightclick and
+				not (placer and placer:get_player_control().sneak) then
+			return def.on_rightclick(under, node, placer, itemstack,
+				pointed_thing) or itemstack
+		end
 		if pointed_thing.type ~= "node" then
 			return itemstack
 		end
 
 		local pos = pointed_thing.under
-		local node = minetest.get_node(pos)
+		node = minetest.get_node(pos)
 
 		if not node or node.name == "ignore" then
 			return itemstack

--- a/mods/farming/api.lua
+++ b/mods/farming/api.lua
@@ -313,6 +313,15 @@ farming.register_plant = function(name, def)
 		}),
 
 		on_place = function(itemstack, placer, pointed_thing)
+			local under = pointed_thing.under
+			local node = minetest.get_node(under)
+			local udef = minetest.registered_nodes[node.name]
+			if udef and udef.on_rightclick and
+					not (placer and placer:get_player_control().sneak) then
+				return udef.on_rightclick(under, node, placer, itemstack,
+					pointed_thing) or itemstack
+			end
+
 			return farming.place_seed(itemstack, placer, pointed_thing, mname .. ":seed_" .. pname)
 		end,
 		next_plant = mname .. ":" .. pname .. "_1",


### PR DESCRIPTION
- beds
- boats
- carts
- key/skeleton key
- seeds

All these had on_place handlers that did not allow nodes with
an on_rightclick() handler to be used first (if not using
sneak). This code is taken from the torches mod and applied
everywhere.

This allows all these items to e.g. be inserted into the `frame`
mod's item frames.