### PR TITLE
Correct farming/stairs dependency

### DIFF
--- a/mods/farming/depends.txt
+++ b/mods/farming/depends.txt
@@ -1,2 +1,3 @@
 default
 wool
+stairs

--- a/mods/farming/nodes.lua
+++ b/mods/farming/nodes.lua
@@ -98,6 +98,16 @@ minetest.register_node("farming:straw", {
 	sounds = default.node_sound_leaves_defaults(),
 })
 
+stairs.register_stair_and_slab(
+	"straw",
+	"farming:straw",
+	{snappy = 3, flammable = 4},
+	{"farming_straw.png"},
+	"Straw Stair",
+	"Straw Slab",
+	default.node_sound_leaves_defaults()
+)
+
 minetest.register_abm({
 	label = "Farming soil",
 	nodenames = {"group:field"},

--- a/mods/stairs/depends.txt
+++ b/mods/stairs/depends.txt
@@ -1,2 +1,1 @@
 default
-farming

--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -713,16 +713,6 @@ stairs.register_stair_and_slab(
 )
 
 stairs.register_stair_and_slab(
-	"straw",
-	"farming:straw",
-	{snappy = 3, flammable = 4},
-	{"farming_straw.png"},
-	"Straw Stair",
-	"Straw Slab",
-	default.node_sound_leaves_defaults()
-)
-
-stairs.register_stair_and_slab(
 	"steelblock",
 	"default:steelblock",
 	{cracky = 1, level = 2},


### PR DESCRIPTION
Stairs is a far more fundamental and basic mod than farming, so should not depend on farming. 

This PR causes farming to register its own stairs, making it possible to use stairs without farming.