### PR TITLE
Doors: ignore permission check if player parameter is omitted

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -150,7 +150,7 @@ function _doors.door_toggle(pos, node, clicker)
 
 	replace_old_owner_information(pos)
 
-	if not default.can_interact_with_node(clicker, pos) then
+	if clicker and not default.can_interact_with_node(clicker, pos) then
 		return false
 	end
 
@@ -530,7 +530,7 @@ function _doors.trapdoor_toggle(pos, node, clicker)
 
 	replace_old_owner_information(pos)
 
-	if not default.can_interact_with_node(clicker, pos) then
+	if clicker and not default.can_interact_with_node(clicker, pos) then
 		return false
 	end
 


### PR DESCRIPTION
As written in `game_api.txt`.

Makes mesecons doors working again 😃 