### PR TITLE
Flower spread: Only spread to the same surface node

### DIFF
--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -154,11 +154,14 @@ function flowers.flower_spread(pos, node)
 	if num_soils >= 1 then
 		for si = 1, math.min(3, num_soils) do
 			local soil = soils[math.random(num_soils)]
+			local soil_name = minetest.get_node(soil).name
 			local soil_above = {x = soil.x, y = soil.y + 1, z = soil.z}
 			light = minetest.get_node_light(soil_above)
 			if light and light >= 13 and
+					-- Only spread to same surface node
+					soil_name == under.name and
 					-- Desert sand is in the soil group
-					minetest.get_node(soil).name ~= "default:desert_sand" then
+					soil_name ~= "default:desert_sand" then
 				minetest.set_node(soil_above, {name = node.name})
 			end
 		end


### PR DESCRIPTION
![screenshot_20180211_090044](https://user-images.githubusercontent.com/3686677/36071668-3e0d530e-0f0a-11e8-976c-19b8aa8c6958.png)

^ First flower was placed just above crosshair (ABM speeded up for testing)

Keeps flora within native biomes.
Attends to https://github.com/minetest/minetest_game/issues/2022#issuecomment-362875539
Players may need to adapt occasionally due to this but i think it's worth it.