### PR TITLE
Junglegrass: Prevent seeding of dirt_with_grass

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1170,7 +1170,7 @@ minetest.register_node("default:junglegrass", {
 	sunlight_propagates = true,
 	walkable = false,
 	buildable_to = true,
-	groups = {snappy = 3, flora = 1, attached_node = 1, grass = 1, flammable = 1},
+	groups = {snappy = 3, flora = 1, attached_node = 1, flammable = 1},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
 		type = "fixed",


### PR DESCRIPTION
Previously you could place junglegrass on dirt to convert that dirt to
dirt_with_grass, but this is unsuitable now that rainforest has a
surface of dirt_with_rainforest_litter.
Remove junglegrass from the 'grass' group.
//////////////////////////////////////////////////

Fixes #1643 