### PR TITLE
Player API: Set eye height property for new player model

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -364,8 +364,9 @@ The player API can register player models and update the player's appearence
 			bar = {x = 20, y = 39},
 		-- ...
 		},
-		collisionbox = {-0.3, 0.0, -0.3, 0.3, 1.77, 0.3}, -- In nodes from feet position
+		collisionbox = {-0.3, 0.0, -0.3, 0.3, 1.7, 0.3}, -- In nodes from feet position
 		stepheight = 0.6, -- In nodes
+		eye_height = 1.47, -- In nodes above feet position
 	}
 
 

--- a/mods/player_api/api.lua
+++ b/mods/player_api/api.lua
@@ -45,8 +45,9 @@ function player_api.set_model(player, model_name)
 			textures = player_textures[name] or model.textures,
 			visual = "mesh",
 			visual_size = model.visual_size or {x = 1, y = 1},
-			collisionbox = model.collisionbox or {-0.3, 0.0, -0.3, 0.3, 1.77, 0.3},
+			collisionbox = model.collisionbox or {-0.3, 0.0, -0.3, 0.3, 1.7, 0.3},
 			stepheight = model.stepheight or 0.6,
+			eye_height = model.eye_height or 1.47,
 		})
 		player_api.set_animation(player, "stand")
 	else
@@ -55,6 +56,7 @@ function player_api.set_model(player, model_name)
 			visual = "upright_sprite",
 			collisionbox = {-0.3, 0.0, -0.3, 0.3, 1.75, 0.3},
 			stepheight = 0.6,
+			eye_height = 1.625,
 		})
 	end
 	player_model[name] = model_name

--- a/mods/player_api/init.lua
+++ b/mods/player_api/init.lua
@@ -15,6 +15,7 @@ player_api.register_model("character.b3d", {
 	},
 	collisionbox = {-0.3, 0.0, -0.3, 0.3, 1.7, 0.3},
 	stepheight = 0.6,
+	eye_height = 1.47,
 })
 
 -- Update appearance when the player joins


### PR DESCRIPTION
 Player API: Set eye height property for new player model

Correct the collisionbox height.
////////////////

![screenshot_20171105_045219](https://user-images.githubusercontent.com/3686677/32412143-5917b7b4-c1e6-11e7-9971-a4977f388680.png)

^ Exactly level with centre of head (average eye height for skins)

To be merged with https://github.com/minetest/minetest/pull/6579
Sets the new 'eye_height' player object property for the character.b3d model and sets it at the lower position for the new player model.