### PR TITLE
Flora spread: Re-enable dry shrub replacing flora in desert sand

### DIFF
--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -107,9 +107,16 @@ function flowers.flower_spread(pos, node)
 	pos.y = pos.y - 1
 	local under = minetest.get_node(pos)
 	pos.y = pos.y + 1
+	-- Replace flora with dry shrub in desert sand and silver sand,
+	-- as this is the only way to generate them.
+	-- However, preserve grasses in sand dune biomes.
+	if minetest.get_item_group(under.name, "sand") == 1 and
+			under.name ~= "default:sand" then
+		minetest.set_node(pos, {name = "default:dry_shrub"})
+		return
+	end
+
 	if minetest.get_item_group(under.name, "soil") == 0 then
-		-- Do not replace with dry shrub here as
-		-- this breaks flower pots and other mods.
 		return
 	end
 


### PR DESCRIPTION
Flora is converted to dry shrub in desert sand and silver sand.
No conversion in sand to preserve sand dune grasses.
Dry shrubs do not spread so this conversion, used by players, is the
only way to generate them.
////////////////////////////////////////////////

Addresses https://github.com/minetest/minetest_game/pull/1660#issuecomment-288580809