### PR TITLE
Keys: Show owner in description

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1727,9 +1727,13 @@ minetest.register_node("default:chest_locked", {
 	on_key_use = function(pos, player)
 		local secret = minetest.get_meta(pos):get_string("key_lock_secret")
 		local itemstack = player:get_wielded_item()
-		local key_meta = minetest.parse_json(itemstack:get_metadata())
+		local key_meta = itemstack:get_meta()
 
-		if secret ~= key_meta.secret then
+		if key_meta:get_string("secret") == "" then
+			key_meta:set_string("secret", minetest.parse_json(itemstack:get_metadata()).secret)
+		end
+
+		if secret ~= key_meta:get_string("secret") then
 			return
 		end
 

--- a/mods/default/tools.lua
+++ b/mods/default/tools.lua
@@ -410,9 +410,10 @@ minetest.register_tool("default:skeleton_key", {
 				-- finish and return the new key
 				itemstack:take_item()
 				itemstack:add_item("default:key")
-				itemstack:set_metadata(minetest.write_json({
-					secret = secret
-				}))
+				local meta = itemstack:get_meta()
+				meta:set_string("secret", secret)
+				meta:set_string("description", "Key to "..placer:get_player_name().."'s "
+					..minetest.registered_nodes[node.name].description)
 				return itemstack
 			end
 		end

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -144,9 +144,14 @@ function _doors.door_toggle(pos, node, clicker)
 		local item = clicker:get_wielded_item()
 		local owner = meta:get_string("doors_owner")
 		if item:get_name() == "default:key" then
-			local key_meta = minetest.parse_json(item:get_metadata())
+			local key_meta = item:get_meta()
 			local secret = meta:get_string("key_lock_secret")
-			if secret ~= key_meta.secret then
+
+			if key_meta:get_string("secret") == "" then
+				key_meta:set_string("secret", minetest.parse_json(item:get_metadata()).secret)
+			end
+
+			if secret ~= key_meta:get_string("secret") then
 				return false
 			end
 
@@ -532,9 +537,14 @@ function _doors.trapdoor_toggle(pos, node, clicker)
 		local meta = minetest.get_meta(pos)
 		local owner = meta:get_string("doors_owner")
 		if item:get_name() == "default:key" then
-			local key_meta = minetest.parse_json(item:get_metadata())
+			local key_meta = item:get_meta()
 			local secret = meta:get_string("key_lock_secret")
-			if secret ~= key_meta.secret then
+
+			if key_meta:get_string("secret") == "" then
+				key_meta:set_string("secret", minetest.parse_json(item:get_metadata()).secret)
+			end
+
+			if secret ~= key_meta:get_string("secret") then
 				return false
 			end
 


### PR DESCRIPTION
Utilizes several new features allowing the description of an item to be changed using the `description` meta key. This also moves keys from using the old single-value itemstack metadata system to the new node-like metadata system.