### PR TITLE
Add tin block slab and stair

### DIFF
--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -580,6 +580,16 @@ stairs.register_stair_and_slab(
 )
 
 stairs.register_stair_and_slab(
+	"tinblock",
+	"default:tinblock",
+	{cracky = 1, level = 2},
+	{"default_tin_block.png"},
+	"Tin Block Stair",
+	"Tin Block Slab",
+	default.node_sound_metal_defaults()
+)
+
+stairs.register_stair_and_slab(
 	"copperblock",
 	"default:copperblock",
 	{cracky = 1, level = 2},


### PR DESCRIPTION
Adds long awaited tin block's slab and stair into the game.
![default](https://user-images.githubusercontent.com/16494741/27977597-1a74cdb0-6374-11e7-886b-b5f6ede92283.png)