### PR TITLE
Beds: Strip colour bits from param2 in 'get look yaw'

### DIFF
--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -9,15 +9,18 @@ end
 -- Helper functions
 
 local function get_look_yaw(pos)
-	local n = minetest.get_node(pos)
-	if n.param2 == 1 then
-		return pi / 2, n.param2
-	elseif n.param2 == 3 then
-		return -pi / 2, n.param2
-	elseif n.param2 == 0 then
-		return pi, n.param2
+	local rotation = minetest.get_node(pos).param2
+	if rotation > 3 then
+		rotation = rotation % 4 -- Mask colorfacedir values
+	end
+	if rotation == 1 then
+		return pi / 2, rotation
+	elseif rotation == 3 then
+		return -pi / 2, rotation
+	elseif rotation == 0 then
+		return pi, rotation
 	else
-		return 0, n.param2
+		return 0, rotation
 	end
 end
 


### PR DESCRIPTION
Based on code by github user 'hdak1945git'.
Fixes a crash when 'colorfacedir' param2 is used for beds.
/////////////

Partially replaces #1826 
Gets the necessary bugfix done while we discuss other stuff.