### PR TITLE
Stairs: Use one recipe matching inventory appearence

### DIFF
--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -89,16 +89,7 @@ function stairs.register_stair(subname, recipeitem, groups, images, description,
 	end
 
 	if recipeitem then
-		minetest.register_craft({
-			output = 'stairs:stair_' .. subname .. ' 8',
-			recipe = {
-				{recipeitem, "", ""},
-				{recipeitem, recipeitem, ""},
-				{recipeitem, recipeitem, recipeitem},
-			},
-		})
-
-		-- Flipped recipe for the silly minecrafters
+		-- Recipe matches appearence in inventory
 		minetest.register_craft({
 			output = 'stairs:stair_' .. subname .. ' 8',
 			recipe = {


### PR DESCRIPTION
No longer have 2 recipes for stairs, choose the one that matches the appearence
in inventory (stair rising toward the right).
Helps to reduce recipe count now that an increasing number of stairs are
being registered.
//////////////////

Addresses #1741 
Makes space for another recipe added by #1740 