### PR TITLE
TNT: add tnt.boom defaults

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -358,7 +358,7 @@ TNT API
   * `bottom` Bottom tile. By default the name of the tnt with a suffix of `_bottom.png`.
   * `burning` Top tile when lit. By default the name of the tnt with a suffix of `_top_burning_animated.png".
 
-`tnt.boom(position, definition)`
+`tnt.boom(position[, definition])`
 
 ^ Create an explosion.
 

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -387,6 +387,9 @@ local function tnt_explode(pos, radius, ignore_protection, ignore_on_blast, owne
 end
 
 function tnt.boom(pos, def)
+	def = def or {}
+	def.radius = def.radius or 1
+	def.damage_radius = def.damage_radius or def.radius * 2
 	local meta = minetest.get_meta(pos)
 	local owner = meta:get_string("owner")
 	if not def.explode_center then


### PR DESCRIPTION
This adds def , def.radius and def.damage_radius defaults to the tnt.boom() function if they aren't specified on call.

Fixes: https://github.com/minetest/minetest_game/issues/1901