### PR TITLE
Screwdriver: allow simple wallmounted rotation.

### DIFF
--- a/mods/screwdriver/init.lua
+++ b/mods/screwdriver/init.lua
@@ -1,13 +1,5 @@
 screwdriver = {}
 
-local function nextrange(x, max)
-	x = x + 1
-	if x > max then
-		x = 0
-	end
-	return x
-end
-
 screwdriver.ROTATE_FACE = 1
 screwdriver.ROTATE_AXIS = 2
 screwdriver.disallow = function(pos, node, user, mode, new_param2)
@@ -21,19 +13,27 @@ end
 
 screwdriver.rotate = {}
 
-screwdriver.rotate.facedir = function(node, mode)
-	-- Compute param2
-	local rotationPart = node.param2 % 32 -- get first 4 bits
-	local preservePart = node.param2 - rotationPart
-	local axisdir = math.floor(rotationPart / 4)
-	local rotation = rotationPart - axisdir * 4
-	if mode == screwdriver.ROTATE_FACE then
-		rotationPart = axisdir * 4 + nextrange(rotation, 3)
-	elseif mode == screwdriver.ROTATE_AXIS then
-		rotationPart = nextrange(axisdir, 5) * 4
-	end
+local facedir_tbl = {
+	[screwdriver.ROTATE_FACE] = {
+		[0] = 1, [1] = 2, [2] = 3, [3] = 0,
+		[4] = 5, [5] = 6, [6] = 7, [7] = 4,
+		[8] = 9, [9] = 10, [10] = 11, [11] = 8,
+		[12] = 13, [13] = 14, [14] = 15, [15] = 12,
+		[16] = 17, [17] = 18, [18] = 19, [19] = 16,
+		[20] = 21, [21] = 22, [22] = 23, [23] = 20,
+	},
+	[screwdriver.ROTATE_AXIS] = {
+		[0] = 4, [1] = 4, [2] = 4, [3] = 4,
+		[4] = 8, [5] = 8, [6] = 8, [7] = 8,
+		[8] = 12, [9] = 12, [10] = 12, [11] = 12,
+		[12] = 16, [13] = 16, [14] = 16, [15] = 16,
+		[16] = 20, [17] = 20, [18] = 20, [19] = 20,
+		[20] = 0, [21] = 0, [22] = 0, [23] = 0,
+	},
+}
 
-	return preservePart + rotationPart
+screwdriver.rotate.facedir = function(node, mode)
+	return facedir_tbl[mode][node.param2]
 end
 
 local wallmounted_tbl = {

--- a/mods/screwdriver/init.lua
+++ b/mods/screwdriver/init.lua
@@ -130,6 +130,7 @@ screwdriver.handler = function(itemstack, user, pointed_thing, mode, uses)
 	if should_rotate then
 		node.param2 = new_param2
 		minetest.swap_node(pos, node)
+		minetest.check_for_falling(pos)
 	end
 
 	if not minetest.setting_getbool("creative_mode") then

--- a/mods/screwdriver/init.lua
+++ b/mods/screwdriver/init.lua
@@ -11,6 +11,19 @@ screwdriver.rotate_simple = function(pos, node, user, mode, new_param2)
 	end
 end
 
+-- For attached wallmounted nodes: returns true if rotation is valid
+-- simplified version of minetest:builtin/game/falling.lua#L148.
+local function check_attached_node(pos, rotation)
+	local d = minetest.wallmounted_to_dir(rotation)
+	local p2 = vector.add(pos, d)
+	local n = minetest.get_node(p2).name
+	local def2 = minetest.registered_nodes[n]
+	if def2 and not def2.walkable then
+		return false
+	end
+	return true
+end
+
 screwdriver.rotate = {}
 
 local facedir_tbl = {
@@ -32,17 +45,38 @@ local facedir_tbl = {
 	},
 }
 
-screwdriver.rotate.facedir = function(node, mode)
-	return facedir_tbl[mode][node.param2]
+screwdriver.rotate.facedir = function(pos, node, mode)
+	local rotation = node.param2 % 32 -- get first 5 bits
+	local other = node.param2 - rotation
+	rotation = facedir_tbl[mode][rotation] or 0
+	return rotation + other
 end
+
+screwdriver.rotate.colorfacedir = screwdriver.rotate.facedir
 
 local wallmounted_tbl = {
 	[screwdriver.ROTATE_FACE] = {[2] = 5, [3] = 4, [4] = 2, [5] = 3, [1] = 0, [0] = 1},
 	[screwdriver.ROTATE_AXIS] = {[2] = 5, [3] = 4, [4] = 2, [5] = 1, [1] = 0, [0] = 3}
 }
-screwdriver.rotate.wallmounted = function(node, mode)
-	return wallmounted_tbl[mode][node.param2]
+
+screwdriver.rotate.wallmounted = function(pos, node, mode)
+	local rotation = node.param2 % 8 -- get first 3 bits
+	local other = node.param2 - rotation
+	rotation = wallmounted_tbl[mode][rotation] or 0
+	if minetest.get_item_group(node.name, "attached_node") ~= 0 then
+		-- find an acceptable orientation
+		for i = 1, 5 do
+			if not check_attached_node(pos, rotation) then
+				rotation = wallmounted_tbl[mode][rotation] or 0
+			else
+				break
+			end
+		end
+	end
+	return rotation + other
 end
+
+screwdriver.rotate.colorwallmounted = screwdriver.rotate.wallmounted
 
 -- Handles rotation
 screwdriver.handler = function(itemstack, user, pointed_thing, mode, uses)
@@ -66,7 +100,7 @@ screwdriver.handler = function(itemstack, user, pointed_thing, mode, uses)
 	end
 
 	local should_rotate = true
-	local new_param2 = fn(node, mode)
+	local new_param2 = fn(pos, node, mode)
 
 	-- Node provides a handler, so let the handler decide instead if the node can be rotated
 	if ndef and ndef.on_rotate then
@@ -80,7 +114,7 @@ screwdriver.handler = function(itemstack, user, pointed_thing, mode, uses)
 			should_rotate = false
 		end
 	else
-		if not ndef or not ndef.paramtype2 == "facedir" or
+		if not ndef or
 				ndef.on_rotate == false or
 				(ndef.drawtype == "nodebox" and
 				(ndef.node_box and ndef.node_box.type ~= "fixed")) or


### PR DESCRIPTION
Allows rotating things like signs and torches. Axis rotation
rotates over all 6 faces, face rotation flips upside down to
flat on floor only, and of course in the 4 horizontal directions.

Made the code a bit more modular to account for different rotation
schemes. Should be easier to extend from here on to other needs,
and the functions can be reused by other mods for convenience.