### PR TITLE
default:dirt_with_snow: Re-add to soil group

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -447,7 +447,7 @@ minetest.register_node("default:dirt_with_snow", {
 	tiles = {"default_snow.png", "default_dirt.png",
 		{name = "default_dirt.png^default_snow_side.png",
 			tileable_vertical = false}},
-	groups = {crumbly = 3, spreading_dirt_type = 1, snowy = 1},
+	groups = {crumbly = 3, soil = 1, spreading_dirt_type = 1, snowy = 1},
 	drop = 'default:dirt',
 	sounds = default.node_sound_dirt_defaults({
 		footstep = {name = "default_snow_footstep", gain = 0.2},


### PR DESCRIPTION
Previously, saplings were not growing if the dirt they are on turned to
'dirt with snow' before growth.
Also for consistency with other dirt nodes.
///////////////
Fix for #2014 

See #1755 the soil group has been added and removed already, there was some debate over it, at least this decides it =)