### PR TITLE
grass spread without ABM

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -388,70 +388,70 @@ end
 -- Convert dirt to something that fits the environment
 --
 
-minetest.register_abm({
-	label = "Grass spread",
-	nodenames = {"default:dirt"},
-	neighbors = {
-		"air",
-		"group:grass",
-		"group:dry_grass",
-		"default:snow",
-	},
-	interval = 6,
-	chance = 50,
-	catch_up = false,
-	action = function(pos, node)
-		-- Check for darkness: night, shadow or under a light-blocking node
-		-- Returns if ignore above
-		local above = {x = pos.x, y = pos.y + 1, z = pos.z}
-		if (minetest.get_node_light(above) or 0) < 13 then
-			return
-		end
+--~ minetest.register_abm({
+	--~ label = "Grass spread",
+	--~ nodenames = {"default:dirt"},
+	--~ neighbors = {
+		--~ "air",
+		--~ "group:grass",
+		--~ "group:dry_grass",
+		--~ "default:snow",
+	--~ },
+	--~ interval = 6,
+	--~ chance = 50,
+	--~ catch_up = false,
+	--~ action = function(pos, node)
+		--~ -- Check for darkness: night, shadow or under a light-blocking node
+		--~ -- Returns if ignore above
+		--~ local above = {x = pos.x, y = pos.y + 1, z = pos.z}
+		--~ if (minetest.get_node_light(above) or 0) < 13 then
+			--~ return
+		--~ end
 
-		-- Look for spreading dirt-type neighbours
-		local p2 = minetest.find_node_near(pos, 1, "group:spreading_dirt_type")
-		if p2 then
-			local n3 = minetest.get_node(p2)
-			minetest.set_node(pos, {name = n3.name})
-			return
-		end
+		--~ -- Look for spreading dirt-type neighbours
+		--~ local p2 = minetest.find_node_near(pos, 1, "group:spreading_dirt_type")
+		--~ if p2 then
+			--~ local n3 = minetest.get_node(p2)
+			--~ minetest.set_node(pos, {name = n3.name})
+			--~ return
+		--~ end
 
-		-- Else, any seeding nodes on top?
-		local name = minetest.get_node(above).name
-		-- Snow check is cheapest, so comes first
-		if name == "default:snow" then
-			minetest.set_node(pos, {name = "default:dirt_with_snow"})
-		-- Most likely case first
-		elseif minetest.get_item_group(name, "grass") ~= 0 then
-			minetest.set_node(pos, {name = "default:dirt_with_grass"})
-		elseif minetest.get_item_group(name, "dry_grass") ~= 0 then
-			minetest.set_node(pos, {name = "default:dirt_with_dry_grass"})
-		end
-	end
-})
+		--~ -- Else, any seeding nodes on top?
+		--~ local name = minetest.get_node(above).name
+		--~ -- Snow check is cheapest, so comes first
+		--~ if name == "default:snow" then
+			--~ minetest.set_node(pos, {name = "default:dirt_with_snow"})
+		--~ -- Most likely case first
+		--~ elseif minetest.get_item_group(name, "grass") ~= 0 then
+			--~ minetest.set_node(pos, {name = "default:dirt_with_grass"})
+		--~ elseif minetest.get_item_group(name, "dry_grass") ~= 0 then
+			--~ minetest.set_node(pos, {name = "default:dirt_with_dry_grass"})
+		--~ end
+	--~ end
+--~ })
 
 
 --
 -- Grass and dry grass removed in darkness
 --
 
