### PR TITLE
TNT's tnt:boom cleanup

### DIFF
--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -405,12 +405,6 @@ minetest.register_node("tnt:boom", {
 	walkable = false,
 	drop = "",
 	groups = {dig_immediate = 3},
-	on_construct = function(pos)
-		minetest.get_node_timer(pos):start(0.4)
-	end,
-	on_timer = function(pos, elapsed)
-		minetest.remove_node(pos)
-	end,
 	-- unaffected by explosions
 	on_blast = function() end,
 })


### PR DESCRIPTION
The tnt:boom node doesn't actually need the on_construct and on_timer functions to remove the node after 0.4 seconds as the tnt_explode function already does this beforehand, so this pull should help reduce tnt lag.