### PR TITLE
Books: Show title and author in description tooltip

### DIFF
--- a/mods/default/craftitems.lua
+++ b/mods/default/craftitems.lua
@@ -15,11 +15,19 @@ minetest.register_craftitem("default:paper", {
 local lpp = 14 -- Lines per book's page
 local function book_on_use(itemstack, user)
 	local player_name = user:get_player_name()
-	local data = minetest.deserialize(itemstack:get_metadata())
+	local meta = itemstack:get_meta()
 	local title, text, owner = "", "", player_name
 	local page, page_max, lines, string = 1, 1, {}, ""
 
-	if data then
+	-- Backwards compatibility
+	local old_data = minetest.deserialize(itemstack:get_metadata())
+	if old_data then
+		meta:from_table({ fields = old_data })
+	end
+
+	local data = meta:to_table().fields
+
+	if data.owner then
 		title = data.title
 		text = data.text
 		owner = data.owner
@@ -81,34 +89,37 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 				new_stack = ItemStack("default:book_written")
 			end
 		else
-			data = minetest.deserialize(stack:get_metadata())
+			data = stack:get_meta():to_table().fields
 		end
 
 		if not data then data = {} end
 		data.title = fields.title
+		data.owner = player:get_player_name()
+		data.description = "\""..fields.title.."\" by "..data.owner
 		data.text = fields.text
 		data.text_len = #data.text
 		data.page = 1
 		data.page_max = math.ceil((#data.text:gsub("[^\n]", "") + 1) / lpp)
-		data.owner = player:get_player_name()
-		local data_str = minetest.serialize(data)
 
 		if new_stack then
-			new_stack:set_metadata(data_str)
+			new_stack:get_meta():from_table({ fields = data })
 			if inv:room_for_item("main", new_stack) then
 				inv:add_item("main", new_stack)
 			else
 				minetest.add_item(player:getpos(), new_stack)
 			end
 		else
-			stack:set_metadata(data_str)
+			stack:get_meta():from_table({ fields = data })
 		end
 
 	elseif fields.book_next or fields.book_prev then
-		local data = minetest.deserialize(stack:get_metadata())
+		local data = stack:get_meta():to_table().fields
 		if not data or not data.page then
 			return
 		end
+
+		data.page = tonumber(data.page)
+		data.page_max = tonumber(data.page_max)
 
 		if fields.book_next then
 			data.page = data.page + 1
@@ -249,4 +260,3 @@ minetest.register_craftitem("default:flint", {
 	description = "Flint",
 	inventory_image = "default_flint.png"
 })
-


### PR DESCRIPTION
Utilizes the new key-meta (as with nodes) and the ability to set the description of an itemstack with the `description` meta key. Includes code to convert old metadata to new key-meta. 

~Note: This uses a custom function rather than using the default :from_table() function as this function seems to be broken. Though the code is currently fully functional, an extra 11 lines are required to create wanted functionality. With this in mind, it would be best if `:from_table()` were fixed before this PR is merged.~ Fixed. I misunderstood how the ItemStack metadata table worked.