### PR TITLE
sfinv: Fix wrong tab being highlighted

### DIFF
--- a/mods/sfinv/api.lua
+++ b/mods/sfinv/api.lua
@@ -70,7 +70,7 @@ function sfinv.get_formspec(player, context)
 			nav[#nav + 1] = pdef.title
 			nav_ids[#nav_ids + 1] = pdef.name
 			if pdef.name == context.page then
-				current_idx = i
+				current_idx = #nav_ids
 			end
 		end
 	end


### PR DESCRIPTION
Thank you to @ForbiddenJ for finding cause of the issue, credit should go to them (#1602).

This fixes an issue where the wrong tab was highlighed when creative mode was disabled.
When creative is disabled, the tabs are hidden from sfinv using `is_in_nav`. However, `current_idx` uses `i`, which still counted tabs which were hidden into account - as it's just the iterator over registered tabs.