### PR TITLE
Fix books getting erased on page button use.

### DIFF
--- a/mods/default/craftitems.lua
+++ b/mods/default/craftitems.lua
@@ -139,7 +139,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 			end
 		end
 
-		stack:get_meta():from_table(data)
+		stack:get_meta():from_table({fields = data})
 		stack = book_on_use(stack, player)
 	end
 


### PR DESCRIPTION
Changing the book page caused the entire itemstack meta to
get wiped due to improper calling of meta:from_table().

Fixes #1711