### PR TITLE
Flora spread: Generalise, allow spread on rainforest litter

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -434,7 +434,7 @@ minetest.register_node("default:dirt_with_snow", {
 	tiles = {"default_snow.png", "default_dirt.png",
 		{name = "default_dirt.png^default_snow_side.png",
 			tileable_vertical = false}},
-	groups = {crumbly = 3, soil = 1, spreading_dirt_type = 1, snowy = 1},
+	groups = {crumbly = 3, spreading_dirt_type = 1, snowy = 1},
 	drop = 'default:dirt',
 	sounds = default.node_sound_dirt_defaults({
 		footstep = {name = "default_snow_footstep", gain = 0.15},


### PR DESCRIPTION
Fixes #1650 but also simplifies and generalises to group:soil instead of naming individual nodes.
The previous code did not take account of any sand other than desert sand, now flora turns to dry shrub if placed on any non-soil node.

Untested.