### PR TITLE
Make underwater torches drop

### DIFF
--- a/mods/default/torch.lua
+++ b/mods/default/torch.lua
@@ -35,6 +35,12 @@ See LICENSE.txt and http://www.gnu.org/licenses/lgpl-2.1.txt
 
 --]]
 
+local on_flood = function(pos, oldnode, newnode)
+	local obj = minetest.add_item(pos, ItemStack("default:torch 1"))
+	minetest.sound_play("fire_extinguish_flame", {pos = pos, max_hear_distance = 8, gain = 0.07})
+	return false -- To allow the water to take out the torch
+end
+
 minetest.register_node("default:torch", {
 	description = "Torch",
 	drawtype = "mesh",
@@ -83,7 +89,9 @@ minetest.register_node("default:torch", {
 		itemstack:set_name("default:torch")
 
 		return itemstack
-	end
+	end,
+	floodable = true,
+	on_flood = on_flood,
 })
 
 minetest.register_node("default:torch_wall", {
@@ -105,6 +113,8 @@ minetest.register_node("default:torch_wall", {
 		wall_side = {-1/2, -1/2, -1/8, -1/8, 1/8, 1/8},
 	},
 	sounds = default.node_sound_wood_defaults(),
+	floodable = true,
+	on_flood = on_flood,
 })
 
 minetest.register_node("default:torch_ceiling", {
@@ -126,6 +136,8 @@ minetest.register_node("default:torch_ceiling", {
 		wall_top = {-1/8, -1/16, -5/16, 1/8, 1/2, 1/8},
 	},
 	sounds = default.node_sound_wood_defaults(),
+	floodable = true,
+	on_flood = on_flood,
 })
 
 minetest.register_lbm({

--- a/mods/default/torch.lua
+++ b/mods/default/torch.lua
@@ -38,12 +38,20 @@ See LICENSE.txt and http://www.gnu.org/licenses/lgpl-2.1.txt
 local function on_flood(pos, oldnode, newnode)
 	local nodedef = minetest.registered_items[newnode.name]
 	-- Drop the torch if the liquid does not burn.
-	if nodedef ~= nil and not (
+	if nodedef == nil or not (
 			nodedef.groups ~= nil and
 			nodedef.groups.igniter ~= nil and
 			nodedef.groups.igniter > 0) then
 		minetest.add_item(pos, ItemStack("default:torch 1"))
-		minetest.sound_play("fire_extinguish_flame", {pos = pos, max_hear_distance = 8, gain = 0.07})
+		minetest.sound_play(
+			"fire_extinguish_flame",
+			{pos = pos, max_hear_distance = 16, gain = 0.1}
+		)
+	else -- we're burning the torch.
+		minetest.sound_play(
+			"fire_fire",
+			{pos = pos, max_hear_distance = 16, gain = 0.05}
+		)
 	end
 	return false -- To allow the liquid to take out the torch
 end

--- a/mods/default/torch.lua
+++ b/mods/default/torch.lua
@@ -36,19 +36,23 @@ See LICENSE.txt and http://www.gnu.org/licenses/lgpl-2.1.txt
 --]]
 
 local function on_flood(pos, oldnode, newnode)
+	-- Instantiate item drop.
+	minetest.add_item(pos, ItemStack("default:torch 1"))
+	
+	-- Play sound if torch is not flooded by igniter type liquid.
 	local nodedef = minetest.registered_items[newnode.name]
-	-- Drop the torch if the liquid does not burn.
 	if nodedef == nil or not (
 			nodedef.groups ~= nil and
 			nodedef.groups.igniter ~= nil and
 			nodedef.groups.igniter > 0) then
-		minetest.add_item(pos, ItemStack("default:torch 1"))
 		minetest.sound_play(
 			"default_cool_lava",
 			{pos = pos, max_hear_distance = 16, gain = 0.10}
 		)
 	end
-	return false -- To allow the liquid to take out the torch
+	
+	-- Allow the liquid to remove the torch node.
+	return false 
 end
 
 minetest.register_node("default:torch", {

--- a/mods/default/torch.lua
+++ b/mods/default/torch.lua
@@ -35,10 +35,17 @@ See LICENSE.txt and http://www.gnu.org/licenses/lgpl-2.1.txt
 
 --]]
 
-local on_flood = function(pos, oldnode, newnode)
-	local obj = minetest.add_item(pos, ItemStack("default:torch 1"))
-	minetest.sound_play("fire_extinguish_flame", {pos = pos, max_hear_distance = 8, gain = 0.07})
-	return false -- To allow the water to take out the torch
+local function on_flood(pos, oldnode, newnode)
+	local nodedef = minetest.registered_items[newnode.name]
+	-- Drop the torch if the liquid does not burn.
+	if nodedef ~= nil and not (
+			nodedef.groups ~= nil and
+			nodedef.groups.igniter ~= nil and
+			nodedef.groups.igniter > 0) then
+		minetest.add_item(pos, ItemStack("default:torch 1"))
+		minetest.sound_play("fire_extinguish_flame", {pos = pos, max_hear_distance = 8, gain = 0.07})
+	end
+	return false -- To allow the liquid to take out the torch
 end
 
 minetest.register_node("default:torch", {

--- a/mods/default/torch.lua
+++ b/mods/default/torch.lua
@@ -44,13 +44,8 @@ local function on_flood(pos, oldnode, newnode)
 			nodedef.groups.igniter > 0) then
 		minetest.add_item(pos, ItemStack("default:torch 1"))
 		minetest.sound_play(
-			"fire_extinguish_flame",
-			{pos = pos, max_hear_distance = 16, gain = 0.1}
-		)
-	else -- we're burning the torch.
-		minetest.sound_play(
-			"fire_fire",
-			{pos = pos, max_hear_distance = 16, gain = 0.05}
+			"default_cool_lava",
+			{pos = pos, max_hear_distance = 16, gain = 0.10}
 		)
 	end
 	return false -- To allow the liquid to take out the torch

--- a/mods/default/torch.lua
+++ b/mods/default/torch.lua
@@ -38,7 +38,7 @@ See LICENSE.txt and http://www.gnu.org/licenses/lgpl-2.1.txt
 local function on_flood(pos, oldnode, newnode)
 	-- Instantiate item drop.
 	minetest.add_item(pos, ItemStack("default:torch 1"))
-	
+
 	-- Play sound if torch is not flooded by igniter type liquid.
 	local nodedef = minetest.registered_items[newnode.name]
 	if nodedef == nil or not (
@@ -50,9 +50,9 @@ local function on_flood(pos, oldnode, newnode)
 			{pos = pos, max_hear_distance = 16, gain = 0.10}
 		)
 	end
-	
+
 	-- Allow the liquid to remove the torch node.
-	return false 
+	return false
 end
 
 minetest.register_node("default:torch", {


### PR DESCRIPTION
Implements the suggestion #1830.

Torches drop when water floods over them.

I'm not sure how loud the sound should be, but I am certain it's quieter than a fire's equivalent.