### PR TITLE
Fix screwdriver crash

### DIFF
--- a/mods/screwdriver/init.lua
+++ b/mods/screwdriver/init.lua
@@ -66,7 +66,7 @@ screwdriver.handler = function(itemstack, user, pointed_thing, mode, uses)
 		if not ndef or not ndef.paramtype2 == "facedir" or
 				ndef.on_rotate == false or
 				(ndef.drawtype == "nodebox" and
-				(ndef.node_box and not ndef.node_box.type == "fixed")) or
+				(ndef.node_box and ndef.node_box.type ~= "fixed")) or
 				node.param2 == nil then
 			return
 		end

--- a/mods/screwdriver/init.lua
+++ b/mods/screwdriver/init.lua
@@ -66,7 +66,7 @@ screwdriver.handler = function(itemstack, user, pointed_thing, mode, uses)
 		if not ndef or not ndef.paramtype2 == "facedir" or
 				ndef.on_rotate == false or
 				(ndef.drawtype == "nodebox" and
-				not ndef.node_box.type == "fixed") or
+				(ndef.node_box and not ndef.node_box.type == "fixed")) or
 				node.param2 == nil then
 			return
 		end


### PR DESCRIPTION
Sometimes a node's node_box.type can return nil which crashes screwdriver mod so this checks for that.