### PR TITLE
Add use_textures_alpha to xpanes

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -690,7 +690,7 @@ Creates panes that automatically connect to each other
 		groups = {group = rating}, -- Uses the known node groups, see [Known damage and digging time defining groups]
 		sounds = SoundSpec,        -- See [#Default sounds]
 		recipe = {{"","","","","","","","",""}}, -- Recipe field only
-		use_texture_alpha = true, -- Optional parameter for colored glass panes
+		use_texture_alpha = true, -- Optional boolean (default: `false`) for colored glass panes
 	}
 
 Raillike definitions

--- a/game_api.txt
+++ b/game_api.txt
@@ -690,6 +690,7 @@ Creates panes that automatically connect to each other
 		groups = {group = rating}, -- Uses the known node groups, see [Known damage and digging time defining groups]
 		sounds = SoundSpec,        -- See [#Default sounds]
 		recipe = {{"","","","","","","","",""}}, -- Recipe field only
+		use_texture_alpha = true, -- For colored glass panes
 	}
 
 Raillike definitions

--- a/game_api.txt
+++ b/game_api.txt
@@ -690,7 +690,7 @@ Creates panes that automatically connect to each other
 		groups = {group = rating}, -- Uses the known node groups, see [Known damage and digging time defining groups]
 		sounds = SoundSpec,        -- See [#Default sounds]
 		recipe = {{"","","","","","","","",""}}, -- Recipe field only
-		use_texture_alpha = true, -- For colored glass panes
+		use_texture_alpha = true, -- Optional parameter for colored glass panes
 	}
 
 Raillike definitions

--- a/mods/xpanes/init.lua
+++ b/mods/xpanes/init.lua
@@ -104,6 +104,7 @@ function xpanes.register_pane(name, def)
 		groups = flatgroups,
 		drop = "xpanes:" .. name .. "_flat",
 		sounds = def.sounds,
+		use_texture_alpha = def.use_texture_alpha or false,
 		node_box = {
 			type = "fixed",
 			fixed = {{-1/2, -1/2, -1/32, 1/2, 1/2, 1/32}},
@@ -128,6 +129,7 @@ function xpanes.register_pane(name, def)
 		groups = groups,
 		drop = "xpanes:" .. name .. "_flat",
 		sounds = def.sounds,
+		use_texture_alpha = def.use_texture_alpha or false,
 		node_box = {
 			type = "connected",
 			fixed = {{-1/32, -1/2, -1/32, 1/32, 1/2, 1/32}},


### PR DESCRIPTION
Works well when looking south, when looking north some glasses behind are invisible. This bug will disappear when z-sorting is fixed

![screenshot_20171224_223902](https://user-images.githubusercontent.com/16163058/34329316-da260ebe-e8fb-11e7-8080-14d7fba5efbc.png)

![screenshot_20171224_223855](https://user-images.githubusercontent.com/16163058/34329318-e2ea77f6-e8fb-11e7-83e9-5c4584b2e704.png)

Does not effect regular glass panes

![screenshot_20171224_224611](https://user-images.githubusercontent.com/16163058/34329339-72f2549a-e8fc-11e7-8cf9-ebfad87ba34f.png)

addresses #1983