### PR TITLE
xpanes: support use_texture_alpha option

### DIFF
--- a/mods/xpanes/init.lua
+++ b/mods/xpanes/init.lua
@@ -94,6 +94,7 @@ function xpanes.register_pane(name, def)
 	minetest.register_node(":xpanes:" .. name .. "_flat", {
 		description = def.description,
 		drawtype = "nodebox",
+		use_texture_alpha = def.use_texture_alpha,
 		paramtype = "light",
 		is_ground_content = false,
 		sunlight_propagates = true,
@@ -120,6 +121,7 @@ function xpanes.register_pane(name, def)
 	groups.not_in_creative_inventory = 1
 	minetest.register_node(":xpanes:" .. name, {
 		drawtype = "nodebox",
+		use_texture_alpha = def.use_texture_alpha,
 		paramtype = "light",
 		is_ground_content = false,
 		sunlight_propagates = true,


### PR DESCRIPTION
My [stained_glass](https://github.com/ForbiddenJ/stained_glass) mod uses a soup-bowl combination of textures to make it transparent while being dynamically updated to whatever texture. However, xpanes doesn't support use_texture_alpha. That's why I need this option supported.

![screenshot from 2017-03-18 21-48-08](https://cloud.githubusercontent.com/assets/26123860/24077849/c729f2ea-0c28-11e7-951b-73d0b3f5c240.png)
Before

![screenshot from 2017-03-18 21-47-34](https://cloud.githubusercontent.com/assets/26123860/24077852/d0696c0a-0c28-11e7-83b3-af58397a7ae3.png)
After