### PR TITLE
Fix furnace being able to cook items without enough fuel.

### DIFF
--- a/mods/default/furnace.lua
+++ b/mods/default/furnace.lua
@@ -118,7 +118,7 @@ local function furnace_node_timer(pos, elapsed)
 	local fuel
 
 	local update = true
-	while update do
+	while elapsed > 0 and update do
 		update = false
 
 		srclist = inv:get_list("src")
@@ -149,6 +149,9 @@ local function furnace_node_timer(pos, elapsed)
 						src_time = src_time - cooked.time
 						update = true
 					end
+				else
+					-- Item could not be cooked: probably missing fuel
+					update = true
 				end
 			end
 		else

--- a/mods/default/furnace.lua
+++ b/mods/default/furnace.lua
@@ -134,6 +134,10 @@ local function furnace_node_timer(pos, elapsed)
 		cookable = cooked.time ~= 0
 
 		local el = math.min(elapsed, fuel_totaltime - fuel_time)
+		if cookable then -- fuel lasts long enough, adjust el to cooking duration
+			el = math.min(el, cooked.time - src_time)
+		end
+
 		-- Check if we have enough fuel to burn
 		if fuel_time < fuel_totaltime then
 			-- The furnace is currently active and has enough fuel

--- a/mods/default/furnace.lua
+++ b/mods/default/furnace.lua
@@ -133,13 +133,14 @@ local function furnace_node_timer(pos, elapsed)
 		cooked, aftercooked = minetest.get_craft_result({method = "cooking", width = 1, items = srclist})
 		cookable = cooked.time ~= 0
 
+		local el = math.min(elapsed, fuel_totaltime - fuel_time)
 		-- Check if we have enough fuel to burn
 		if fuel_time < fuel_totaltime then
 			-- The furnace is currently active and has enough fuel
-			fuel_time = fuel_time + elapsed
+			fuel_time = fuel_time + el
 			-- If there is a cookable item then check if it is ready yet
 			if cookable then
-				src_time = src_time + elapsed
+				src_time = src_time + el
 				if src_time >= cooked.time then
 					-- Place result in dst list if possible
 					if inv:room_for_item("dst", cooked.item) then
@@ -165,8 +166,7 @@ local function furnace_node_timer(pos, elapsed)
 					-- Take fuel from fuel list
 					inv:set_stack("fuel", 1, afterfuel.items[1])
 					update = true
-					fuel_totaltime = fuel.time + (fuel_time - fuel_totaltime)
-					src_time = src_time + elapsed
+					fuel_totaltime = fuel.time + (fuel_totaltime - fuel_time)
 				end
 			else
 				-- We don't need to get new fuel since there is no cookable item
@@ -176,7 +176,7 @@ local function furnace_node_timer(pos, elapsed)
 			fuel_time = 0
 		end
 
-		elapsed = 0
+		elapsed = elapsed - el
 	end
 
 	if fuel and fuel_totaltime > fuel.time then


### PR DESCRIPTION
This triggered when too much time had elapsed when timer was called.
Also, fix timer resolution giving free fuel time.
Fixes #1986.