### PR TITLE
Doors: place sound when placing a door.

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -332,6 +332,8 @@ function doors.register(name, def)
 				itemstack:take_item()
 			end
 
+			minetest.sound_play(def.sounds.place, {pos = pos})
+
 			on_place_node(pos, minetest.get_node(pos),
 				placer, node, itemstack, pointed_thing)
 


### PR DESCRIPTION
Due to door items being the thing that's placed, we need to
explicitly play a sound when placing a door.

Fixes #1363