### PR TITLE
Fix crash on keys without meta.

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -562,7 +562,11 @@ function default.can_interact_with_node(player, pos)
 		local key_meta = item:get_meta()
 
 		if key_meta:get_string("secret") == "" then
-			key_meta:set_string("secret", minetest.parse_json(item:get_metadata()).secret)
+			local oldmeta = minetest.parse_json(item:get_metadata())
+			if not oldmeta then
+				return false
+			end
+			key_meta:set_string("secret", oldmeta.secret)
 			item:set_metadata("")
 		end
 

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -148,7 +148,11 @@ function _doors.door_toggle(pos, node, clicker)
 			local secret = meta:get_string("key_lock_secret")
 
 			if key_meta:get_string("secret") == "" then
-				key_meta:set_string("secret", minetest.parse_json(item:get_metadata()).secret)
+				local oldmeta = minetest.parse_json(item:get_metadata())
+				if not oldmeta then
+					return false
+				end
+				key_meta:set_string("secret", oldmeta.secret)
 				item:set_metadata("")
 			end
 
@@ -542,7 +546,12 @@ function _doors.trapdoor_toggle(pos, node, clicker)
 			local secret = meta:get_string("key_lock_secret")
 
 			if key_meta:get_string("secret") == "" then
-				key_meta:set_string("secret", minetest.parse_json(item:get_metadata()).secret)
+				local oldmeta = minetest.parse_json(item:get_metadata())
+				if not oldmeta then
+					return false
+				end
+				key_meta:set_string("secret", oldmeta.secret)
+				item:set_metadata("")
 			end
 
 			if secret ~= key_meta:get_string("secret") then


### PR DESCRIPTION
If you /giveme a default:key, it will crash on use on a door.

We can harden it a little bit by parsing the old metadata string
and if that errors (which will show in singleplayer/local server)
we just error, but not crash the client.