### PR TITLE
Disable fire by default on servers

### DIFF
--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -292,13 +292,13 @@ minetest.register_abm({
 
 local fire_enabled = minetest.setting_getbool("enable_fire")
 if fire_enabled == nil then
-	-- New setting not specified, check for old setting
-	fire_enabled = minetest.setting_getbool("disable_fire")
-	if fire_enabled == nil then
+	-- enable_fire setting not specified, check for disable_fire
+	local fire_disabled = minetest.setting_getbool("disable_fire")
+	if fire_disabled == nil then
 		-- Neither setting specified, check whether singleplayer
 		fire_enabled = minetest.is_singleplayer()
 	else
-		fire_enabled = not fire_enabled
+		fire_enabled = not fire_disabled
 	end
 end
 

--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -296,11 +296,7 @@ if fire_enabled == nil then
 	fire_enabled = minetest.setting_getbool("disable_fire")
 	if fire_enabled == nil then
 		-- Neither setting specified, check whether singleplayer
-		if minetest.is_singleplayer() then
-			fire_enabled = true
-		else
-			fire_enabled = false
-		end
+		fire_enabled = minetest.is_singleplayer()
 	else
 		fire_enabled = not fire_enabled
 	end

--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -292,9 +292,18 @@ minetest.register_abm({
 
 local fire_enabled = minetest.setting_getbool("enable_fire")
 if fire_enabled == nil then
-	-- New setting not specified, check for old setting.
-	-- If old setting is also not specified, 'not nil' is true.
-	fire_enabled = not minetest.setting_getbool("disable_fire")
+	-- New setting not specified, check for old setting
+	fire_enabled = minetest.setting_getbool("disable_fire")
+	if fire_enabled == nil then
+		-- Neither setting specified, check whether singleplayer
+		if minetest.is_singleplayer() then
+			fire_enabled = true
+		else
+			fire_enabled = false
+		end
+	else
+		fire_enabled = not fire_enabled
+	end
 end
 
 if not fire_enabled then


### PR DESCRIPTION
This disables fire on servers if neither enable_fire nor disable_fire are set in minetest.conf. Singleplayer remains unchanged. Aim is to prevent new server owners finding their maps griefed because they didn't realise there was an option.

This PR resulted from discussion on -hub where it seemed to have strong support.