### PR TITLE
Leafdecay: Change Aspen radius back to 3

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -2203,7 +2203,7 @@ default.register_leafdecay({
 default.register_leafdecay({
 	trunks = {"default:aspen_tree"},
 	leaves = {"default:aspen_leaves"},
-	radius = 2,
+	radius = 3,
 })
 
 default.register_leafdecay({


### PR DESCRIPTION
Although the new aspen tree schematic only requires a radius of 2 the
many existing aspen trees in a world require radius 3.
///////////////////////////////////////////////////

22:28 kaeza       is it just me, or the topmost leaves node of mapgen-placed aspen trees just fails to decay?
22:28 kaeza       haven't tested aspen trees grown from saplings
22:30 paramat     i raised the trunk by 1 node in the schematic, ahh perhaps the already-placed aspens are as they were before, so the new leafdecay radius 2 is not large enough for them
22:31 sofar       paramat: lol, yes, that would do that
22:31 sofar       kaeza: time for timberrrrr!
22:32 paramat     might have to raise the radius to 3 again for a few years