### PR TITLE
Allow skeleton keys to be stacked

### DIFF
--- a/mods/default/craftitems.lua
+++ b/mods/default/craftitems.lua
@@ -185,6 +185,62 @@ minetest.register_on_craft(function(itemstack, player, old_craft_grid, craft_inv
 	craft_inv:set_stack("craft", index, original)
 end)
 
+minetest.register_craftitem("default:skeleton_key", {
+	description = "Skeleton Key",
+	inventory_image = "default_key_skeleton.png",
+	groups = {key = 1},
+	on_use = function(itemstack, user, pointed_thing)
+		if pointed_thing.type ~= "node" then
+			return itemstack
+		end
+
+		local pos = pointed_thing.under
+		local node = minetest.get_node(pos)
+
+		if not node then
+			return itemstack
+		end
+
+		local on_skeleton_key_use = minetest.registered_nodes[node.name].on_skeleton_key_use
+		if not on_skeleton_key_use then
+			return itemstack
+		end
+
+		-- make a new key secret in case the node callback needs it
+		local random = math.random
+		local newsecret = string.format(
+			"%04x%04x%04x%04x",
+			random(2^16) - 1, random(2^16) - 1,
+			random(2^16) - 1, random(2^16) - 1)
+
+		local secret, _, _ = on_skeleton_key_use(pos, user, newsecret)
+
+		if secret then
+			local inv = minetest.get_inventory({type="player", name=user:get_player_name()})
+
+			-- update original itemstack
+			itemstack:take_item()
+
+			-- finish and return the new key
+			local new_stack = ItemStack("default:key")
+			local meta = new_stack:get_meta()
+			meta:set_string("secret", secret)
+			meta:set_string("description", "Key to "..user:get_player_name().."'s "
+				..minetest.registered_nodes[node.name].description)
+
+			if itemstack:get_count() == 0 then
+				itemstack = new_stack
+			else
+				if inv:add_item("main", new_stack):get_count() > 0 then
+					minetest.add_item(user:getpos(), new_stack)
+				end -- else: added to inventory successfully
+			end
+
+			return itemstack
+		end
+	end
+})
+
 minetest.register_craftitem("default:coal_lump", {
 	description = "Coal Lump",
 	inventory_image = "default_coal_lump.png",

--- a/mods/default/tools.lua
+++ b/mods/default/tools.lua
@@ -379,60 +379,6 @@ minetest.register_tool("default:sword_diamond", {
 	sound = {breaks = "default_tool_breaks"},
 })
 
-minetest.register_craftitem("default:skeleton_key", {
-	description = "Skeleton Key",
-	inventory_image = "default_key_skeleton.png",
-	groups = {key = 1},
-	on_use = function(itemstack, user, pointed_thing)
-		if pointed_thing.type ~= "node" then
-			return itemstack
-		end
-
-		local pos = pointed_thing.under
-		local node = minetest.get_node(pos)
-
-		if not node then
-			return itemstack
-		end
-
-		local on_skeleton_key_use = minetest.registered_nodes[node.name].on_skeleton_key_use
-		if on_skeleton_key_use then
-			-- make a new key secret in case the node callback needs it
-			local random = math.random
-			local newsecret = string.format(
-				"%04x%04x%04x%04x",
-				random(2^16) - 1, random(2^16) - 1,
-				random(2^16) - 1, random(2^16) - 1)
-
-			local secret, _, _ = on_skeleton_key_use(pos, user, newsecret)
-
-			if secret then
-				-- update original itemstack
-				itemstack:take_item()
-
-				-- finish and return the new key
-				local new_stack = ItemStack("default:key")
-				local meta = new_stack:get_meta()
-				local inv = minetest.get_inventory({type="player", name=user:get_player_name()})
-				meta:set_string("secret", secret)
-				meta:set_string("description", "Key to "..user:get_player_name().."'s "
-					..minetest.registered_nodes[node.name].description)
-
-				if itemstack:get_count() == 0 then
-					itemstack = new_stack
-				else
-					if inv:add_item("main", new_stack):get_count() > 0 then
-						minetest.add_item(user:getpos(), new_stack)
-					end
-				end
-
-				return itemstack
-			end
-		end
-		return nil
-	end
-})
-
 minetest.register_tool("default:key", {
 	description = "Key",
 	inventory_image = "default_key.png",

--- a/mods/default/tools.lua
+++ b/mods/default/tools.lua
@@ -379,7 +379,7 @@ minetest.register_tool("default:sword_diamond", {
 	sound = {breaks = "default_tool_breaks"},
 })
 
-minetest.register_tool("default:skeleton_key", {
+minetest.register_craftitem("default:skeleton_key", {
 	description = "Skeleton Key",
 	inventory_image = "default_key_skeleton.png",
 	groups = {key = 1},
@@ -407,13 +407,25 @@ minetest.register_tool("default:skeleton_key", {
 			local secret, _, _ = on_skeleton_key_use(pos, user, newsecret)
 
 			if secret then
-				-- finish and return the new key
+				-- update original itemstack
 				itemstack:take_item()
-				itemstack:add_item("default:key")
-				local meta = itemstack:get_meta()
+
+				-- finish and return the new key
+				local new_stack = ItemStack("default:key")
+				local meta = new_stack:get_meta()
+				local inv = minetest.get_inventory({type="player", name=user:get_player_name()})
 				meta:set_string("secret", secret)
 				meta:set_string("description", "Key to "..user:get_player_name().."'s "
 					..minetest.registered_nodes[node.name].description)
+
+				if itemstack:get_count() == 0 then
+					itemstack = new_stack
+				else
+					if inv:add_item("main", new_stack):get_count() > 0 then
+						minetest.add_item(user:getpos(), new_stack)
+					end
+				end
+
 				return itemstack
 			end
 		end


### PR DESCRIPTION
Addresses #1595

Allows skeleton keys to be stacked by converting them to craft items and adding a few lines of code to add a new itemstack to the inventory with the new key or drop it at the player position if the inventory is full. After all, it makes sense seeing as empty buckets are already stackable.