### PR TITLE
Crafting: Remove duplicate reversed recipes

### DIFF
--- a/mods/default/crafting.lua
+++ b/mods/default/crafting.lua
@@ -190,6 +190,9 @@ minetest.register_craft({
 	}
 })
 
+-- Axes
+-- Recipes face left to match appearence in textures and inventory
+
 minetest.register_craft({
 	output = 'default:axe_wood',
 	recipe = {
@@ -241,60 +244,6 @@ minetest.register_craft({
 		{'default:diamond', 'default:diamond'},
 		{'default:diamond', 'group:stick'},
 		{'', 'group:stick'},
-	}
-})
-
-minetest.register_craft({
-	output = 'default:axe_wood',
-	recipe = {
-		{'group:wood', 'group:wood'},
-		{'group:stick', 'group:wood'},
-		{'group:stick',''},
-	}
-})
-
-minetest.register_craft({
-	output = 'default:axe_stone',
-	recipe = {
-		{'group:stone', 'group:stone'},
-		{'group:stick', 'group:stone'},
-		{'group:stick', ''},
-	}
-})
-
-minetest.register_craft({
-	output = 'default:axe_steel',
-	recipe = {
-		{'default:steel_ingot', 'default:steel_ingot'},
-		{'group:stick', 'default:steel_ingot'},
-		{'group:stick', ''},
-	}
-})
-
-minetest.register_craft({
-	output = 'default:axe_bronze',
-	recipe = {
-		{'default:bronze_ingot', 'default:bronze_ingot'},
-		{'group:stick', 'default:bronze_ingot'},
-		{'group:stick', ''},
-	}
-})
-
-minetest.register_craft({
-	output = 'default:axe_mese',
-	recipe = {
-		{'default:mese_crystal', 'default:mese_crystal'},
-		{'group:stick', 'default:mese_crystal'},
-		{'group:stick', ''},
-	}
-})
-
-minetest.register_craft({
-	output = 'default:axe_diamond',
-	recipe = {
-		{'default:diamond', 'default:diamond'},
-		{'group:stick', 'default:diamond'},
-		{'group:stick', ''},
 	}
 })
 

--- a/mods/farming/api.lua
+++ b/mods/farming/api.lua
@@ -118,15 +118,6 @@ farming.register_hoe = function(name, def)
 				{"", "group:stick", ""}
 			}
 		})
-		-- Reverse Recipe
-		minetest.register_craft({
-			output = name:sub(2),
-			recipe = {
-				{"", def.material, def.material},
-				{"", "group:stick", ""},
-				{"", "group:stick", ""}
-			}
-		})
 	end
 end
 


### PR DESCRIPTION
For axes and hoes only use one recipe that matches the appearence of the texture
and in inventory.
//////////////

To reduce recipe number, and to be consistent with stairs which previously were the only other duplicated recipes.