### PR TITLE
Increase the maximum level of the diamond axe to 3

### DIFF
--- a/mods/default/tools.lua
+++ b/mods/default/tools.lua
@@ -283,7 +283,7 @@ minetest.register_tool("default:axe_diamond", {
 		full_punch_interval = 0.9,
 		max_drop_level=1,
 		groupcaps={
-			choppy={times={[1]=2.10, [2]=0.90, [3]=0.50}, uses=30, maxlevel=2},
+			choppy={times={[1]=2.10, [2]=0.90, [3]=0.50}, uses=30, maxlevel=3},
 		},
 		damage_groups = {fleshy=7},
 	},


### PR DESCRIPTION
Current dig params for `default:axe_mese` with `default:pine_tree` and `default:aspen_tree`:

```
{
	time = 0.20000000298023,
	diggable = true,
	wear = 121
}
```

Current dig params for `default:axe_mese` with `default:tree`, `default:jungletree`, and `default:acacia_tree`:

```
{
	time = 0.33333334326744,
	diggable = true,
	wear = 121
}
```

Current dig params for `default:axe_diamond` with `default:pine_tree` and `default:aspen_tree`:

```
{
	time = 0.25,
	diggable = true,
	wear = 242
}
```

Current dig params for `default:axe_diamond` with `default:tree`, `default:jungletree`, and `default:acacia_tree`:

```
{
	time = 0.44999998807907,
	diggable = true,
	wear = 242
}
```

Changing the maximum level of the diamond axe to 3 keeps the wear consistent with other diamond tools. With `maxlevel=3`, the dig time for apple trees, jungle trees and acacia trees becomes 0.29999998211861 with the diamond axe (this is similar to the dig time for iron ore with the diamond pickaxe) and the wear becomes 80. For pine trees and aspen trees, the dig time becomes 0.16666667163372 (similar to the dig time for coal with the diamond pickaxe) and the wear becomes 80.