### PR TITLE
Enforce valid face_dir values with regards to beds

### DIFF
--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -7,43 +7,22 @@ if enable_respawn == nil then
 end
 
 -- Helper functions
-local facedir_types = {
-	colorwallmounted = 8, -- 3 bits are used for facedir
-	colorfacedir = 32     -- 5 bits are used for facedir
-}
-
 local function get_look_yaw(pos)
 	local n = minetest.get_node(pos)
-	local face_dir = n.param2
-	if face_dir > 3 then
-		minetest.log("warning", "bed: unexpected facedir value, compensating...")
-		minetest.log("info", "bed: offending node name is "..n.name)
-		local metadata = minetest.registered_nodes[n.name]
-		if metadata ~= nil and metadata.paramtype2 ~= nil then
-			local divisor = 32 -- default to facedir values (e.g 0-24, 5 bits)
-			local value_type = metadata.paramtype2
-			local known_type = facedir_types[value_type]
-			if known_type ~= nil then
-				minetest.log("info", "bed: applying paramtype2 rules for: "..value_type)
-				divisor = known_type
-			else
-				minetest.log("info", "bed: applying default rules for: "..value_type)
-				minetest.log("info", "bed: game may still crash if given invaild value")
-			end
-			face_dir = n.param2 % divisor
-			minetest.log("info", "bed: facedir changed "..n.param2.." --> "..face_dir)
-		else
-			minetest.log("warning", "bed: no metadata available (game might crash)")
-		end
+	local rotation = n.param2
+	if rotation > 3 then
+		rotation = rotation % 4 -- mask colorfacedir values
+		minetest.log("info", "bed: rotation changed from " .. n.param2 ..
+			" to " .. rotation)
 	end
-	if face_dir == 1 then
-		return pi / 2, face_dir
-	elseif face_dir == 3 then
-		return -pi / 2, face_dir
-	elseif face_dir == 0 then
-		return pi, face_dir
+	if rotation == 1 then
+		return pi / 2, rotation
+	elseif rotation == 3 then
+		return -pi / 2, rotation
+	elseif rotation == 0 then
+		return pi, rotation
 	else
-		return 0, face_dir
+		return 0, rotation
 	end
 end
 

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -7,13 +7,14 @@ if enable_respawn == nil then
 end
 
 -- Helper functions
-local function get_look_yaw(pos)
+local function get_look_yaw(pos, override_rotation)
 	local n = minetest.get_node(pos)
-	local rotation = n.param2
+	local rotation_param = override_rotation or n.param2
+	local rotation = rotation_param
 	if rotation > 3 then
 		rotation = rotation % 4 -- mask colorfacedir values
-		minetest.log("info", "bed: rotation changed from " .. n.param2 ..
-			" to " .. rotation)
+		minetest.log("info", "bed: rotation changed from " ..
+			rotation_param .. " to " .. rotation)
 	end
 	if rotation == 1 then
 		return pi / 2, rotation
@@ -50,7 +51,7 @@ local function check_in_beds(players)
 	return #players > 0
 end
 
-local function lay_down(player, pos, bed_pos, state, skip)
+local function lay_down(player, pos, bed_pos, state, skip, override_rotation)
 	local name = player:get_player_name()
 	local hud_flags = player:hud_get_flags()
 
@@ -89,7 +90,7 @@ local function lay_down(player, pos, bed_pos, state, skip)
 
 		-- physics, eye_offset, etc
 		player:set_eye_offset({x = 0, y = -13, z = 0}, {x = 0, y = 0, z = 0})
-		local yaw, param2 = get_look_yaw(bed_pos)
+		local yaw, param2 = get_look_yaw(bed_pos, override_rotation)
 		player:set_look_horizontal(yaw)
 		local dir = minetest.facedir_to_dir(param2)
 		local p = {x = bed_pos.x + dir.x / 2, y = bed_pos.y, z = bed_pos.z + dir.z / 2}
@@ -137,14 +138,14 @@ function beds.skip_night()
 	minetest.set_timeofday(0.23)
 end
 
-function beds.on_rightclick(pos, player)
+function beds.on_rightclick(pos, player, override_rotation)
 	local name = player:get_player_name()
 	local ppos = player:getpos()
 	local tod = minetest.get_timeofday()
 
 	if tod > 0.2 and tod < 0.805 then
 		if beds.player[name] then
