### PR TITLE
Ladder recipe: Make wooden ladder recipe more generous

### DIFF
--- a/mods/default/crafting.lua
+++ b/mods/default/crafting.lua
@@ -582,11 +582,11 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-	output = 'default:ladder_wood 3',
+	output = "default:ladder_wood 5",
 	recipe = {
-		{'group:stick', '', 'group:stick'},
-		{'group:stick', 'group:stick', 'group:stick'},
-		{'group:stick', '', 'group:stick'},
+		{"group:stick", "", "group:stick"},
+		{"group:stick", "group:stick", "group:stick"},
+		{"group:stick", "", "group:stick"},
 	}
 })
 


### PR DESCRIPTION
Increase to 5 ladders from 7 sticks.
More generous to help with vertical travel.

Divide the log core volume of 14 * 14 * 16 cubic pixels by the volume of
a ladder node with two 2 * 2 * 16 side pieces and four 2 * 1 * 16 rungs
(cut down to length 14), to get 12.25 ladders per log.
The recipe of 7 stick items is 7 / 16 = 0.4375 logs.
Ladders per 7 stick items = 0.4375 * 12.25 = 5.36.
////////////////////////////////////////////////

Partly to compensate in case the sneak elevator is removed, but also makes sense with calculation of wood volumes. With MT's world height i feel we should be as generous as possible with ladders.

Also see https://github.com/minetest/minetest/pull/5349 faster climb speed.