### PR TITLE
Beds: Improve force-night-skip input checks

### DIFF
--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -214,8 +214,9 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 	end
 
 	if fields.force then
-		update_formspecs(is_night_skip_enabled())
-		if is_night_skip_enabled() then
+		local is_majority = (#minetest.get_connected_players() / 2) < player_in_bed
+		update_formspecs(is_majority and is_night_skip_enabled())
+		if is_majority and is_night_skip_enabled() then
 			beds.skip_night()
 			beds.kick_players()
 		end


### PR DESCRIPTION
Attends to #1964 
WIP seems to have a bug, can't force night skip on a local server with 3 players.