### PR TITLE
Binoculars: Update to use 'zoom_fov' player property

### DIFF
--- a/mods/binoculars/README.txt
+++ b/mods/binoculars/README.txt
@@ -24,12 +24,14 @@ O_O
 
 Usage
 -----
-In survival mode, use of zoom requires the binoculars item in your inventory.
+In survival mode, use of zoom requires the binoculars item in your inventory,
+they will allow a 10 degree field of view.
 It can take up to 5 seconds for adding to or removal from inventory to have an
-effect, however to instantly allow the use of zoom 'use' (leftclick) the item.
+effect, however to instantly allow the use of this zoom 'use' (leftclick) the
+item.
 
-Zoom is automatically allowed in creative mode and for any player with the
-'creative' privilege.
+Zoom with a field of view of 15 degrees is automatically allowed in creative
+mode and for any player with the 'creative' privilege.
 
 The 'binoculars.update_player_property()' function is global so can be
 redefined by a mod for alternative behaviour.

--- a/mods/binoculars/init.lua
+++ b/mods/binoculars/init.lua
@@ -4,12 +4,8 @@ binoculars = {}
 
 
 -- Detect creative mod
-
 local creative_mod = minetest.get_modpath("creative")
-
-
 -- Cache creative mode setting as fallback if creative mod not present
-
 local creative_mode_cache = minetest.settings:get_bool("creative_mode")
 
 
@@ -20,11 +16,18 @@ function binoculars.update_player_property(player)
 	local creative_enabled =
 		(creative_mod and creative.is_enabled_for(player:get_player_name())) or
 		creative_mode_cache
+	local new_zoom_fov = 0
+
+	if player:get_inventory():contains_item(
+			"main", "binoculars:binoculars") then
+		new_zoom_fov = 10
+	elseif creative_enabled then
+		new_zoom_fov = 15
+	end
+
 	-- Only set property if necessary to avoid player mesh reload
-	local new_can_zoom = creative_enabled or player:get_inventory():contains_item(
-			"main", "binoculars:binoculars")
-	if player:get_properties().can_zoom ~= new_can_zoom then
-		player:set_properties({can_zoom = new_can_zoom})
+	if player:get_properties().zoom_fov ~= new_zoom_fov then
+		player:set_properties({zoom_fov = new_zoom_fov})
 	end
 end
 


### PR DESCRIPTION
 Binoculars: Update to use 'zoom_fov' player property

In survival mode, zoom is disabled, the binoculars item is needed to
allow a zoom with a 10 degree FOV, realistic for compact binoculars.

Creative mode or per-player creative privilege allows a zoom with a
15 degree field of view (the default MT engine zoom FOV).
////////////

To be merged soon after https://github.com/minetest/minetest/pull/6650
Tested with the engine PR.