### PR TITLE
Settings: Use new settings object

### DIFF
--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -1,7 +1,7 @@
 local pi = math.pi
 local player_in_bed = 0
 local is_sp = minetest.is_singleplayer()
-local enable_respawn = minetest.setting_getbool("enable_bed_respawn")
+local enable_respawn = minetest.settings:get_bool("enable_bed_respawn")
 if enable_respawn == nil then
 	enable_respawn = true
 end
@@ -22,7 +22,7 @@ local function get_look_yaw(pos)
 end
 
 local function is_night_skip_enabled()
-	local enable_night_skip = minetest.setting_getbool("enable_bed_night_skip")
+	local enable_night_skip = minetest.settings:get_bool("enable_bed_night_skip")
 	if enable_night_skip == nil then
 		enable_night_skip = true
 	end

--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -21,8 +21,8 @@ local bones_formspec =
 	"listring[current_player;main]" ..
 	default.get_hotbar_bg(0,4.85)
 
-local share_bones_time = tonumber(minetest.setting_get("share_bones_time")) or 1200
-local share_bones_time_early = tonumber(minetest.setting_get("share_bones_time_early")) or share_bones_time / 4
+local share_bones_time = tonumber(minetest.settings:get("share_bones_time")) or 1200
+local share_bones_time_early = tonumber(minetest.settings:get("share_bones_time_early")) or share_bones_time / 4
 
 minetest.register_node("bones:bones", {
 	description = "Bones",
@@ -161,7 +161,7 @@ end
 
 minetest.register_on_dieplayer(function(player)
 
-	local bones_mode = minetest.setting_get("bones_mode") or "bones"
+	local bones_mode = minetest.settings:get("bones_mode") or "bones"
 	if bones_mode ~= "bones" and bones_mode ~= "drop" and bones_mode ~= "keep" then
 		bones_mode = "bones"
 	end

--- a/mods/creative/init.lua
+++ b/mods/creative/init.lua
@@ -1,6 +1,6 @@
 creative = {}
 
-local creative_mode_cache = minetest.setting_getbool("creative_mode")
+local creative_mode_cache = minetest.settings:get_bool("creative_mode")
 
 function creative.is_enabled_for(name)
 	return creative_mode_cache

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -131,7 +131,7 @@ default.cool_lava = function(pos, node)
 		{pos = pos, max_hear_distance = 16, gain = 0.25})
 end
 
-if minetest.setting_getbool("enable_lavacooling") ~= false then
+if minetest.settings:get_bool("enable_lavacooling") ~= false then
 	minetest.register_abm({
 		label = "Lava cooling",
 		nodenames = {"default:lava_source", "default:lava_flowing"},

--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -148,7 +148,7 @@ minetest.override_item("default:coalblock", {
 -- Sound
 --
 
-local flame_sound = minetest.setting_getbool("flame_sound")
+local flame_sound = minetest.settings:get_bool("flame_sound")
 if flame_sound == nil then
 	-- Enable if no setting present
 	flame_sound = true
@@ -290,10 +290,10 @@ minetest.register_abm({
 
 -- Enable the following ABMs according to 'enable fire' setting
 
-local fire_enabled = minetest.setting_getbool("enable_fire")
+local fire_enabled = minetest.settings:get_bool("enable_fire")
 if fire_enabled == nil then
 	-- enable_fire setting not specified, check for disable_fire
-	local fire_disabled = minetest.setting_getbool("disable_fire")
+	local fire_disabled = minetest.settings:get_bool("disable_fire")
 	if fire_disabled == nil then
 		-- Neither setting specified, check whether singleplayer
 		fire_enabled = minetest.is_singleplayer()

--- a/mods/give_initial_stuff/init.lua
+++ b/mods/give_initial_stuff/init.lua
@@ -1,4 +1,4 @@
-local stuff_string = minetest.setting_get("initial_stuff") or
+local stuff_string = minetest.settings:get("initial_stuff") or
 		"default:pick_steel,default:axe_steel,default:shovel_steel," ..
 		"default:torch 99,default:cobble 99"
 
@@ -39,6 +39,6 @@ function give_initial_stuff.get_list()
 end
 
 give_initial_stuff.add_from_csv(stuff_string)
-if minetest.setting_getbool("give_initial_stuff") then
+if minetest.settings:get_bool("give_initial_stuff") then
 	minetest.register_on_newplayer(give_initial_stuff.give)
 end

--- a/mods/killme/init.lua
+++ b/mods/killme/init.lua
@@ -3,7 +3,7 @@ minetest.register_chatcommand("killme", {
 	func = function(name)
 		local player = minetest.get_player_by_name(name)
 		if player then
-			if minetest.setting_getbool("enable_damage") then
+			if minetest.settings:get_bool("enable_damage") then
 				player:set_hp(0)
 				return true
 			else

--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -15,7 +15,7 @@ minetest.register_alias("stairs:slab_pinewood", "stairs:slab_pine_wood")
 
 -- Get setting for replace ABM
 
-local replace = minetest.setting_getbool("enable_stairs_replace_abm")
+local replace = minetest.settings:get_bool("enable_stairs_replace_abm")
 
 local function rotate_and_place(itemstack, placer, pointed_thing)
 	local p0 = pointed_thing.under

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -1,7 +1,7 @@
 tnt = {}
 
 -- Default to enabled when in singleplayer
-local enable_tnt = minetest.setting_getbool("enable_tnt")
+local enable_tnt = minetest.settings:get_bool("enable_tnt")
 if enable_tnt == nil then
 	enable_tnt = minetest.is_singleplayer()
 end
@@ -12,7 +12,7 @@ local loss_prob = {}
 loss_prob["default:cobble"] = 3
 loss_prob["default:dirt"] = 4
 
-local tnt_radius = tonumber(minetest.setting_get("tnt_radius") or 3)
+local tnt_radius = tonumber(minetest.settings:get("tnt_radius") or 3)
 
 -- Fill a list with data for content IDs, after all nodes are registered
 local cid_data = {}


### PR DESCRIPTION
Update all setting calls to the new 'settings' object. This stops deprecation messages.

By the way @ShadowNinja where do the deprecation messages appear? I cannot find them anywhere, not even in verbose debug.txt. This makes this PR difficut to test as i don't know if i updated all settings.