### PR TITLE
Adjust kelp placement and add selection box

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1523,6 +1523,13 @@ minetest.register_node("default:sand_with_kelp", {
 	inventory_image = "default_kelp.png",
 	paramtype2 = "leveled",
 	groups = {snappy = 3},
+	selection_box = {
+		type = "fixed",
+		fixed = {
+				{-0.5, -0.5, -0.5, 0.5, 0.5, 0.5},
+				{-0.1, 0.5, -0.1, 0.1, 3.5, 0.1},
+		},
+	},
 	node_placement_prediction = "",
 
 	on_place = function(itemstack, placer, pointed_thing)
@@ -1537,7 +1544,11 @@ minetest.register_node("default:sand_with_kelp", {
 			end
 		end
 
-		local pos = pointed_thing.above
+		local pos = pointed_thing.under
+		if minetest.get_node(pos).name ~= "default:sand" then
+			return itemstack
+		end
+
 		local height = math.random(4, 6)
 		local pos_top = {x = pos.x, y = pos.y + height, z = pos.z}
 		local node_top = minetest.get_node(pos_top)
@@ -1561,6 +1572,10 @@ minetest.register_node("default:sand_with_kelp", {
 		end
 
 		return itemstack
+	end,
+
+	after_destruct  = function(pos, oldnode)
+		minetest.set_node(pos, {name = "default:sand"})
 	end
 })
 

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1531,6 +1531,7 @@ minetest.register_node("default:sand_with_kelp", {
 				{-2/16, 0.5, -2/16, 2/16, 3.5, 2/16},
 		},
 	},
+	node_dig_prediction = "default:sand",
 	node_placement_prediction = "",
 
 	on_place = function(itemstack, placer, pointed_thing)

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1516,7 +1516,7 @@ minetest.register_node("default:acacia_bush_sapling", {
 })
 
 minetest.register_node("default:sand_with_kelp", {
-	description = "Kelp On Sand",
+	description = "Kelp",
 	drawtype = "plantlike_rooted",
 	tiles = {"default_sand.png"},
 	special_tiles = {{name = "default_kelp.png", tileable_vertical = true}},

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1518,6 +1518,7 @@ minetest.register_node("default:acacia_bush_sapling", {
 minetest.register_node("default:sand_with_kelp", {
 	description = "Kelp",
 	drawtype = "plantlike_rooted",
+	waving = 1,
 	tiles = {"default_sand.png"},
 	special_tiles = {{name = "default_kelp.png", tileable_vertical = true}},
 	inventory_image = "default_kelp.png",

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1527,7 +1527,7 @@ minetest.register_node("default:sand_with_kelp", {
 		type = "fixed",
 		fixed = {
 				{-0.5, -0.5, -0.5, 0.5, 0.5, 0.5},
-				{-0.1, 0.5, -0.1, 0.1, 3.5, 0.1},
+				{-2/16, 0.5, -2/16, 2/16, 3.5, 2/16},
 		},
 	},
 	node_placement_prediction = "",


### PR DESCRIPTION
This does three things:
- Adds a selection box to the kelp itself.
- When digging kelp you now leave the sand it was in behind, meaning no more ugly holes getting left after collecting it.
- When planting kelp, it no longer places a new sand node; it just adds the kelp to whichever sand node you targeted.