### PR TITLE
Make description capitalization consistent

### DIFF
--- a/mods/carts/rails.lua
+++ b/mods/carts/rails.lua
@@ -22,7 +22,7 @@ minetest.register_alias("default:rail", "carts:rail")
 
 
 carts:register_rail("carts:powerrail", {
-	description = "Powered rail",
+	description = "Powered Rail",
 	tiles = {
 		"carts_rail_straight_pwr.png", "carts_rail_curved_pwr.png",
 		"carts_rail_t_junction_pwr.png", "carts_rail_crossing_pwr.png"
@@ -41,7 +41,7 @@ minetest.register_craft({
 
 
 carts:register_rail("carts:brakerail", {
-	description = "Brake rail",
+	description = "Brake Rail",
 	tiles = {
 		"carts_rail_straight_brk.png", "carts_rail_curved_brk.png",
 		"carts_rail_t_junction_brk.png", "carts_rail_crossing_brk.png"

--- a/mods/dye/init.lua
+++ b/mods/dye/init.lua
@@ -28,21 +28,21 @@ dye.dyes = {
 -- This collection of colors is partly a historic thing, partly something else
 
 local dyes = {
-	{"white",      "White dye",      {dye=1, basecolor_white=1,   excolor_white=1,      unicolor_white=1}},
-	{"grey",       "Grey dye",       {dye=1, basecolor_grey=1,    excolor_grey=1,       unicolor_grey=1}},
-	{"dark_grey",  "Dark grey dye",  {dye=1, basecolor_grey=1,    excolor_darkgrey=1,   unicolor_darkgrey=1}},
-	{"black",      "Black dye",      {dye=1, basecolor_black=1,   excolor_black=1,      unicolor_black=1}},
-	{"violet",     "Violet dye",     {dye=1, basecolor_magenta=1, excolor_violet=1,     unicolor_violet=1}},
-	{"blue",       "Blue dye",       {dye=1, basecolor_blue=1,    excolor_blue=1,       unicolor_blue=1}},
-	{"cyan",       "Cyan dye",       {dye=1, basecolor_cyan=1,    excolor_cyan=1,       unicolor_cyan=1}},
-	{"dark_green", "Dark green dye", {dye=1, basecolor_green=1,   excolor_green=1,      unicolor_dark_green=1}},
-	{"green",      "Green dye",      {dye=1, basecolor_green=1,   excolor_green=1,      unicolor_green=1}},
-	{"yellow",     "Yellow dye",     {dye=1, basecolor_yellow=1,  excolor_yellow=1,     unicolor_yellow=1}},
-	{"brown",      "Brown dye",      {dye=1, basecolor_brown=1,   excolor_orange=1,     unicolor_dark_orange=1}},
-	{"orange",     "Orange dye",     {dye=1, basecolor_orange=1,  excolor_orange=1,     unicolor_orange=1}},
-	{"red",        "Red dye",        {dye=1, basecolor_red=1,     excolor_red=1,        unicolor_red=1}},
-	{"magenta",    "Magenta dye",    {dye=1, basecolor_magenta=1, excolor_red_violet=1, unicolor_red_violet=1}},
-	{"pink",       "Pink dye",       {dye=1, basecolor_red=1,     excolor_red=1,        unicolor_light_red=1}},
+	{"white",      "White Dye",      {dye=1, basecolor_white=1,   excolor_white=1,      unicolor_white=1}},
+	{"grey",       "Grey Dye",       {dye=1, basecolor_grey=1,    excolor_grey=1,       unicolor_grey=1}},
+	{"dark_grey",  "Dark Grey Dye",  {dye=1, basecolor_grey=1,    excolor_darkgrey=1,   unicolor_darkgrey=1}},
+	{"black",      "Black Dye",      {dye=1, basecolor_black=1,   excolor_black=1,      unicolor_black=1}},
+	{"violet",     "Violet Dye",     {dye=1, basecolor_magenta=1, excolor_violet=1,     unicolor_violet=1}},
+	{"blue",       "Blue Dye",       {dye=1, basecolor_blue=1,    excolor_blue=1,       unicolor_blue=1}},
+	{"cyan",       "Cyan Dye",       {dye=1, basecolor_cyan=1,    excolor_cyan=1,       unicolor_cyan=1}},
+	{"dark_green", "Dark Green Dye", {dye=1, basecolor_green=1,   excolor_green=1,      unicolor_dark_green=1}},
+	{"green",      "Green Dye",      {dye=1, basecolor_green=1,   excolor_green=1,      unicolor_green=1}},
+	{"yellow",     "Yellow Dye",     {dye=1, basecolor_yellow=1,  excolor_yellow=1,     unicolor_yellow=1}},
+	{"brown",      "Brown Dye",      {dye=1, basecolor_brown=1,   excolor_orange=1,     unicolor_dark_orange=1}},
+	{"orange",     "Orange Dye",     {dye=1, basecolor_orange=1,  excolor_orange=1,     unicolor_orange=1}},
+	{"red",        "Red Dye",        {dye=1, basecolor_red=1,     excolor_red=1,        unicolor_red=1}},
+	{"magenta",    "Magenta Dye",    {dye=1, basecolor_magenta=1, excolor_red_violet=1, unicolor_red_violet=1}},
+	{"pink",       "Pink Dye",       {dye=1, basecolor_red=1,     excolor_red=1,        unicolor_light_red=1}},
 }
 
 -- Define items

--- a/mods/farming/init.lua
+++ b/mods/farming/init.lua
@@ -9,7 +9,7 @@ dofile(farming.path .. "/hoes.lua")
 
 -- WHEAT
 farming.register_plant("farming:wheat", {
-	description = "Wheat seed",
+	description = "Wheat Seed",
 	paramtype2 = "meshoptions",
 	inventory_image = "farming_wheat_seed.png",
 	steps = 8,
@@ -47,7 +47,7 @@ minetest.register_craft({
 
 -- Cotton
 farming.register_plant("farming:cotton", {
-	description = "Cotton seed",
+	description = "Cotton Seed",
 	inventory_image = "farming_cotton_seed.png",
 	steps = 8,
 	minlight = 13,

--- a/mods/xpanes/init.lua
+++ b/mods/xpanes/init.lua
@@ -159,7 +159,7 @@ xpanes.register_pane("pane", {
 })
 
 xpanes.register_pane("bar", {
-	description = "Iron bar",
+	description = "Iron Bar",
 	textures = {"xpanes_bar.png","xpanes_bar.png","xpanes_bar_top.png"},
 	inventory_image = "xpanes_bar.png",
 	wield_image = "xpanes_bar.png",


### PR DESCRIPTION
This will make capitalisation of node/item descriptions consistent throughout MTG.