### PR TITLE
Creative: Cache inventory items on load

### DIFF
--- a/mods/creative/inventory.lua
+++ b/mods/creative/inventory.lua
@@ -1,4 +1,19 @@
 local player_inventory = {}
+local inventory_cache = {}
+
+local function init_creative_cache(items)
+	inventory_cache[items] = {}
+	local i_cache = inventory_cache[items]
+
+	for name, def in pairs(items) do
+		if def.groups.not_in_creative_inventory ~= 1 and
+				def.description and def.description ~= "" then
+			i_cache[name] = def
+		end
+	end
+	table.sort(i_cache)
+	return i_cache
+end
 
 function creative.init_creative_inventory(player)
 	local player_name = player:get_player_name()
@@ -45,11 +60,11 @@ function creative.update_creative_inventory(player_name, tab_content)
 			creative.init_creative_inventory(minetest.get_player_by_name(player_name))
 	local player_inv = minetest.get_inventory({type = "detached", name = "creative_" .. player_name})
 
-	for name, def in pairs(tab_content) do
-		if not (def.groups.not_in_creative_inventory == 1) and
-				def.description and def.description ~= "" and
-				(def.name:find(inv.filter, 1, true) or
-					def.description:lower():find(inv.filter, 1, true)) then
+	local items = inventory_cache[tab_content] or init_creative_cache(tab_content)
+
+	for name, def in pairs(items) do
+		if def.name:find(inv.filter, 1, true) or
+				def.description:lower():find(inv.filter, 1, true) then
 			creative_list[#creative_list+1] = name
 		end
 	end
@@ -161,9 +176,9 @@ function creative.register_tab(name, title, items)
 	})
 end
 
-minetest.register_on_joinplayer(function(player)
-	creative.update_creative_inventory(player:get_player_name(), minetest.registered_items)
-end)
+--minetest.register_on_joinplayer(function(player)
+--	creative.update_creative_inventory(player:get_player_name(), minetest.registered_items)
+--end)
 
 creative.register_tab("all", "All", minetest.registered_items)
 creative.register_tab("nodes", "Nodes", minetest.registered_nodes)

--- a/mods/creative/inventory.lua
+++ b/mods/creative/inventory.lua
@@ -176,10 +176,6 @@ function creative.register_tab(name, title, items)
 	})
 end
 
---minetest.register_on_joinplayer(function(player)
---	creative.update_creative_inventory(player:get_player_name(), minetest.registered_items)
---end)
-
 creative.register_tab("all", "All", minetest.registered_items)
 creative.register_tab("nodes", "Nodes", minetest.registered_nodes)
 creative.register_tab("tools", "Tools", minetest.registered_tools)


### PR DESCRIPTION
Takes some load from the servers by pre-filtering the lists and caching the sorted output. This gets helpful with 10'000 items where the most of them aren't listed anyway (due circular saw, CNC, tool enchanting).
Loading durations of up to 30 ms [were reported](http://irc.minetest.net/minetest-hub/2017-10-09#i_5104404). This `on_joinplayer` callback can be removed as the crafting table is always the first selected one.

Opinions?