### PR TITLE
TNT: Only burn visually connected powder

### DIFF
--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -513,15 +513,15 @@ minetest.register_node("tnt:gunpowder_burning", {
 	on_timer = function(pos, elapsed)
 		for dx = -1, 1 do
 		for dz = -1, 1 do
-		for dy = -1, 1 do
-			if not (dx == 0 and dz == 0) then
-				tnt.burn({
-					x = pos.x + dx,
-					y = pos.y + dy,
-					z = pos.z + dz,
-				})
+			if math.abs(dx) + math.abs(dz) == 1 then
+				for dy = -1, 1 do
+					tnt.burn({
+						x = pos.x + dx,
+						y = pos.y + dy,
+						z = pos.z + dz,
+					})
+				end
 			end
-		end
 		end
 		end
 		minetest.remove_node(pos)


### PR DESCRIPTION
See problem here: https://github.com/minetest/minetest_game/issues/1754#issuecomment-318170202

Only burns gunpowder that's visually connected.