### PR TITLE
Doors: Avoid crash on nil player in 'can dig door'

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -203,12 +203,7 @@ end
 
 local function can_dig_door(pos, digger)
 	replace_old_owner_information(pos)
-	if default.can_interact_with_node(digger, pos) then
-		return true
-	else
-		minetest.record_protection_violation(pos, digger:get_player_name())
-		return false
-	end
+	return default.can_interact_with_node(digger, pos)
 end
 
 function doors.register(name, def)


### PR DESCRIPTION
For #2032 
@ShadowNinja @sofar 