### PR TITLE
Mapgen: Use decoration sidelen 16 for jungletrees and junglegrass

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -1323,7 +1323,7 @@ function default.register_decorations()
 	minetest.register_decoration({
 		deco_type = "schematic",
 		place_on = {"default:dirt_with_rainforest_litter", "default:dirt"},
-		sidelen = 80,
+		sidelen = 16,
 		fill_ratio = 0.1,
 		biomes = {"rainforest", "rainforest_swamp"},
 		y_min = -1,
@@ -1336,7 +1336,7 @@ function default.register_decorations()
 	minetest.register_decoration({
 		deco_type = "schematic",
 		place_on = {"default:dirt_with_rainforest_litter", "default:dirt"},
-		sidelen = 80,
+		sidelen = 16,
 		fill_ratio = 0.005,
 		biomes = {"rainforest", "rainforest_swamp"},
 		y_min = 1,
@@ -1597,7 +1597,7 @@ function default.register_decorations()
 	minetest.register_decoration({
 		deco_type = "simple",
 		place_on = {"default:dirt_with_rainforest_litter"},
-		sidelen = 80,
+		sidelen = 16,
 		fill_ratio = 0.1,
 		biomes = {"rainforest"},
 		y_min = 1,


### PR DESCRIPTION
Currently jungletrees and junglegrass use sidelen 80 for simplicity,
but this results in a more uneven distribution of decorations. A more
even distribution helps keep rainforest darker with a more unbroken
canopy.
This is also more consistent. 80 is based on the default mapchunk
size, all other decorations use sidelen 16 or smaller to divide into
any mapchunk size.
/////////////////////////////////////////////////

Note by 'more even distribution' i mean 'more even random distribution'. The change is likely to be very subtle. The main issue here is consistency and dividing into any mapchunk size.