### PR TITLE
doors: add groups to the door craftitem

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -254,6 +254,7 @@ function doors.register(name, def)
 	minetest.register_craftitem(":" .. name, {
 		description = def.description,
 		inventory_image = def.inventory_image,
+		groups = def.groups,
 
 		on_place = function(itemstack, placer, pointed_thing)
 			local pos


### PR DESCRIPTION
This change makes it possible to add groups for the door craftitems.

Reason:
I am making a mod which should add new doors which aren’t in the creative inventory, but at the moment this is not possible, because the `doors.register(name, def)` function doesn’t allow to set the not_in_creative_inventory group of the craftitem to 1.