### PR TITLE
Torches: Reduce light source level from 13 to 12

### DIFF
--- a/mods/default/torch.lua
+++ b/mods/default/torch.lua
@@ -50,7 +50,7 @@ minetest.register_node("default:torch", {
 	sunlight_propagates = true,
 	walkable = false,
 	liquids_pointable = false,
-	light_source = 13,
+	light_source = 12,
 	groups = {choppy=2, dig_immediate=3, flammable=1, attached_node=1, torch=1},
 	drop = "default:torch",
 	selection_box = {
@@ -97,7 +97,7 @@ minetest.register_node("default:torch_wall", {
 	paramtype2 = "wallmounted",
 	sunlight_propagates = true,
 	walkable = false,
-	light_source = 13,
+	light_source = 12,
 	groups = {choppy=2, dig_immediate=3, flammable=1, not_in_creative_inventory=1, attached_node=1, torch=1},
 	drop = "default:torch",
 	selection_box = {
@@ -118,7 +118,7 @@ minetest.register_node("default:torch_ceiling", {
 	paramtype2 = "wallmounted",
 	sunlight_propagates = true,
 	walkable = false,
-	light_source = 13,
+	light_source = 12,
 	groups = {choppy=2, dig_immediate=3, flammable=1, not_in_creative_inventory=1, attached_node=1, torch=1},
 	drop = "default:torch",
 	selection_box = {
@@ -144,4 +144,3 @@ minetest.register_lbm({
 		end
 	end
 })
-


### PR DESCRIPTION
As part of the original plan for a new lightcurve.

With the old lightcurve lights were so dim all light sources had light
source level 13 or 14 to compensate, resulting in almost no difference
between torchlight and a maximum brightness light.

The new lightcurve makes all light sources effectively much brighter by
spreading visually-bright light further, torches are now slightly too
bright. So now we can reduce the light source level of torches while
actually making them effectively brighter than with the old lightcurve.
This also creates a desirable difference between torchlight and a
maximum-brightness light source.
/////////////////////////////////////////////////////

Below: identical seetings and at the same height above the terrain of mgflat.

![screenshot_20170216_214632](https://cloud.githubusercontent.com/assets/3686677/23042805/fd2671c4-f491-11e6-877e-536b20fe85ee.png)

^ 0.4.15 stable with old light curve and torch light source level 13

![screenshot_20170216_214528](https://cloud.githubusercontent.com/assets/3686677/23042833/1c6dc4c4-f492-11e6-9619-92cc902ec0dd.png)

^ 0.4.15 dev with new light curve and torch light source level 12

The very dim light spreads further in the first screenshot, but that low light level is useless.
Actual light range is only 1 node smaller but appears more than 1 node smaller, this may be because the new lightcurve has a more gentle falloff of light near light level zero.
The central diamond shape of useful light is roughly the same size, but much brighter.

With this commit torches are 12, fire and lava are 13 and maximum brightness lights are 14, making torches more noticeably different to maximum brightness lights, and makng fire and lava brighter than a torch.

Doing this was part of the lightcurve plan, and was meant to be done soon after the new lightcurve was added. Unfortunately the delay means that people have had time to get used to the super-bright torch, so i ask please compare to 0.4.15 stable, not current torch brightness, otherwise this will feel like torch is getting dimmer whereas in fact in stable releases it will be getting much brighter.

This does not affect the growing of plants or crops, as 13 was not bright enough to do that either.