### PR TITLE
Keys: Update default.can_interact_with_node to new item meta

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -551,21 +551,23 @@ function default.can_interact_with_node(player, pos)
 
 	local meta = minetest.get_meta(pos)
 
-	-- is player wielding the right key?
-	local item = player:get_wielded_item()
-	if item:get_name() == "default:key" then
-		local key_meta = minetest.parse_json(item:get_metadata())
-		local secret = meta:get_string("key_lock_secret")
-		if secret ~= key_meta.secret then
-			return false
-		end
-
+	if player:get_player_name() == meta:get_string("owner") then
+		-- Owner can access the node to any time
 		return true
 	end
 
-	if player:get_player_name() ~= meta:get_string("owner") then
-		return false
+	-- is player wielding the right key?
+	local item = player:get_wielded_item()
+	if item:get_name() == "default:key" then
+		local key_meta = item:get_meta()
+
+		if key_meta:get_string("secret") == "" then
+			key_meta:set_string("secret", minetest.parse_json(item:get_metadata()).secret)
+			item:set_metadata("")
+		end
+
+		return meta:get_string("key_lock_secret") == key_meta:get_string("secret")
 	end
 
-	return true
+	return false
 end

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1805,6 +1805,7 @@ minetest.register_node("default:chest_locked", {
 
 		if key_meta:get_string("secret") == "" then
 			key_meta:set_string("secret", minetest.parse_json(itemstack:get_metadata()).secret)
+			itemstack:set_metadata("")
 		end
 
 		if secret ~= key_meta:get_string("secret") then

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -149,6 +149,7 @@ function _doors.door_toggle(pos, node, clicker)
 
 			if key_meta:get_string("secret") == "" then
 				key_meta:set_string("secret", minetest.parse_json(item:get_metadata()).secret)
+				item:set_metadata("")
 			end
 
 			if secret ~= key_meta:get_string("secret") then


### PR DESCRIPTION
Completes a forgotten update in 9d3a526
Fixes #1626 and allows owner to access their nodes to any time, no matter what they're holding.