### PR TITLE
Flora spread: Do not replace flora with dry shrub, only 'return' 

### DIFF
--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -107,10 +107,9 @@ function flowers.flower_spread(pos, node)
 	pos.y = pos.y - 1
 	local under = minetest.get_node(pos)
 	pos.y = pos.y + 1
-	if minetest.get_item_group(under.name, "soil") == 0 and
-			-- Do not replace sand dune grasses
-			under.name ~= "default:sand" then
-		minetest.set_node(pos, {name = "default:dry_shrub"})
+	if minetest.get_item_group(under.name, "soil") == 0 then
+		-- Do not replace with dry shrub here as
+		-- this breaks flower pots and other mods.
 		return
 	end
 


### PR DESCRIPTION
If there is no group:soil node found below, do not replace flora with
dry shrub, this was breaking flower pots and other mods.
Originally, flora would only turn to dry shrub if in desert sand.
////////////////////////////////////////////

Fixes 2 issues detailed in #1657 and probably avoids other breakage.