### PR TITLE
Add option for enabling/disabling tool wear

### DIFF
--- a/mods/default/tools.lua
+++ b/mods/default/tools.lua
@@ -1,5 +1,24 @@
 -- mods/default/tools.lua
 
+local t_uses = {}
+local tool_wear_enabled = minetest.settings:get_bool("enable_tool_wear")
+if tool_wear_enabled == nil then
+	-- Default is enabled
+	tool_wear_enabled = true
+end
+
+if tool_wear_enabled then
+	t_uses.ten = 10
+	t_uses.twenty = 20
+	t_uses.thirty = 30
+	t_uses.forty = 40
+else
+	t_uses.ten = 0
+	t_uses.twenty = 0
+	t_uses.thirty = 0
+	t_uses.forty = 0
+end
+
 -- The hand
 minetest.register_item(":", {
 	type = "none",
@@ -28,7 +47,7 @@ minetest.register_tool("default:pick_wood", {
 		full_punch_interval = 1.2,
 		max_drop_level=0,
 		groupcaps={
-			cracky = {times={[3]=1.60}, uses=10, maxlevel=1},
+			cracky = {times={[3]=1.60}, uses=t_uses.ten, maxlevel=1},
 		},
 		damage_groups = {fleshy=2},
 	},
@@ -43,7 +62,7 @@ minetest.register_tool("default:pick_stone", {
 		full_punch_interval = 1.3,
 		max_drop_level=0,
 		groupcaps={
-			cracky = {times={[2]=2.0, [3]=1.00}, uses=20, maxlevel=1},
+			cracky = {times={[2]=2.0, [3]=1.00}, uses=t_uses.twenty, maxlevel=1},
 		},
 		damage_groups = {fleshy=3},
 	},
@@ -57,7 +76,7 @@ minetest.register_tool("default:pick_steel", {
 		full_punch_interval = 1.0,
 		max_drop_level=1,
 		groupcaps={
-			cracky = {times={[1]=4.00, [2]=1.60, [3]=0.80}, uses=20, maxlevel=2},
+			cracky = {times={[1]=4.00, [2]=1.60, [3]=0.80}, uses=t_uses.twenty, maxlevel=2},
 		},
 		damage_groups = {fleshy=4},
 	},
@@ -71,7 +90,7 @@ minetest.register_tool("default:pick_bronze", {
 		full_punch_interval = 1.0,
 		max_drop_level=1,
 		groupcaps={
-			cracky = {times={[1]=4.00, [2]=1.60, [3]=0.80}, uses=30, maxlevel=2},
+			cracky = {times={[1]=4.00, [2]=1.60, [3]=0.80}, uses=t_uses.thirty, maxlevel=2},
 		},
 		damage_groups = {fleshy=4},
 	},
@@ -85,7 +104,7 @@ minetest.register_tool("default:pick_mese", {
 		full_punch_interval = 0.9,
 		max_drop_level=3,
 		groupcaps={
-			cracky = {times={[1]=2.4, [2]=1.2, [3]=0.60}, uses=20, maxlevel=3},
+			cracky = {times={[1]=2.4, [2]=1.2, [3]=0.60}, uses=t_uses.twenty, maxlevel=3},
 		},
 		damage_groups = {fleshy=5},
 	},
@@ -99,7 +118,7 @@ minetest.register_tool("default:pick_diamond", {
 		full_punch_interval = 0.9,
 		max_drop_level=3,
 		groupcaps={
-			cracky = {times={[1]=2.0, [2]=1.0, [3]=0.50}, uses=30, maxlevel=3},
+			cracky = {times={[1]=2.0, [2]=1.0, [3]=0.50}, uses=t_uses.thirty, maxlevel=3},
 		},
 		damage_groups = {fleshy=5},
 	},
@@ -118,7 +137,7 @@ minetest.register_tool("default:shovel_wood", {
 		full_punch_interval = 1.2,
 		max_drop_level=0,
 		groupcaps={
-			crumbly = {times={[1]=3.00, [2]=1.60, [3]=0.60}, uses=10, maxlevel=1},
+			crumbly = {times={[1]=3.00, [2]=1.60, [3]=0.60}, uses=t_uses.ten, maxlevel=1},
 		},
 		damage_groups = {fleshy=2},
 	},
@@ -134,7 +153,7 @@ minetest.register_tool("default:shovel_stone", {
 		full_punch_interval = 1.4,
 		max_drop_level=0,
 		groupcaps={
-			crumbly = {times={[1]=1.80, [2]=1.20, [3]=0.50}, uses=20, maxlevel=1},
+			crumbly = {times={[1]=1.80, [2]=1.20, [3]=0.50}, uses=t_uses.twenty, maxlevel=1},
 		},
 		damage_groups = {fleshy=2},
 	},
@@ -149,7 +168,7 @@ minetest.register_tool("default:shovel_steel", {
 		full_punch_interval = 1.1,
 		max_drop_level=1,
 		groupcaps={
-			crumbly = {times={[1]=1.50, [2]=0.90, [3]=0.40}, uses=30, maxlevel=2},
+			crumbly = {times={[1]=1.50, [2]=0.90, [3]=0.40}, uses=t_uses.thirty, maxlevel=2},
 		},
 		damage_groups = {fleshy=3},
 	},
@@ -164,7 +183,7 @@ minetest.register_tool("default:shovel_bronze", {
 		full_punch_interval = 1.1,
 		max_drop_level=1,
 		groupcaps={
-			crumbly = {times={[1]=1.50, [2]=0.90, [3]=0.40}, uses=40, maxlevel=2},
+			crumbly = {times={[1]=1.50, [2]=0.90, [3]=0.40}, uses=t_uses.forty, maxlevel=2},
 		},
 		damage_groups = {fleshy=3},
 	},
@@ -179,7 +198,7 @@ minetest.register_tool("default:shovel_mese", {
 		full_punch_interval = 1.0,
 		max_drop_level=3,
 		groupcaps={
-			crumbly = {times={[1]=1.20, [2]=0.60, [3]=0.30}, uses=20, maxlevel=3},
+			crumbly = {times={[1]=1.20, [2]=0.60, [3]=0.30}, uses=t_uses.twenty, maxlevel=3},
 		},
 		damage_groups = {fleshy=4},
 	},
@@ -194,7 +213,7 @@ minetest.register_tool("default:shovel_diamond", {
 		full_punch_interval = 1.0,
 		max_drop_level=1,
 		groupcaps={
-			crumbly = {times={[1]=1.10, [2]=0.50, [3]=0.30}, uses=30, maxlevel=3},
+			crumbly = {times={[1]=1.10, [2]=0.50, [3]=0.30}, uses=t_uses.thirty, maxlevel=3},
 		},
 		damage_groups = {fleshy=4},
 	},
@@ -212,7 +231,7 @@ minetest.register_tool("default:axe_wood", {
 		full_punch_interval = 1.0,
 		max_drop_level=0,
 		groupcaps={
-			choppy = {times={[2]=3.00, [3]=1.60}, uses=10, maxlevel=1},
+			choppy = {times={[2]=3.00, [3]=1.60}, uses=t_uses.ten, maxlevel=1},
 		},
 		damage_groups = {fleshy=2},
 	},
@@ -227,7 +246,7 @@ minetest.register_tool("default:axe_stone", {
 		full_punch_interval = 1.2,
 		max_drop_level=0,
 		groupcaps={
-			choppy={times={[1]=3.00, [2]=2.00, [3]=1.30}, uses=20, maxlevel=1},
+			choppy={times={[1]=3.00, [2]=2.00, [3]=1.30}, uses=t_uses.twenty, maxlevel=1},
 		},
 		damage_groups = {fleshy=3},
 	},
@@ -241,7 +260,7 @@ minetest.register_tool("default:axe_steel", {
 		full_punch_interval = 1.0,
 		max_drop_level=1,
 		groupcaps={
-			choppy={times={[1]=2.50, [2]=1.40, [3]=1.00}, uses=20, maxlevel=2},
+			choppy={times={[1]=2.50, [2]=1.40, [3]=1.00}, uses=t_uses.twenty, maxlevel=2},
 		},
 		damage_groups = {fleshy=4},
 	},
@@ -255,7 +274,7 @@ minetest.register_tool("default:axe_bronze", {
 		full_punch_interval = 1.0,
 		max_drop_level=1,
 		groupcaps={
-			choppy={times={[1]=2.50, [2]=1.40, [3]=1.00}, uses=30, maxlevel=2},
+			choppy={times={[1]=2.50, [2]=1.40, [3]=1.00}, uses=t_uses.thirty, maxlevel=2},
 		},
 		damage_groups = {fleshy=4},
 	},
@@ -269,7 +288,7 @@ minetest.register_tool("default:axe_mese", {
 		full_punch_interval = 0.9,
 		max_drop_level=1,
 		groupcaps={
-			choppy={times={[1]=2.20, [2]=1.00, [3]=0.60}, uses=20, maxlevel=3},
+			choppy={times={[1]=2.20, [2]=1.00, [3]=0.60}, uses=t_uses.twenty, maxlevel=3},
 		},
 		damage_groups = {fleshy=6},
 	},
@@ -283,7 +302,7 @@ minetest.register_tool("default:axe_diamond", {
 		full_punch_interval = 0.9,
 		max_drop_level=1,
 		groupcaps={
-			choppy={times={[1]=2.10, [2]=0.90, [3]=0.50}, uses=30, maxlevel=2},
+			choppy={times={[1]=2.10, [2]=0.90, [3]=0.50}, uses=t_uses.thirty, maxlevel=2},
 		},
 		damage_groups = {fleshy=7},
 	},
@@ -301,7 +320,7 @@ minetest.register_tool("default:sword_wood", {
 		full_punch_interval = 1,
 		max_drop_level=0,
 		groupcaps={
-			snappy={times={[2]=1.6, [3]=0.40}, uses=10, maxlevel=1},
+			snappy={times={[2]=1.6, [3]=0.40}, uses=t_uses.ten, maxlevel=1},
 		},
 		damage_groups = {fleshy=2},
 	},
@@ -316,7 +335,7 @@ minetest.register_tool("default:sword_stone", {
 		full_punch_interval = 1.2,
 		max_drop_level=0,
 		groupcaps={
-			snappy={times={[2]=1.4, [3]=0.40}, uses=20, maxlevel=1},
+			snappy={times={[2]=1.4, [3]=0.40}, uses=t_uses.twenty, maxlevel=1},
 		},
 		damage_groups = {fleshy=4},
 	},
@@ -330,7 +349,7 @@ minetest.register_tool("default:sword_steel", {
 		full_punch_interval = 0.8,
 		max_drop_level=1,
 		groupcaps={
-			snappy={times={[1]=2.5, [2]=1.20, [3]=0.35}, uses=30, maxlevel=2},
+			snappy={times={[1]=2.5, [2]=1.20, [3]=0.35}, uses=t_uses.thirty, maxlevel=2},
 		},
 		damage_groups = {fleshy=6},
 	},
@@ -344,7 +363,7 @@ minetest.register_tool("default:sword_bronze", {
 		full_punch_interval = 0.8,
 		max_drop_level=1,
 		groupcaps={
-			snappy={times={[1]=2.5, [2]=1.20, [3]=0.35}, uses=40, maxlevel=2},
+			snappy={times={[1]=2.5, [2]=1.20, [3]=0.35}, uses=t_uses.forty, maxlevel=2},
 		},
 		damage_groups = {fleshy=6},
 	},
@@ -358,7 +377,7 @@ minetest.register_tool("default:sword_mese", {
 		full_punch_interval = 0.7,
 		max_drop_level=1,
 		groupcaps={
-			snappy={times={[1]=2.0, [2]=1.00, [3]=0.35}, uses=30, maxlevel=3},
+			snappy={times={[1]=2.0, [2]=1.00, [3]=0.35}, uses=t_uses.thirty, maxlevel=3},
 		},
 		damage_groups = {fleshy=7},
 	},
@@ -372,7 +391,7 @@ minetest.register_tool("default:sword_diamond", {
 		full_punch_interval = 0.7,
 		max_drop_level=1,
 		groupcaps={
-			snappy={times={[1]=1.90, [2]=0.90, [3]=0.30}, uses=40, maxlevel=3},
+			snappy={times={[1]=1.90, [2]=0.90, [3]=0.30}, uses=t_uses.forty, maxlevel=3},
 		},
 		damage_groups = {fleshy=8},
 	},

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -46,3 +46,6 @@ share_bones_time (Bone share time) int 1200 0
 
 #    Replaces old stairs with new ones. Only required for older worlds.
 enable_stairs_replace_abm (Replace old stairs) bool false
+
+#    Tools & weapons will wear down & break when used for digging, chopping, etc.
+enable_tool_wear (Tools wear & break on use) bool true


### PR DESCRIPTION
- ***enable_tool_wear*** (Tools wear & break on use) bool *true*
  - Tools & weapons will wear down & break when used for digging,
chopping, etc.

**-- Edit --**

I'd like to be able to do this for tools/weapons when fighting as well. But, I'm not sure how because the *wear* system for fighting is different & based on how much damage is dealt I believe.