### PR TITLE
Binoculars: Only set property if necessary to reduce mesh reloading

### DIFF
--- a/mods/binoculars/init.lua
+++ b/mods/binoculars/init.lua
@@ -3,7 +3,12 @@
 binoculars = {}
 
 
--- Cache creative mode setting
+-- Detect creative mod
+
+local creative_mod = minetest.get_modpath("creative")
+
+
+-- Cache creative mode setting as fallback if creative mod not present
 
 local creative_mode_cache = minetest.settings:get_bool("creative_mode")
 
@@ -13,14 +18,13 @@ local creative_mode_cache = minetest.settings:get_bool("creative_mode")
 
 function binoculars.update_player_property(player)
 	local creative_enabled =
-		(creative and creative.is_enabled_for(player:get_player_name())) or
+		(creative_mod and creative.is_enabled_for(player:get_player_name())) or
 		creative_mode_cache
-
-	if creative_enabled or
-			player:get_inventory():contains_item("main", "binoculars:binoculars") then
-		player:set_properties({can_zoom = true})
-	else
-		player:set_properties({can_zoom = false})
+	-- Only set property if necessary to avoid player mesh reload
+	local new_can_zoom = creative_enabled or player:get_inventory():contains_item(
+			"main", "binoculars:binoculars")
+	if player:get_properties().can_zoom ~= new_can_zoom then
+		player:set_properties({can_zoom = new_can_zoom})
 	end
 end
 


### PR DESCRIPTION
WIP i need to test.

Addresses https://github.com/minetest/minetest/issues/6572 by only setting 'can zoom' property when necessary, therefore avoiding player mesh reload every 5s.
Adds a mod table that stores the 'can zoom' setting, the cyclic update checks this to see if status has changed.
Setting the 'can zoom' property and initialising the table entry is forced on player join.
Table entry is deleted on player leave.