### PR TITLE
default.register_fence: Allow setting nodedefs to 'false'

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -297,7 +297,7 @@ function default.register_fence(name, def)
 		groups = {},
 	}
 	for k, v in pairs(default_fields) do
-		if not def[k] then
+		if def[k] == nil then
 			def[k] = v
 		end
 	end


### PR DESCRIPTION
Instead of using not to find out whether a field is set, the value is compared with nil.
If some field is set to false, it's currently treated as not existent, so when registering fences you e.g. can't properly set sunlight_propagates to false.