### PR TITLE
Book: Also limit the max size of the title.

### DIFF
--- a/mods/default/craftitems.lua
+++ b/mods/default/craftitems.lua
@@ -76,6 +76,8 @@ local function book_on_use(itemstack, user)
 end
 
 local max_text_size = 10000
+local max_title_size = 80
+local short_title_size = 35
 minetest.register_on_player_receive_fields(function(player, formname, fields)
 	if formname ~= "default:book" then return end
 	local inv = player:get_inventory()
@@ -101,9 +103,14 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		end
 
 		if not data then data = {} end
-		data.title = fields.title
+		data.title = fields.title:sub(1, max_title_size)
 		data.owner = player:get_player_name()
-		data.description = "\""..fields.title.."\" by "..data.owner
+		local short_title = data.title
+		-- Don't bother triming the title if the trailing dots would make it longer
+		if #short_title > short_title_size + 3 then
+			short_title = short_title:sub(1, short_title_size) .. "..."
+		end
+		data.description = "\""..short_title.."\" by "..data.owner
 		data.text = fields.text:sub(1, max_text_size)
 		data.page = 1
 		data.page_max = math.ceil((#data.text:gsub("[^\n]", "") + 1) / lpp)


### PR DESCRIPTION
This limits the max size of the full title of the book to `80` letters and the size of the part thats displayed in the tooltip to `35` letters.

I forgot that this could also be abused when making #1775, sorry about that.