### PR TITLE
Flint & steel sounds: Fix bugs caused by nil position

### DIFF
--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -80,27 +80,27 @@ minetest.register_tool("fire:flint_and_steel", {
 	sound = {breaks = "default_tool_breaks"},
 
 	on_use = function(itemstack, user, pointed_thing)
-		local pt = pointed_thing
+		local sound_pos = pointed_thing.above or user:get_pos()
 		minetest.sound_play(
 			"fire_flint_and_steel",
-			{pos = pt.above, gain = 0.5, max_hear_distance = 8}
+			{pos = sound_pos, gain = 0.5, max_hear_distance = 8}
 		)
-		if pt.type == "node" then
-			local node_under = minetest.get_node(pt.under).name
+		if pointed_thing.type == "node" then
+			local node_under = minetest.get_node(pointed_thing.under).name
 			local nodedef = minetest.registered_nodes[node_under]
 			if not nodedef then
 				return
 			end
 			local player_name = user:get_player_name()
-			if minetest.is_protected(pt.under, player_name) then
+			if minetest.is_protected(pointed_thing.under, player_name) then
 				minetest.chat_send_player(player_name, "This area is protected")
 				return
 			end
 			if nodedef.on_ignite then
-				nodedef.on_ignite(pt.under, user)
+				nodedef.on_ignite(pointed_thing.under, user)
 			elseif minetest.get_item_group(node_under, "flammable") >= 1
-					and minetest.get_node(pt.above).name == "air" then
-				minetest.set_node(pt.above, {name = "fire:basic_flame"})
+					and minetest.get_node(pointed_thing.above).name == "air" then
+				minetest.set_node(pointed_thing.above, {name = "fire:basic_flame"})
 			end
 		end
 		if not minetest.setting_getbool("creative_mode") then
@@ -109,7 +109,7 @@ minetest.register_tool("fire:flint_and_steel", {
 			itemstack:add_wear(1000)
 			-- Tool break sound
 			if itemstack:get_count() == 0 and wdef.sound and wdef.sound.breaks then
-				minetest.sound_play(wdef.sound.breaks, {pos = pt.above, gain = 0.5})
+				minetest.sound_play(wdef.sound.breaks, {pos = sound_pos, gain = 0.5})
 			end
 			return itemstack
 		end


### PR DESCRIPTION
Usage and tool break sounds were played at 'pointed_thing.above' which
can be nil if not pointing at anything or at an entity. This caused
sounds to be played to all players on a server non-positionally.

Fallback to player pos for sounds if 'pointed_thing.above' is nil.

Replace 'pt' variable with 'pointed_thing' in 'register_tool'.
/////////////////////////////////////////////////

Addresses #1613 
Tested.