### PR TITLE
Fix crash when using unconfigured default:key

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -562,7 +562,12 @@ function default.can_interact_with_node(player, pos)
 		local key_meta = item:get_meta()
 
 		if key_meta:get_string("secret") == "" then
-			key_meta:set_string("secret", minetest.parse_json(item:get_metadata()).secret)
+			local key_oldmeta = item:get_metadata()
+			if key_oldmeta == "" or not minetest.parse_json(key_oldmeta) then
+				return false
+			end
+
+			key_meta:set_string("secret", minetest.parse_json(key_oldmeta).secret)
 			item:set_metadata("")
 		end
 


### PR DESCRIPTION
Addresses #1640

Since meta secret field is blank on any keys (default:key) obtained using /give, the game will crash if you attempt to use one of these. This follows along the principle that the game should never have any reason to crash.