### PR TITLE
Boats: Prevent entering 'ignore' nodes 

### DIFF
--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -172,15 +172,23 @@ function boat.on_step(self, dtime)
 	local new_velo
 	local new_acce = {x = 0, y = 0, z = 0}
 	if not is_water(p) then
-		local nodedef = minetest.registered_nodes[minetest.get_node(p).name]
-		if (not nodedef) or nodedef.walkable then
+		local nodename = minetest.get_node(p).name
+		local nodedef = minetest.registered_nodes[nodename]
+		if nodename == "ignore" then
+			-- at world edge bounce boat back into world
+			self.v = -self.v
+			-- at world base avoid falling into ignore
+			new_velo = get_velocity(self.v, self.object:getyaw(), 0)
+		elseif (not nodedef) or nodedef.walkable then
 			self.v = 0
 			new_acce = {x = 0, y = 1, z = 0}
+			new_velo = get_velocity(self.v, self.object:getyaw(),
+				self.object:getvelocity().y)
 		else
 			new_acce = {x = 0, y = -9.8, z = 0}
+			new_velo = get_velocity(self.v, self.object:getyaw(),
+				self.object:getvelocity().y)
 		end
-		new_velo = get_velocity(self.v, self.object:getyaw(),
-			self.object:getvelocity().y)
 		self.object:setpos(self.object:getpos())
 	else
 		p.y = p.y + 1


### PR DESCRIPTION
At world edge make boat bounce back into world by inverting speed.
At world base avoid falling into ignore by setting y velocity to 0.
//////////////////

As part of world edge stuff https://github.com/minetest/minetest/issues/6984
Should be merged if https://github.com/minetest/minetest/pull/6998 is. Should be tested with that applied but not at the 31000 edge, set 'mapgen_limit' to a smaller value and test at a less distant world edge (at the 31000 world edge other code automatically deletes the boat entity).

It will be rare that a boat is used to drop into void at world base, but i added protection against that anyway, y velocity is set to zero. I did try a vertical bounce but this had no advantage and often resulted in a boat having zero y velocity and stuck about 1 node below world base. So at world base it is necessary for the player to exit the boat, pick it up and jump back up into the world.