### PR TITLE
Map mod: Remove confusing 'use', reduce update interval

### DIFF
--- a/mods/map/README.txt
+++ b/mods/map/README.txt
@@ -32,13 +32,12 @@ WPD
 Usage
 -----
 In survival mode, use of the minimap requires the mapping kit item in your
-inventory.
-Once crafted, to instantly enable, 'use' (left click) the item, otherwise the
-minimap will be automatically enabled a few seconds later.
-Minimap radar mode is always disabled in survival mode.
+inventory. It can take up to 3 seconds for adding to or removal from inventory
+to have an effect.
+Minimap radar mode is always disallowed in survival mode.
 
-Minimap and minimap radar mode will be automatically enabled in creative mode
-and for any player with the 'creative' privilege.
+Minimap and minimap radar mode are automatically allowed in creative mode and
+for any player with the 'creative' privilege.
 
 The 'map.update_hud_flags()' function is global so can be redefined by a mod for
 alternative behaviour.

--- a/mods/map/init.lua
+++ b/mods/map/init.lua
@@ -40,10 +40,10 @@ local function cyclic_update()
 	for _, player in ipairs(minetest.get_connected_players()) do
 		map.update_hud_flags(player)
 	end
-	minetest.after(7, cyclic_update)
+	minetest.after(3.1, cyclic_update)
 end
 
-minetest.after(7, cyclic_update)
+minetest.after(3.1, cyclic_update)
 
 
 -- Mapping kit item
@@ -53,10 +53,6 @@ minetest.register_craftitem("map:mapping_kit", {
 	inventory_image = "map_mapping_kit.png",
 	stack_max = 1,
 	groups = {flammable = 3},
-	-- For instant update of HUD flags
-	on_use = function(itemstack, user, pointed_thing)
-		map.update_hud_flags(user)
-	end,
 })
 
 


### PR DESCRIPTION
 Map mod: Remove confusing 'use', reduce update interval
Clarify README.txt.
//////////////

Improvements as discussed on IRC.
3.1 is a prime of 0.1, i will use 2.9 for binocular mod.
We intend to add inventory callbacks later so that adding and removal have instant effect, for now i have reduced the update interval.