### PR TITLE
Binoculars / Map mods: Clarify key-activation of items in descriptions

### DIFF
--- a/mods/binoculars/init.lua
+++ b/mods/binoculars/init.lua
@@ -47,7 +47,7 @@ minetest.after(4.7, cyclic_update)
 -- Binoculars item
 
 minetest.register_craftitem("binoculars:binoculars", {
-	description = "Binoculars",
+	description = "Binoculars\nUse with 'Zoom' key",
 	inventory_image = "binoculars_binoculars.png",
 	stack_max = 1,
 

--- a/mods/map/README.txt
+++ b/mods/map/README.txt
@@ -32,8 +32,9 @@ WPD
 Usage
 -----
 In survival mode, use of the minimap requires the mapping kit item in your
-inventory. It can take up to 3 seconds for adding to or removal from inventory
-to have an effect.
+inventory. It can take up to 5 seconds for adding to or removal from inventory
+to have an effect, however to instantly allow the use of the minimap 'use'
+(leftclick) the item.
 Minimap radar mode is always disallowed in survival mode.
 
 Minimap and minimap radar mode are automatically allowed in creative mode and

--- a/mods/map/init.lua
+++ b/mods/map/init.lua
@@ -40,19 +40,23 @@ local function cyclic_update()
 	for _, player in ipairs(minetest.get_connected_players()) do
 		map.update_hud_flags(player)
 	end
-	minetest.after(3.1, cyclic_update)
+	minetest.after(5.3, cyclic_update)
 end
 
-minetest.after(3.1, cyclic_update)
+minetest.after(5.3, cyclic_update)
 
 
 -- Mapping kit item
 
 minetest.register_craftitem("map:mapping_kit", {
-	description = "Mapping Kit",
+	description = "Mapping Kit\nUse with 'Minimap' key",
 	inventory_image = "map_mapping_kit.png",
 	stack_max = 1,
 	groups = {flammable = 3},
+
+	on_use = function(itemstack, user, pointed_thing)
+		map.update_hud_flags(user)
+	end,
 })
 
 


### PR DESCRIPTION
Binoculars / Map mods: Clarify key-activation of items in descriptions

Map mod:
Tune cyclic update interval.
Re-add HUD flags update on item 'use'.
////////////////

To help with potential confusion about how to use these items.

![screenshot from 2017-10-24 05-03-57](https://user-images.githubusercontent.com/3686677/31924411-dc03eed0-b878-11e7-9847-5cea4205704c.png)

![screenshot from 2017-10-24 05-04-11](https://user-images.githubusercontent.com/3686677/31924414-df4d951e-b878-11e7-83c9-1dc46ca39f68.png)