### PR TITLE
TNT explosion custom sound

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -295,6 +295,7 @@ TNT API
  * `description` A description for your TNT.
  * `radius` The radius within which the TNT can destroy nodes. The default is 3.
  * `damage_radius` The radius within which the TNT can damage players and mobs. By default it is twice the `radius`.
+ * `sound` The sound played when explosion occurs. By default it is `tnt_explode`.
  * `disable_drops` Disable drops. By default it is set to false.
  * `ignore_protection` Don't check `minetest.is_protected` before removing a node.
  * `ignore_on_blast` Don't call `on_blast` even if a node has one.

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -386,7 +386,7 @@ function tnt.boom(pos, def)
 	local owner = meta:get_string("owner")
 	local sound = def.sound or "tnt_explode"
 	minetest.sound_play(sound, {pos = pos, gain = 1.5,
-			max_hear_distance = math.min(def.radius * 20, 128})
+			max_hear_distance = math.min(def.radius * 20, 128)})
 	minetest.set_node(pos, {name = "tnt:boom"})
 	local drops, radius = tnt_explode(pos, def.radius, def.ignore_protection,
 			def.ignore_on_blast, owner)

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -384,7 +384,8 @@ end
 function tnt.boom(pos, def)
 	local meta = minetest.get_meta(pos)
 	local owner = meta:get_string("owner")
-	minetest.sound_play("tnt_explode", {pos = pos, gain = 1.5, max_hear_distance = 2*64})
+	local sound = def.sound or "tnt_explode"
+	minetest.sound_play(sound, {pos = pos, gain = 1.5, max_hear_distance = 2*64})
 	minetest.set_node(pos, {name = "tnt:boom"})
 	local drops, radius = tnt_explode(pos, def.radius, def.ignore_protection,
 			def.ignore_on_blast, owner)

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -385,7 +385,8 @@ function tnt.boom(pos, def)
 	local meta = minetest.get_meta(pos)
 	local owner = meta:get_string("owner")
 	local sound = def.sound or "tnt_explode"
-	minetest.sound_play(sound, {pos = pos, gain = 1.5, max_hear_distance = 2*64})
+	minetest.sound_play(sound, {pos = pos, gain = 1.5,
+			max_hear_distance = math.min(def.radius * 20, 128})
 	minetest.set_node(pos, {name = "tnt:boom"})
 	local drops, radius = tnt_explode(pos, def.radius, def.ignore_protection,
 			def.ignore_on_blast, owner)


### PR DESCRIPTION
This adds the ability to customise explosion sound when using tnt.boom() which can be used when creating custom tnt or when using other mods directly, it also fixes the 128 node max_hear_distance always being used by calculating the sound distance using the explosion radius.