### PR TITLE
Add shape_type and base_material attributes to the shaped items definition

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -304,6 +304,8 @@ function default.register_fence(name, def)
 	-- Always add to the fence group, even if no group provided
 	def.groups.fence = 1
 
+	def.base_material = def.material
+	def.shape_type = "fence"
 	def.texture = nil
 	def.material = nil
 

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -257,10 +257,17 @@ function doors.register(name, def)
 		end
 	})
 
+	local function get_chape_type(def)
+		if def.base_material then
+			return "door"
+		end
+	end
+
 	minetest.register_craftitem(":" .. name, {
 		description = def.description,
 		inventory_image = def.inventory_image,
-
+		shape_type = get_chape_type(def),
+		base_material = def.base_material,
 		on_place = function(itemstack, placer, pointed_thing)
 			local pos
 
@@ -343,6 +350,7 @@ function doors.register(name, def)
 			return itemstack
 		end
 	})
+	def.base_material = nil
 	def.inventory_image = nil
 
 	if def.recipe then
@@ -450,6 +458,7 @@ doors.register("door_wood", {
 		description = "Wooden Door",
 		inventory_image = "doors_item_wood.png",
 		groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 2},
+		base_material = "default:wood",
 		recipe = {
 			{"group:wood", "group:wood"},
 			{"group:wood", "group:wood"},
@@ -466,6 +475,7 @@ doors.register("door_steel", {
 		sounds = default.node_sound_metal_defaults(),
 		sound_open = "doors_steel_door_open",
 		sound_close = "doors_steel_door_close",
+		base_material = "default:steel_ingot",
 		recipe = {
 			{"default:steel_ingot", "default:steel_ingot"},
 			{"default:steel_ingot", "default:steel_ingot"},
@@ -481,6 +491,7 @@ doors.register("door_glass", {
 		sounds = default.node_sound_glass_defaults(),
 		sound_open = "doors_glass_door_open",
 		sound_close = "doors_glass_door_close",
+		base_material = "default:glass",
 		recipe = {
 			{"default:glass", "default:glass"},
 			{"default:glass", "default:glass"},
@@ -496,6 +507,7 @@ doors.register("door_obsidian_glass", {
 		sounds = default.node_sound_glass_defaults(),
 		sound_open = "doors_glass_door_open",
 		sound_close = "doors_glass_door_close",
+		base_material = "default:obsidian_glass",
 		recipe = {
 			{"default:obsidian_glass", "default:obsidian_glass"},
 			{"default:obsidian_glass", "default:obsidian_glass"},
@@ -646,6 +658,10 @@ function doors.register_trapdoor(name, def)
 
 	local def_opened = table.copy(def)
 	local def_closed = table.copy(def)
+	def_opened.base_material = nil
+	if def_closed.base_material then
+		def_closed.shape_type = "trapdoor"
+	end
 
 	def_closed.node_box = {
 		type = "fixed",
@@ -691,6 +707,7 @@ doors.register_trapdoor("doors:trapdoor", {
 	tile_front = "doors_trapdoor.png",
 	tile_side = "doors_trapdoor_side.png",
 	groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 2, door = 1},
+	base_material = "group:wood",
 })
 
 doors.register_trapdoor("doors:trapdoor_steel", {
@@ -704,6 +721,7 @@ doors.register_trapdoor("doors:trapdoor_steel", {
 	sound_open = "doors_steel_door_open",
 	sound_close = "doors_steel_door_close",
 	groups = {cracky = 1, level = 2, door = 1},
+	base_material = "default:steel_ingot",
 })
 
 minetest.register_craft({

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -759,6 +759,8 @@ function doors.register_fencegate(name, def)
 	fence.groups.fence = 1
 
 	local fence_closed = table.copy(fence)
+	fence_closed.shape_type = "fencegate"
+	fence_closed.base_material = def.material
 	fence_closed.mesh = "doors_fencegate_closed.obj"
 	fence_closed.gate = name .. "_open"
 	fence_closed.sound = "doors_fencegate_open"

--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -33,6 +33,8 @@ function stairs.register_stair(subname, recipeitem, groups, images, description,
 		is_ground_content = false,
 		groups = groups,
 		sounds = sounds,
+		base_material = recipeitem,
+		shape_type = "stair",
 		selection_box = {
 			type = "fixed",
 			fixed = {
@@ -143,6 +145,8 @@ function stairs.register_slab(subname, recipeitem, groups, images, description, 
 		is_ground_content = false,
 		groups = groups,
 		sounds = sounds,
+		base_material = recipeitem,
+		shape_type = "slab",
 		node_box = {
 			type = "fixed",
 			fixed = {-0.5, -0.5, -0.5, 0.5, 0, 0.5},
@@ -346,7 +350,7 @@ stairs.register_stair_and_slab(
 
 stairs.register_stair_and_slab(
 	"mossycobble",
-	nil,
+	"default:mossycobble",
 	{cracky = 3},
 	{"default_mossycobble.png"},
 	"Mossy Cobblestone Stair",

--- a/mods/walls/init.lua
+++ b/mods/walls/init.lua
@@ -21,6 +21,8 @@ walls.register = function(wall_name, wall_desc, wall_texture, wall_mat, wall_sou
 		walkable = true,
 		groups = { cracky = 3, wall = 1, stone = 2 },
 		sounds = wall_sounds,
+		base_material = wall_mat,
+		shape_type = "wall",
 	})
 
 	-- crafting recipe


### PR DESCRIPTION
This PR introduces two item definition attributes placed for shaped items: base_material and shape_type. If the attributes are set the item becomes less value in inventory visibility that should animate mod developers to take more shape combinations.
See started discussion in https://forum.minetest.net/viewtopic.php?f=47&t=16788

I added a new tab "Shaped" to the creative inventory and filter them out from Nodes and Items. Unsure about the tools, that are all shaped too.

And I am sure there will be more usage purposes for the both fields if already exists. 