### PR TITLE
Changed "Junglewood" to "Jungle Wood"

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -693,7 +693,7 @@ minetest.register_node("default:jungletree", {
 })
 
 minetest.register_node("default:junglewood", {
-	description = "Junglewood Planks",
+	description = "Jungle Wood Planks",
 	paramtype2 = "facedir",
 	place_param2 = 0,
 	tiles = {"default_junglewood.png"},
@@ -2264,7 +2264,7 @@ default.register_fence("default:fence_acacia_wood", {
 })
 
 default.register_fence("default:fence_junglewood", {
-	description = "Junglewood Fence",
+	description = "Jungle Wood Fence",
 	texture = "default_fence_junglewood.png",
 	inventory_image = "default_fence_overlay.png^default_junglewood.png^default_fence_overlay.png^[makealpha:255,126,126",
 	wield_image = "default_fence_overlay.png^default_junglewood.png^default_fence_overlay.png^[makealpha:255,126,126",

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -787,7 +787,7 @@ doors.register_fencegate("doors:gate_acacia_wood", {
 })
 
 doors.register_fencegate("doors:gate_junglewood", {
-	description = "Junglewood Fence Gate",
+	description = "Jungle Wood Fence Gate",
 	texture = "default_junglewood.png",
 	material = "default:junglewood",
 	groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 2}


### PR DESCRIPTION
Fixes mismatch created with 983af7b1c0a01436fe38111d5aed664e4765d7ea