### PR TITLE
Add aliases for sandplus nodes to be changed to default nodes.

### DIFF
--- a/mods/default/aliases.lua
+++ b/mods/default/aliases.lua
@@ -75,3 +75,11 @@ minetest.register_alias("default:pinewood", "default:pine_wood")
 
 minetest.register_alias("default:ladder", "default:ladder_wood")
 minetest.register_alias("default:sign_wall", "default:sign_wall_wood")
+
+-- Aliases for sandplus node names
+minetest.register_alias("sandplus:desert_sandstone", "default:desert_sandstone")
+minetest.register_alias("sandplus:desert_sandstone_block", "default:desert_sandstone_block")
+minetest.register_alias("sandplus:desert_sandstone_brick", "default:desert_sandstone_brick")
+minetest.register_alias("sandplus:silver_sandstone", "default:silver_sandstone")
+minetest.register_alias("sandplus:silver_sandstone_block", "default:silver_sandstone_block")
+minetest.register_alias("sandplus:silver_sandstone_brick", "default:silver_sandstone_brick")


### PR DESCRIPTION
[People](https://forum.minetest.net/viewtopic.php?f=9&t=16281#p255927) (that had used [sandplus](https://forum.minetest.net/viewtopic.php?f=9&t=16281) nodes already) wanted me to create aliases for my mod since my mod's content was [added to minetest_game](https://github.com/minetest/minetest_game/pull/1596). This PR adds some aliases to change my nodes to default nodes.
