### PR TITLE
Chests: Check 'def' of node above chest to avoid crash

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1783,13 +1783,14 @@ local function get_chest_formspec(pos)
 end
 
 local function chest_lid_obstructed(pos)
-	local above = { x = pos.x, y = pos.y + 1, z = pos.z }
+	local above = {x = pos.x, y = pos.y + 1, z = pos.z}
 	local def = minetest.registered_nodes[minetest.get_node(above).name]
 	-- allow ladders, signs, wallmounted things and torches to not obstruct
-	if def.drawtype == "airlike" or
+	if def and
+			(def.drawtype == "airlike" or
 			def.drawtype == "signlike" or
 			def.drawtype == "torchlike" or
-			(def.drawtype == "nodebox" and def.paramtype2 == "wallmounted") then
+			(def.drawtype == "nodebox" and def.paramtype2 == "wallmounted")) then
 		return false
 	end
 	return true


### PR DESCRIPTION
Addresses a rare crash reported by Ihrfussel on IRC:
http://irc.minetest.net/minetest-hub/2017-06-15#i_4974670

"07:54 IhrFussel    The default mod crashed my server...the causing line was "if def.drawtype == "airlike" or" apparently def was nil (nodes.lua L1788) ... anyone a clue what could cause a node definition of a pointed pos to be nil?
08:52 shivajiva    wow, is it repeatable or just a random event?
09:27 IhrFussel    shivajiva, it happened once since June 4 so...pretty unlikely to happen again I guess
09:34 shivajiva    I can't find it in my logs so it's pretty rare
09:35 IhrFussel    Here is the exact error line ServerError: AsyncErr: ServerThread::run Lua: Runtime error from mod '' in callback item_OnPlace(): ...hare/minetest/games/minetest_game/mods/default/nodes.lua:1788: attempt to index local 'def' (a nil value)"

I guess caused by an unknown or unloaded node above a chest.