-minetest.register_abm({
-	label = "Grass covered",
-	nodenames = {"group:spreading_dirt_type"},
-	interval = 8,
-	chance = 50,
-	catch_up = false,
-	action = function(pos, node)
-		local above = {x = pos.x, y = pos.y + 1, z = pos.z}
-		local name = minetest.get_node(above).name
-		local nodedef = minetest.registered_nodes[name]
-		if name ~= "ignore" and nodedef and not ((nodedef.sunlight_propagates or
-				nodedef.paramtype == "light") and
-				nodedef.liquidtype == "none") then
-			minetest.set_node(pos, {name = "default:dirt"})
-		end
-	end
-})
+--~ minetest.register_abm({
+	--~ label = "Grass covered",
+	--~ nodenames = {"group:spreading_dirt_type"},
+	--~ interval = 8,
+	--~ chance = 50,
+	--~ catch_up = false,
+	--~ action = function(pos, node)
+		--~ local above = {x = pos.x, y = pos.y + 1, z = pos.z}
+		--~ local name = minetest.get_node(above).name
+		--~ local nodedef = minetest.registered_nodes[name]
+		--~ if name ~= "ignore" and nodedef and not ((nodedef.sunlight_propagates or
+				--~ nodedef.paramtype == "light") and
+				--~ nodedef.liquidtype == "none") then
+			--~ minetest.set_node(pos, {name = "default:dirt"})
+		--~ end
+	--~ end
+--~ })
 
 
 --

--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -687,7 +687,7 @@ function default.register_biomes()
 		node_top = "default:dirt_with_grass",
 		depth_top = 1,
 		node_filler = "default:dirt",
-		depth_filler = 1,
+		depth_filler = 3,
 		--node_stone = "",
 		--node_water_top = "",
 		--depth_water_top = ,
@@ -999,7 +999,7 @@ function default.register_biomes()
 		node_top = "default:dirt_with_dry_grass",
 		depth_top = 1,
 		node_filler = "default:dirt",
-		depth_filler = 1,
+		depth_filler = 3,
 		--node_stone = "",
 		--node_water_top = "",
 		--depth_water_top = ,
@@ -1578,19 +1578,19 @@ function default.register_decorations()
 
 	-- Grasses
 
-	register_grass_decoration(-0.03,  0.09,  5)
-	register_grass_decoration(-0.015, 0.075, 4)
-	register_grass_decoration(0,      0.06,  3)
-	register_grass_decoration(0.015,  0.045, 2)
-	register_grass_decoration(0.03,   0.03,  1)
+	--~ register_grass_decoration(-0.03,  0.09,  5)
+	--~ register_grass_decoration(-0.015, 0.075, 4)
+	--~ register_grass_decoration(0,      0.06,  3)
+	--~ register_grass_decoration(0.015,  0.045, 2)
+	--~ register_grass_decoration(0.03,   0.03,  1)
 
 	-- Dry grasses
 
-	register_dry_grass_decoration(0.01, 0.05,  5)
-	register_dry_grass_decoration(0.03, 0.03,  4)
-	register_dry_grass_decoration(0.05, 0.01,  3)
-	register_dry_grass_decoration(0.07, -0.01, 2)
-	register_dry_grass_decoration(0.09, -0.03, 1)
+	--~ register_dry_grass_decoration(0.01, 0.05,  5)
+	--~ register_dry_grass_decoration(0.03, 0.03,  4)
+	--~ register_dry_grass_decoration(0.05, 0.01,  3)
+	--~ register_dry_grass_decoration(0.07, -0.01, 2)
+	--~ register_dry_grass_decoration(0.09, -0.03, 1)
 
 	-- Junglegrass
 

--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -122,7 +122,7 @@ function flowers.flower_spread(pos, node)
 
 	local pos0 = vector.subtract(pos, 4)
 	local pos1 = vector.add(pos, 4)
-	if #minetest.find_nodes_in_area(pos0, pos1, "group:flora") > 3 then
+	if #minetest.find_nodes_in_area(pos0, pos1, "group:flower") > 3 then
 		return
 	end
 
@@ -141,7 +141,7 @@ end
 
 minetest.register_abm({
 	label = "Flower spread",
-	nodenames = {"group:flora"},
+	nodenames = {"group:flower"},
 	neighbors = {"default:dirt_with_grass", "default:dirt_with_dry_grass",
 		"default:desert_sand"},
 	interval = 13,


### PR DESCRIPTION
This PR includes a method to spread dirt_with_grass and dirt_with_dry_grass without ABM. But it includes some other features.

I don't know if this is useful for MTG. I don't want to maintain it, but maybe someone else can use this for an ABM less approach