### PR TITLE
Carts: Correct visuals of going up/down

### DIFF
--- a/mods/carts/functions.lua
+++ b/mods/carts/functions.lua
@@ -23,6 +23,8 @@ function carts:manage_attachment(player, obj)
 	else
 		player:set_detach()
 		player:set_eye_offset({x=0, y=0, z=0},{x=0, y=0, z=0})
+		-- HACK in effect! Force updating the attachment rotation
+		player:set_properties({})
 	end
 end
 


### PR DESCRIPTION
Fixes #1927 

![screenshot_20171027_125531](https://user-images.githubusercontent.com/1497498/32100947-3729ecca-bb16-11e7-980b-34ebfbab4d6e.png)
![screenshot_20171027_125658](https://user-images.githubusercontent.com/1497498/32100972-573375d6-bb16-11e7-9929-dda3b98b6955.png)

Ugly side-effects:
* The player stays rotated like that for a *few seconds* after detaching. Seems to be a core issue.
* The eye offset is changed, but it's not bound to the player head when rotating around. Core issue as well (?)