### PR TITLE
TNT: do not change behavior based on `singleplayer` gameplay.

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -32,7 +32,7 @@
 #initial_stuff = default:pick_steel,default:axe_steel,default:shovel_steel,default:torch 99,default:cobble 99
 
 # Whether the TNT mod should be enabled
-#enable_tnt = <true in singleplayer, false in multiplayer>
+#enable_tnt = true
 
 # The radius of a TNT explosion
 #tnt_radius = 3

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -2,9 +2,6 @@ tnt = {}
 
 -- Default to enabled when in singleplayer
 local enable_tnt = minetest.setting_getbool("enable_tnt")
-if enable_tnt == nil then
-	enable_tnt = minetest.is_singleplayer()
-end
 
 -- loss probabilities array (one in X will be lost)
 local loss_prob = {}


### PR DESCRIPTION
`minetest.is_singleplayer()` is considered bad. The flag specifies
that the game was started in `singleplayer` mode. However, entirely
functionally equal is a game that is started as a local LAN game
(multiplayer server).

For this reason we should not introduce gameplay different behavior
when the world is loaded in singleplayer or server mode. It is
entirely reasonable that players start in singleplayer, but
later change to hosting their worlds on a LAN with `server` mode.

Changing the behavior based on this flag is therefore bad form as
it makes assumptions that can't be made. So, don't make them.