### PR TITLE
Lavacooling: Return to chance = 2

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -136,7 +136,7 @@ minetest.register_abm({
 	nodenames = {"default:lava_source", "default:lava_flowing"},
 	neighbors = {"group:cools_lava", "group:water"},
 	interval = 1,
-	chance = 1,
+	chance = 2,
 	catch_up = false,
 	action = function(...)
 		default.cool_lava(...)


### PR DESCRIPTION
Return to previous parameters interval = 1, chance = 2.
Compensates for the increase in default active block radius.
Large amounts of lava cooling at once is known to overload sound
creation, producing error messages.
////////////////////////////////////////////////

Probably temporary until we implement 'on construct' for liquids to cool lava as an event-based method.
I had a report recently of error messages caused by overloading of sounds due to lavacooliing.