-			lay_down(player, nil, nil, false)
+			lay_down(player, nil, nil, false, nil, override_rotation)
 		end
 		minetest.chat_send_player(name, "You can only sleep at night.")
 		return
@@ -152,10 +153,10 @@ function beds.on_rightclick(pos, player)
 
 	-- move to bed
 	if not beds.player[name] then
-		lay_down(player, ppos, pos)
+		lay_down(player, ppos, pos, nil, nil, override_rotation)
 		beds.set_spawns() -- save respawn positions when entering bed
 	else
-		lay_down(player, nil, nil, false)
+		lay_down(player, nil, nil, false, nil, override_rotation)
 	end
 
 	if not is_sp then

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -9,12 +9,9 @@ end
 -- Helper functions
 local function get_look_yaw(pos, override_rotation)
 	local n = minetest.get_node(pos)
-	local rotation_param = override_rotation or n.param2
-	local rotation = rotation_param
+	local rotation = override_rotation or n.param2
 	if rotation > 3 then
 		rotation = rotation % 4 -- mask colorfacedir values
-		minetest.log("info", "bed: rotation changed from " ..
-			rotation_param .. " to " .. rotation)
 	end
 	if rotation == 1 then
 		return pi / 2, rotation

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -15,8 +15,9 @@ local facedir_types = {
 local function get_look_yaw(pos)
 	local n = minetest.get_node(pos)
 	local face_dir = n.param2
-	if face_dir < 0 or face_dir > 24 then
-		minetest.log("warning", "bed: facedir value invalid, compensating...")
+	if face_dir > 3 then
+		minetest.log("warning", "bed: unexpected facedir value, compensating...")
+		minetest.log("info", "bed: offending node name is "..n.name)
 		local metadata = minetest.registered_nodes[n.name]
 		if metadata ~= nil and metadata.paramtype2 ~= nil then
 			local divisor = 32 -- default to facedir values (e.g 0-24, 5 bits)

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -19,7 +19,7 @@ local function get_look_yaw(pos)
 		minetest.log("warning", "bed: facedir value invalid, compensating...")
 		local metadata = minetest.registered_nodes[n.name]
 		if metadata ~= nil and metadata.paramtype2 ~= nil then
-			local divisor = 32 -- default to facedir values (e.g 0-21, 5 bits)
+			local divisor = 32 -- default to facedir values (e.g 0-24, 5 bits)
 			local value_type = metadata.paramtype2
 			local known_type = facedir_types[value_type]
 			if known_type ~= nil then

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -10,14 +10,21 @@ end
 
 local function get_look_yaw(pos)
 	local n = minetest.get_node(pos)
-	if n.param2 == 1 then
-		return pi / 2, n.param2
-	elseif n.param2 == 3 then
-		return -pi / 2, n.param2
-	elseif n.param2 == 0 then
-		return pi, n.param2
+	local face_dir = n.param2
+	if face_dir > 3 then
+		-- Enforce valid param2 facedir values (see minetest/minetest_game#1784)
+		minetest.log("warning", "face_dir value exceeds the maximum!")
+		face_dir = (1 * (n.param2 % 2)) + (2 * (math.floor(n.param2 / 2) % 2))
+		minetest.log("warning", "face_dir from:" .. n.param2 .. " to:" .. face_dir)
+	end
+	if face_dir == 1 then
+		return pi / 2, face_dir
+	elseif face_dir == 3 then
+		return -pi / 2, face_dir
+	elseif face_dir == 0 then
+		return pi, face_dir
 	else
-		return 0, n.param2
+		return 0, face_dir
 	end
 end
 


### PR DESCRIPTION
This commit allows players to sleep in homedecor_modpack bed's again (after reverting commit [9693d9d](https://github.com/minetest-mods/homedecor_modpack/commit/9693d9dd464e2252bf07e6abb120053757d9dab1) first). It's been tested, without any problems, against the minetest_game 0.4.16 release.

The reason minetest_game was patched (instead of homedecor) is to prevent some graphical glitches (e.g. brief toggling of bed color to white from any color).

---

face_dir values tend to be solely 0-3, however, some mods may use bits from
this value for other functionality. This commit strips out any invalid bits
with a bit of clever math; and presents a warning to the console when doing so.

Related issues: minetest-mods/homedecor_modpack#367
                minetest/minetest_game#1784