### PR TITLE
Add option to disable lavacooling

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -27,6 +27,9 @@
 # Enable flame sound.
 #flame_sound = true
 
+# Whether lavacooling should be enabled.
+#enable_lavacooling = true
+
 # Whether the stuff in initial_stuff should be given to new players
 #give_initial_stuff = false
 #initial_stuff = default:pick_steel,default:axe_steel,default:shovel_steel,default:torch 99,default:cobble 99

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -131,18 +131,19 @@ default.cool_lava = function(pos, node)
 		{pos = pos, max_hear_distance = 16, gain = 0.25})
 end
 
-minetest.register_abm({
-	label = "Lava cooling",
-	nodenames = {"default:lava_source", "default:lava_flowing"},
-	neighbors = {"group:cools_lava", "group:water"},
-	interval = 1,
-	chance = 2,
-	catch_up = false,
-	action = function(...)
-		default.cool_lava(...)
-	end,
-})
-
+if minetest.setting_getbool("enable_lavacooling") ~= false then
+	minetest.register_abm({
+		label = "Lava cooling",
+		nodenames = {"default:lava_source", "default:lava_flowing"},
+		neighbors = {"group:cools_lava", "group:water"},
+		interval = 1,
+		chance = 2,
+		catch_up = false,
+		action = function(...)
+			default.cool_lava(...)
+		end,
+	})
+end
 
 --
 -- optimized helper to put all items in an inventory into a drops list

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -16,6 +16,9 @@ enable_fire (Fire) bool true
 #    Enable flame sound.
 flame_sound (Flame sound) bool true
 
+#    Enable lavacooling.
+enable_lavacooling (Lavacooling) bool true
+
 #    If enabled, steel tools, torches and cobblestone will be given to new
 #    players.
 give_initial_stuff (Give initial items) bool false


### PR DESCRIPTION
Adds a simple option to disable lavacooling. Lavacooling can be used for griefing and isn't always wanted by server owners.

This doesn't change default behaviour.