### PR TITLE
Dry shrub: Use plantlike meshoption for bushy appearence

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -1593,6 +1593,7 @@ function default.register_mgv6_decorations()
 		y_min = 1,
 		y_max = 30,
 		decoration = "default:dry_shrub",
+		param2 = 4,
 	})
 end
 
@@ -2018,6 +2019,7 @@ function default.register_decorations()
 		y_min = 2,
 		y_max = 31000,
 		decoration = "default:dry_shrub",
+		param2 = 4,
 	})
 
 	-- Coral reef

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1183,6 +1183,8 @@ minetest.register_node("default:dry_shrub", {
 	inventory_image = "default_dry_shrub.png",
 	wield_image = "default_dry_shrub.png",
 	paramtype = "light",
+	paramtype2 = "meshoptions",
+	place_param2 = 4,
 	sunlight_propagates = true,
 	walkable = false,
 	buildable_to = true,
@@ -1190,7 +1192,7 @@ minetest.register_node("default:dry_shrub", {
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
 		type = "fixed",
-		fixed = {-5 / 16, -0.5, -5 / 16, 5 / 16, 4 / 16, 5 / 16},
+		fixed = {-6 / 16, -0.5, -6 / 16, 6 / 16, 4 / 16, 6 / 16},
 	},
 })
 


### PR DESCRIPTION
Dry shrub: Use plantlike meshoption for bushy appearence

Adjust selectionbox width for a better fit and consistency with other
grasses.
/////////////

![screenshot_20180101_093056](https://user-images.githubusercontent.com/3686677/34466794-b67db07a-eed7-11e7-8d02-1d9314e07fe7.png)

![screenshot_20180101_093752](https://user-images.githubusercontent.com/3686677/34466787-90739782-eed7-11e7-9e97-96e1a2916c2f.png)

@sofar 
Uses meshoption 4 for 4 faces leaning outwards.
Dry shrubs are always at low density so extra faces are not a problem.