### PR TITLE
Dungeon loot: Reduce maximum processed rooms to 8

### DIFF
--- a/mods/dungeon_loot/mapgen.lua
+++ b/mods/dungeon_loot/mapgen.lua
@@ -131,8 +131,8 @@ minetest.register_on_generated(function(minp, maxp, blockseed)
 	local rand = PcgRandom(noise3d_integer(noise, poslist[1]))
 
 	local candidates = {}
-	-- process at most 16 rooms to keep runtime of this predictable
-	local num_process = math.min(#poslist, 16)
+	-- process at most 8 rooms to keep runtime of this predictable
+	local num_process = math.min(#poslist, 8)
 	for i = 1, num_process do
 		local room = find_walls(poslist[i])
 		-- skip small rooms and everything that doesn't at least have 3 walls


### PR DESCRIPTION
Attends to #2023 as suggested here https://github.com/minetest/minetest_game/issues/2023#issuecomment-359011243
Probably won't make a big performance difference but since maximum number of rooms for dungeons is 16, the average will be around 8 so that seems a reasonable maximum number to process. Each processed room involves many 'get nodes'.
@sfan5 