### PR TITLE
Sfinv: Add 'position[]' parameter to theming

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -476,9 +476,10 @@ Sfinv API
 
 **Theming**
 
-* sfinv.make_formspec(player, context, content, show_inv, size) - adds a theme to a formspec
+* sfinv.make_formspec(player, context, content, show_inv, size, position) - adds a theme to a formspec
     * show_inv, defaults to false. Whether to show the player's main inventory
     * size, defaults to `size[8,8.6]` if not specified
+    * position, defaults to `position[0.5,0.5]` (screen centre) if not specified
 * sfinv.get_nav_fs(player, context, nav, current_idx) - creates tabheader or ""
 
 ### sfinv Members

--- a/mods/sfinv/api.lua
+++ b/mods/sfinv/api.lua
@@ -44,9 +44,10 @@ local theme_inv = default.gui_slots .. [[
 		list[current_player;main;0,5.85;8,3;8]
 	]]
 
-function sfinv.make_formspec(player, context, content, show_inv, size)
+function sfinv.make_formspec(player, context, content, show_inv, size, position)
 	local tmp = {
 		size or "size[8,8.6]",
+		position or "position[0.5,0.5]",
 		theme_main,
 		sfinv.get_nav_fs(player, context, context.nav_titles, context.nav_idx),
 		content


### PR DESCRIPTION
![screenshot from 2017-10-17 06-39-17](https://user-images.githubusercontent.com/3686677/31648498-f6904bc2-b305-11e7-8f50-3a203c8315da.png)

Allows a sfinv formspec to be positioned. Useful for skin mods to allow seeing the player using F7 while selecting skins.
@rubenwardy 