### PR TITLE
Improve burn times

### DIFF
--- a/mods/default/crafting.lua
+++ b/mods/default/crafting.lua
@@ -1011,7 +1011,7 @@ minetest.register_craft({
 minetest.register_craft({
 	type = "fuel",
 	recipe = "default:junglegrass",
-	burntime = 2,
+	burntime = 3,
 })
 
 minetest.register_craft({
@@ -1029,7 +1029,7 @@ minetest.register_craft({
 minetest.register_craft({
 	type = "fuel",
 	recipe = "default:papyrus",
-	burntime = 1,
+	burntime = 3,
 })
 
 minetest.register_craft({

--- a/mods/default/crafting.lua
+++ b/mods/default/crafting.lua
@@ -853,7 +853,7 @@ minetest.register_craft({
 -- Fuels
 --
 
--- Support use of group:tree
+-- Support use of group:tree, includes default:tree which has the same burn time
 minetest.register_craft({
 	type = "fuel",
 	recipe = "group:tree",
@@ -878,12 +878,6 @@ minetest.register_craft({
 
 minetest.register_craft({
 	type = "fuel",
-	recipe = "default:tree",
-	burntime = 30,
-})
-
-minetest.register_craft({
-	type = "fuel",
 	recipe = "default:acacia_tree",
 	burntime = 34,
 })
@@ -895,7 +889,7 @@ minetest.register_craft({
 })
 
 
--- Support use of group:wood
+-- Support use of group:wood, includes default:wood which has the same burn time
 minetest.register_craft({
 	type = "fuel",
 	recipe = "group:wood",
@@ -916,12 +910,6 @@ minetest.register_craft({
 
 minetest.register_craft({
 	type = "fuel",
-	recipe = "default:wood",
-	burntime = 7,
-})
-
-minetest.register_craft({
-	type = "fuel",
 	recipe = "default:acacia_wood",
 	burntime = 8,
 })
@@ -933,53 +921,47 @@ minetest.register_craft({
 })
 
 
--- Support use of group:sapling
+-- Support use of group:sapling, includes default:sapling which has the same burn time
 minetest.register_craft({
 	type = "fuel",
 	recipe = "group:sapling",
-	burntime = 10,
+	burntime = 5,
 })
 
 minetest.register_craft({
 	type = "fuel",
 	recipe = "default:bush_sapling",
-	burntime = 6,
+	burntime = 3,
 })
 
 minetest.register_craft({
 	type = "fuel",
 	recipe = "default:acacia_bush_sapling",
-	burntime = 7,
+	burntime = 4,
 })
 
 minetest.register_craft({
 	type = "fuel",
 	recipe = "default:aspen_sapling",
-	burntime = 8,
+	burntime = 4,
 })
 
 minetest.register_craft({
 	type = "fuel",
 	recipe = "default:pine_sapling",
-	burntime = 9,
-})
-
-minetest.register_craft({
-	type = "fuel",
-	recipe = "default:sapling",
-	burntime = 10,
+	burntime = 5,
 })
 
 minetest.register_craft({
 	type = "fuel",
 	recipe = "default:acacia_sapling",
-	burntime = 11,
+	burntime = 6,
 })
 
 minetest.register_craft({
 	type = "fuel",
 	recipe = "default:junglesapling",
-	burntime = 12,
+	burntime = 6,
 })
 
 
@@ -1035,7 +1017,7 @@ minetest.register_craft({
 minetest.register_craft({
 	type = "fuel",
 	recipe = "group:leaves",
-	burntime = 1,
+	burntime = 4,
 })
 
 minetest.register_craft({
@@ -1090,12 +1072,6 @@ minetest.register_craft({
 	type = "fuel",
 	recipe = "default:chest_locked",
 	burntime = 30,
-})
-
-minetest.register_craft({
-	type = "fuel",
-	recipe = "default:apple",
-	burntime = 3,
 })
 
 minetest.register_craft({

--- a/mods/default/crafting.lua
+++ b/mods/default/crafting.lua
@@ -1041,7 +1041,7 @@ minetest.register_craft({
 minetest.register_craft({
 	type = "fuel",
 	recipe = "default:ladder_wood",
-	burntime = 2,
+	burntime = 7,
 })
 
 minetest.register_craft({


### PR DESCRIPTION
Fixes #1946. (And a bit more)

- Raises leaves burntime from 1 to 4.
- Reduces all sapling burntimes by /2.
- Removes apples from fuels. (Eat them instead! They're good for you!)
- Removes redundant recipes (those where a specific recipe is not needed because there is a group recipe with the same burntime that will be fallen back on instead).