### PR TITLE
Do not give creative priv to admin.

### DIFF
--- a/mods/creative/init.lua
+++ b/mods/creative/init.lua
@@ -2,7 +2,8 @@ creative = {}
 
 minetest.register_privilege("creative", {
 	description = "Allow player to use creative inventory",
-	give_to_singleplayer = false
+	give_to_singleplayer = false,
+	give_to_admin = false
 })
 
 local creative_mode_cache = minetest.settings:get_bool("creative_mode")


### PR DESCRIPTION
Related to minetest [#6460](https://github.com/minetest/minetest/pull/6460)

Admin does not get creative priv by default (which changes gameplay in annoying ways), but can still grant it to self.