### PR TITLE
rename junglewood to rosewood

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -681,7 +681,7 @@ minetest.register_node("default:apple", {
 
 
 minetest.register_node("default:jungletree", {
-	description = "Jungle Tree",
+	description = "Rosewood Tree",
 	tiles = {"default_jungletree_top.png", "default_jungletree_top.png",
 		"default_jungletree.png"},
 	paramtype2 = "facedir",
@@ -693,7 +693,7 @@ minetest.register_node("default:jungletree", {
 })
 
 minetest.register_node("default:junglewood", {
-	description = "Jungle Wood Planks",
+	description = "Rosewood Planks",
 	paramtype2 = "facedir",
 	place_param2 = 0,
 	tiles = {"default_junglewood.png"},
@@ -703,7 +703,7 @@ minetest.register_node("default:junglewood", {
 })
 
 minetest.register_node("default:jungleleaves", {
-	description = "Jungle Tree Leaves",
+	description = "Rosewood Leaves",
 	drawtype = "allfaces_optional",
 	waving = 1,
 	tiles = {"default_jungleleaves.png"},
@@ -724,7 +724,7 @@ minetest.register_node("default:jungleleaves", {
 })
 
 minetest.register_node("default:junglesapling", {
-	description = "Jungle Tree Sapling",
+	description = "Rosewood Sapling",
 	drawtype = "plantlike",
 	tiles = {"default_junglesapling.png"},
 	inventory_image = "default_junglesapling.png",
@@ -2272,7 +2272,7 @@ default.register_fence("default:fence_acacia_wood", {
 })
 
 default.register_fence("default:fence_junglewood", {
-	description = "Jungle Wood Fence",
+	description = "Rosewood Fence",
 	texture = "default_fence_junglewood.png",
 	inventory_image = "default_fence_overlay.png^default_junglewood.png^default_fence_overlay.png^[makealpha:255,126,126",
 	wield_image = "default_fence_overlay.png^default_junglewood.png^default_fence_overlay.png^[makealpha:255,126,126",


### PR DESCRIPTION
The descriptions of jungle tree and co. are changed to rosewood.
Related: #1817 