### PR TITLE
Carts: Make rail recipes more generous

### DIFF
--- a/mods/carts/rails.lua
+++ b/mods/carts/rails.lua
@@ -10,11 +10,11 @@ carts:register_rail("carts:rail", {
 }, {})
 
 minetest.register_craft({
-	output = "carts:rail 16",
+	output = "carts:rail 18",
 	recipe = {
+		{"default:steel_ingot", "group:wood", "default:steel_ingot"},
 		{"default:steel_ingot", "", "default:steel_ingot"},
-		{"default:steel_ingot", "group:stick", "default:steel_ingot"},
-		{"default:steel_ingot", "", "default:steel_ingot"},
+		{"default:steel_ingot", "group:wood", "default:steel_ingot"},
 	}
 })
 
@@ -31,11 +31,11 @@ carts:register_rail("carts:powerrail", {
 }, {acceleration = 5})
 
 minetest.register_craft({
-	output = "carts:powerrail 8",
+	output = "carts:powerrail 18",
 	recipe = {
-		{"default:steel_ingot", "default:mese_crystal_fragment", "default:steel_ingot"},
-		{"default:steel_ingot", "group:stick", "default:steel_ingot"},
-		{"default:steel_ingot", "default:mese_crystal_fragment", "default:steel_ingot"},
+		{"default:steel_ingot", "group:wood", "default:steel_ingot"},
+		{"default:steel_ingot", "default:mese_crystal", "default:steel_ingot"},
+		{"default:steel_ingot", "group:wood", "default:steel_ingot"},
 	}
 })
 
@@ -50,10 +50,10 @@ carts:register_rail("carts:brakerail", {
 }, {acceleration = -3})
 
 minetest.register_craft({
-	output = "carts:brakerail 8",
+	output = "carts:brakerail 18",
 	recipe = {
+		{"default:steel_ingot", "group:wood", "default:steel_ingot"},
 		{"default:steel_ingot", "default:coal_lump", "default:steel_ingot"},
-		{"default:steel_ingot", "group:stick", "default:steel_ingot"},
-		{"default:steel_ingot", "default:coal_lump", "default:steel_ingot"},
+		{"default:steel_ingot", "group:wood", "default:steel_ingot"},
 	}
 })


### PR DESCRIPTION
As part of making vertical travel easier to reduce reliance on
sneak ladders.
Calculate using cubic pixels of steel.

A steelblock is 16^3 = 4096 cubic pixels steel.
6 ingots is 6/9 steelblocks.
A rail is a 2*2*16 pixel length of steel, 64 cubic pixels steel.
6 ingots produces 2*21 rails = 21 rail nodes.
Choose 18 for an even number that is a multiple of ingot number.

Replace the stick with 2 wood in the recipe to be closer to the amount
of wood that would be needed for 20*4 sleepers.

Replace 2 mese crystal fragments with 1 mese crystal to
compensate for the larger number of nodes returned. The result
is the recipe is much more generous with steel usage but slightly
less generous with mese usage, keeping power rail cost reasonably high.

Replace 2 coal lumps with 1 for a similar recipe to power rails.
///////////////////////////////////////////////////

S = steel ingot
W = group:wood
M = mese crystal
C = coal lump

Rail 18
SWS
S_S
SWS

Power rail 18
SWS
SMS
SWS

Brake rail 18
SWS
SCS
SWS