### PR TITLE
Put y_max above y_min in mapgen registrations

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -59,8 +59,8 @@ function default.register_mgv6_ores()
 		wherein         = {"default:sand"},
 		clust_scarcity  = 16 * 16 * 16,
 		clust_size      = 5,
-		y_min           = -15,
 		y_max           = 0,
+		y_min           = -15,
 		noise_threshold = 0.0,
 		noise_params    = {
 			offset = 0.5,
@@ -80,8 +80,8 @@ function default.register_mgv6_ores()
 		wherein         = {"default:stone", "default:desert_stone"},
 		clust_scarcity  = 16 * 16 * 16,
 		clust_size      = 5,
-		y_min           = -31,
 		y_max           = 0,
+		y_min           = -31,
 		noise_threshold = 0.0,
 		noise_params    = {
 			offset = 0.5,
@@ -101,8 +101,8 @@ function default.register_mgv6_ores()
 		wherein         = {"default:stone"},
 		clust_scarcity  = 16 * 16 * 16,
 		clust_size      = 5,
-		y_min           = -31,
 		y_max           = 31000,
+		y_min           = -31,
 		noise_threshold = 0.0,
 		noise_params    = {
 			offset = 0.5,
@@ -122,8 +122,8 @@ function default.register_mgv6_ores()
 		wherein         = {"default:stone"},
 		clust_scarcity  = 16 * 16 * 16,
 		clust_size      = 5,
-		y_min           = -31000,
 		y_max           = 31000,
+		y_min           = -31000,
 		noise_threshold = 0.0,
 		noise_params    = {
 			offset = 0.5,
@@ -146,8 +146,8 @@ function default.register_mgv6_ores()
 		clust_scarcity = 8 * 8 * 8,
 		clust_num_ores = 9,
 		clust_size     = 3,
-		y_min          = 1025,
 		y_max          = 31000,
+		y_min          = 1025,
 	})
 
 	minetest.register_ore({
@@ -157,8 +157,8 @@ function default.register_mgv6_ores()
 		clust_scarcity = 8 * 8 * 8,
 		clust_num_ores = 8,
 		clust_size     = 3,
-		y_min          = -31000,
 		y_max          = 64,
+		y_min          = -31000,
 	})
 
 	minetest.register_ore({
@@ -168,8 +168,8 @@ function default.register_mgv6_ores()
 		clust_scarcity = 24 * 24 * 24,
 		clust_num_ores = 27,
 		clust_size     = 6,
-		y_min          = -31000,
 		y_max          = 0,
+		y_min          = -31000,
 	})
 
 	-- Iron
@@ -181,8 +181,8 @@ function default.register_mgv6_ores()
 		clust_scarcity = 9 * 9 * 9,
 		clust_num_ores = 12,
 		clust_size     = 3,
-		y_min          = 1025,
 		y_max          = 31000,
+		y_min          = 1025,
 	})
 
 	minetest.register_ore({
@@ -192,8 +192,8 @@ function default.register_mgv6_ores()
 		clust_scarcity = 7 * 7 * 7,
 		clust_num_ores = 5,
 		clust_size     = 3,
-		y_min          = -31000,
 		y_max          = 0,
+		y_min          = -31000,
 	})
 
 	minetest.register_ore({
@@ -203,8 +203,8 @@ function default.register_mgv6_ores()
 		clust_scarcity = 24 * 24 * 24,
 		clust_num_ores = 27,
 		clust_size     = 6,
-		y_min          = -31000,
 		y_max          = -64,
+		y_min          = -31000,
 	})
 
 	-- Copper
@@ -216,8 +216,8 @@ function default.register_mgv6_ores()
 		clust_scarcity = 9 * 9 * 9,
 		clust_num_ores = 5,
 		clust_size     = 3,
-		y_min          = 1025,
 		y_max          = 31000,
+		y_min          = 1025,
 	})
 
 	minetest.register_ore({
@@ -227,8 +227,8 @@ function default.register_mgv6_ores()
 		clust_scarcity = 12 * 12 * 12,
 		clust_num_ores = 4,
 		clust_size     = 3,
-		y_min          = -63,
 		y_max          = -16,
+		y_min          = -63,
 	})
 
 	minetest.register_ore({
@@ -238,8 +238,8 @@ function default.register_mgv6_ores()
 		clust_scarcity = 9 * 9 * 9,
 		clust_num_ores = 5,
 		clust_size     = 3,
-		y_min          = -31000,
 		y_max          = -64,
+		y_min          = -31000,
 	})
 
 	-- Tin
@@ -251,8 +251,8 @@ function default.register_mgv6_ores()
 		clust_scarcity = 10 * 10 * 10,
 		clust_num_ores = 5,
 		clust_size     = 3,
-		y_min          = 1025,
 		y_max          = 31000,
+		y_min          = 1025,
 	})
 
 	minetest.register_ore({
@@ -262,8 +262,8 @@ function default.register_mgv6_ores()
 		clust_scarcity = 13 * 13 * 13,
 		clust_num_ores = 4,
 		clust_size     = 3,
-		y_min          = -127,
 		y_max          = -32,
+		y_min          = -127,
 	})
 
 	minetest.register_ore({
@@ -273,8 +273,8 @@ function default.register_mgv6_ores()
 		clust_scarcity = 10 * 10 * 10,
 		clust_num_ores = 5,
 		clust_size     = 3,
-		y_min          = -31000,
 		y_max          = -128,
+		y_min          = -31000,
 	})
 
 	-- Gold
@@ -286,8 +286,8 @@ function default.register_mgv6_ores()
 		clust_scarcity = 13 * 13 * 13,
 		clust_num_ores = 5,
 		clust_size     = 3,
-		y_min          = 1025,
 		y_max          = 31000,
+		y_min          = 1025,
 	})
 
 	minetest.register_ore({
@@ -297,8 +297,8 @@ function default.register_mgv6_ores()
 		clust_scarcity = 15 * 15 * 15,
 		clust_num_ores = 3,
 		clust_size     = 2,
-		y_min          = -255,
 		y_max          = -64,
+		y_min          = -255,
 	})
 
 	minetest.register_ore({
@@ -308,8 +308,8 @@ function default.register_mgv6_ores()
 		clust_scarcity = 13 * 13 * 13,
 		clust_num_ores = 5,
 		clust_size     = 3,
-		y_min          = -31000,
 		y_max          = -256,
+		y_min          = -31000,
 	})
 
 	-- Mese crystal
@@ -321,8 +321,8 @@ function default.register_mgv6_ores()
 		clust_scarcity = 14 * 14 * 14,
 		clust_num_ores = 5,
 		clust_size     = 3,
-		y_min          = 1025,
 		y_max          = 31000,
+		y_min          = 1025,
 	})
 
 	minetest.register_ore({
@@ -332,8 +332,8 @@ function default.register_mgv6_ores()
 		clust_scarcity = 18 * 18 * 18,
 		clust_num_ores = 3,
 		clust_size     = 2,
-		y_min          = -255,
 		y_max          = -64,
+		y_min          = -255,
 	})
 
 	minetest.register_ore({
@@ -343,8 +343,8 @@ function default.register_mgv6_ores()
 		clust_scarcity = 14 * 14 * 14,
 		clust_num_ores = 5,
 		clust_size     = 3,
-		y_min          = -31000,
 		y_max          = -256,
+		y_min          = -31000,
 	})
 
 	-- Diamond
@@ -356,8 +356,8 @@ function default.register_mgv6_ores()
 		clust_scarcity = 15 * 15 * 15,
 		clust_num_ores = 4,
 		clust_size     = 3,
-		y_min          = 1025,
 		y_max          = 31000,
+		y_min          = 1025,
 	})
 
 	minetest.register_ore({
@@ -367,8 +367,8 @@ function default.register_mgv6_ores()
 		clust_scarcity = 17 * 17 * 17,
 		clust_num_ores = 4,
 		clust_size     = 3,
-		y_min          = -255,
 		y_max          = -128,
+		y_min          = -255,
 	})
 
 	minetest.register_ore({
@@ -378,8 +378,8 @@ function default.register_mgv6_ores()
 		clust_scarcity = 15 * 15 * 15,
 		clust_num_ores = 4,
 		clust_size     = 3,
-		y_min          = -31000,
 		y_max          = -256,
+		y_min          = -31000,
 	})
 
 	-- Mese block
@@ -391,8 +391,8 @@ function default.register_mgv6_ores()
 		clust_scarcity = 36 * 36 * 36,
 		clust_num_ores = 3,
 		clust_size     = 2,
-		y_min          = 1025,
 		y_max          = 31000,
+		y_min          = 1025,
 	})
 
 	minetest.register_ore({
@@ -402,8 +402,8 @@ function default.register_mgv6_ores()
 		clust_scarcity = 36 * 36 * 36,
 		clust_num_ores = 3,
 		clust_size     = 2,
-		y_min          = -31000,
 		y_max          = -1024,
+		y_min          = -31000,
 	})
 end
 
@@ -424,8 +424,8 @@ function default.register_ores()
 		wherein         = {"default:sand"},
 		clust_scarcity  = 16 * 16 * 16,
 		clust_size      = 5,
-		y_min           = -15,
 		y_max           = 0,
+		y_min           = -15,
 		noise_threshold = 0.0,
 		noise_params    = {
 			offset = 0.5,
@@ -445,8 +445,8 @@ function default.register_ores()
 		wherein         = {"default:stone"},
 		clust_scarcity  = 16 * 16 * 16,
 		clust_size      = 5,
-		y_min           = -31000,
 		y_max           = 31000,
+		y_min           = -31000,
 		noise_threshold = 0.0,
 		noise_params    = {
 			offset = 0.5,
@@ -474,8 +474,8 @@ function default.register_ores()
 		wherein         = {"default:stone"},
 		clust_scarcity  = 16 * 16 * 16,
 		clust_size      = 5,
-		y_min           = -31,
 		y_max           = 31000,
+		y_min           = -31,
 		noise_threshold = 0.0,
 		noise_params    = {
 			offset = 0.5,
@@ -498,8 +498,8 @@ function default.register_ores()
 		wherein         = {"default:stone"},
 		clust_scarcity  = 16 * 16 * 16,
 		clust_size      = 5,
-		y_min           = -31000,
 		y_max           = 31000,
+		y_min           = -31000,
 		noise_threshold = 0.0,
 		noise_params    = {
 			offset = 0.5,
@@ -530,8 +530,8 @@ function default.register_ores()
 		clust_scarcity = 8 * 8 * 8,
 		clust_num_ores = 9,
 		clust_size     = 3,
-		y_min          = 1025,
 		y_max          = 31000,
+		y_min          = 1025,
 	})
 
 	minetest.register_ore({
@@ -541,8 +541,8 @@ function default.register_ores()
 		clust_scarcity = 8 * 8 * 8,
 		clust_num_ores = 8,
 		clust_size     = 3,
-		y_min          = -31000,
 		y_max          = 64,
+		y_min          = -31000,
 	})
 
 	minetest.register_ore({
@@ -552,8 +552,8 @@ function default.register_ores()
 		clust_scarcity = 24 * 24 * 24,
 		clust_num_ores = 27,
 		clust_size     = 6,
-		y_min          = -31000,
 		y_max          = 0,
+		y_min          = -31000,
 	})
 
 	-- Iron
@@ -565,8 +565,8 @@ function default.register_ores()
 		clust_scarcity = 9 * 9 * 9,
 		clust_num_ores = 12,
 		clust_size     = 3,
-		y_min          = 1025,
 		y_max          = 31000,
+		y_min          = 1025,
 	})
 
 	minetest.register_ore({
@@ -576,8 +576,8 @@ function default.register_ores()
 		clust_scarcity = 7 * 7 * 7,
 		clust_num_ores = 5,
 		clust_size     = 3,
-		y_min          = -31000,
 		y_max          = 0,
+		y_min          = -31000,
 	})
 
 	minetest.register_ore({
@@ -587,8 +587,8 @@ function default.register_ores()
 		clust_scarcity = 24 * 24 * 24,
 		clust_num_ores = 27,
 		clust_size     = 6,
-		y_min          = -31000,
 		y_max          = -64,
+		y_min          = -31000,
 	})
 
 	-- Tin
@@ -600,8 +600,8 @@ function default.register_ores()
 		clust_scarcity = 10 * 10 * 10,
 		clust_num_ores = 5,
 		clust_size     = 3,
-		y_min          = 1025,
 		y_max          = 31000,
+		y_min          = 1025,
 	})
 
 	minetest.register_ore({
@@ -611,8 +611,8 @@ function default.register_ores()
 		clust_scarcity = 13 * 13 * 13,
 		clust_num_ores = 4,
 		clust_size     = 3,
-		y_min          = -127,
 		y_max          = -64,
+		y_min          = -127,
 	})
 
 	minetest.register_ore({
@@ -622,8 +622,8 @@ function default.register_ores()
 		clust_scarcity = 10 * 10 * 10,
 		clust_num_ores = 5,
 		clust_size     = 3,
-		y_min          = -31000,
 		y_max          = -128,
+		y_min          = -31000,
 	})
 
 	-- Copper
@@ -635,8 +635,8 @@ function default.register_ores()
 		clust_scarcity = 9 * 9 * 9,
 		clust_num_ores = 5,
 		clust_size     = 3,
-		y_min          = 1025,
 		y_max          = 31000,
+		y_min          = 1025,
 	})
 
 	minetest.register_ore({
@@ -646,8 +646,8 @@ function default.register_ores()
 		clust_scarcity = 12 * 12 * 12,
 		clust_num_ores = 4,
 		clust_size     = 3,
+		y_max          = 31000,
 		y_min          = -255,
-		y_max          = -128,
 	})
 
 	minetest.register_ore({
@@ -657,8 +657,8 @@ function default.register_ores()
 		clust_scarcity = 9 * 9 * 9,
 		clust_num_ores = 5,
 		clust_size     = 3,
-		y_min          = -31000,
 		y_max          = -256,
+		y_min          = -31000,
 	})
 
 	-- Gold
@@ -670,8 +670,8 @@ function default.register_ores()
 		clust_scarcity = 13 * 13 * 13,
 		clust_num_ores = 5,
 		clust_size     = 3,
-		y_min          = 1025,
 		y_max          = 31000,
+		y_min          = 1025,
 	})
 
 	minetest.register_ore({
@@ -681,8 +681,8 @@ function default.register_ores()
 		clust_scarcity = 15 * 15 * 15,
 		clust_num_ores = 3,
 		clust_size     = 2,
-		y_min          = -1023,
 		y_max          = -256,
+		y_min          = -1023,
 	})
 
 	minetest.register_ore({
@@ -692,8 +692,8 @@ function default.register_ores()
 		clust_scarcity = 13 * 13 * 13,
 		clust_num_ores = 5,
 		clust_size     = 3,
-		y_min          = -31000,
 		y_max          = -1024,
+		y_min          = -31000,
 	})
 
 	-- Diamond
@@ -705,8 +705,8 @@ function default.register_ores()
 		clust_scarcity = 15 * 15 * 15,
 		clust_num_ores = 4,
 		clust_size     = 3,
-		y_min          = 1025,
 		y_max          = 31000,
+		y_min          = 1025,
 	})
 
 	minetest.register_ore({
@@ -716,8 +716,8 @@ function default.register_ores()
 		clust_scarcity = 17 * 17 * 17,
 		clust_num_ores = 4,
 		clust_size     = 3,
-		y_min          = -1023,
 		y_max          = -512,
+		y_min          = -1023,
 	})
 
 	minetest.register_ore({
@@ -727,8 +727,8 @@ function default.register_ores()
 		clust_scarcity = 15 * 15 * 15,
 		clust_num_ores = 4,
 		clust_size     = 3,
-		y_min          = -31000,
 		y_max          = -1024,
+		y_min          = -31000,
 	})
 
 	-- Mese crystal
@@ -740,8 +740,8 @@ function default.register_ores()
 		clust_scarcity = 14 * 14 * 14,
 		clust_num_ores = 5,
 		clust_size     = 3,
-		y_min          = 1025,
 		y_max          = 31000,
+		y_min          = 1025,
 	})
 
 	minetest.register_ore({
@@ -751,8 +751,8 @@ function default.register_ores()
 		clust_scarcity = 18 * 18 * 18,
 		clust_num_ores = 3,
 		clust_size     = 2,
-		y_min          = -1023,
 		y_max          = -512,
+		y_min          = -1023,
 	})
 
 	minetest.register_ore({
@@ -762,8 +762,8 @@ function default.register_ores()
 		clust_scarcity = 14 * 14 * 14,
 		clust_num_ores = 5,
 		clust_size     = 3,
-		y_min          = -31000,
 		y_max          = -1024,
+		y_min          = -31000,
 	})
 
 	-- Mese block
@@ -775,8 +775,8 @@ function default.register_ores()
 		clust_scarcity = 36 * 36 * 36,
 		clust_num_ores = 3,
 		clust_size     = 2,
-		y_min          = 1025,
 		y_max          = 31000,
+		y_min          = 1025,
 	})
 
 	minetest.register_ore({
@@ -786,8 +786,8 @@ function default.register_ores()
 		clust_scarcity = 36 * 36 * 36,
 		clust_num_ores = 3,
 		clust_size     = 2,
-		y_min          = -2047,
 		y_max          = -1024,
+		y_min          = -2047,
 	})
 
 	minetest.register_ore({
@@ -797,8 +797,8 @@ function default.register_ores()
 		clust_scarcity = 28 * 28 * 28,
 		clust_num_ores = 5,
 		clust_size     = 3,
-		y_min          = -31000,
 		y_max          = -2048,
+		y_min          = -31000,
 	})
 end
 
@@ -827,8 +827,8 @@ function default.register_biomes(upper_limit)
 		node_river_water = "default:ice",
 		node_riverbed = "default:gravel",
 		depth_riverbed = 2,
-		y_min = -8,
 		y_max = upper_limit,
+		y_min = -8,
 		heat_point = 0,
 		humidity_point = 73,
 	})
@@ -845,8 +845,8 @@ function default.register_biomes(upper_limit)
 		depth_water_top = 10,
 		--node_water = "",
 		--node_river_water = "",
-		y_min = -112,
 		y_max = -9,
+		y_min = -112,
 		heat_point = 0,
 		humidity_point = 73,
 	})
@@ -867,8 +867,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:gravel",
 		depth_riverbed = 2,
-		y_min = 2,
 		y_max = upper_limit,
+		y_min = 2,
 		heat_point = 0,
 		humidity_point = 40,
 	})
@@ -887,8 +887,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:gravel",
 		depth_riverbed = 2,
-		y_min = -3,
 		y_max = 1,
+		y_min = -3,
 		heat_point = 0,
 		humidity_point = 40,
 	})
@@ -907,8 +907,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:gravel",
 		depth_riverbed = 2,
-		y_min = -112,
 		y_max = -4,
+		y_min = -112,
 		heat_point = 0,
 		humidity_point = 40,
 	})
@@ -929,8 +929,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:sand",
 		depth_riverbed = 2,
-		y_min = 2,
 		y_max = upper_limit,
+		y_min = 2,
 		heat_point = 25,
 		humidity_point = 70,
 	})
@@ -949,8 +949,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:sand",
 		depth_riverbed = 2,
-		y_min = -112,
 		y_max = 1,
+		y_min = -112,
 		heat_point = 25,
 		humidity_point = 70,
 	})
@@ -971,8 +971,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:sand",
 		depth_riverbed = 2,
-		y_min = 5,
 		y_max = upper_limit,
+		y_min = 5,
 		heat_point = 20,
 		humidity_point = 35,
 	})
@@ -991,8 +991,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:sand",
 		depth_riverbed = 2,
-		y_min = -112,
 		y_max = 4,
+		y_min = -112,
 		heat_point = 20,
 		humidity_point = 35,
 	})
@@ -1013,8 +1013,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:sand",
 		depth_riverbed = 2,
-		y_min = 6,
 		y_max = upper_limit,
+		y_min = 6,
 		heat_point = 50,
 		humidity_point = 35,
 	})
@@ -1033,8 +1033,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:sand",
 		depth_riverbed = 2,
-		y_min = 4,
 		y_max = 5,
+		y_min = 4,
 		heat_point = 50,
 		humidity_point = 35,
 	})
@@ -1053,8 +1053,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:sand",
 		depth_riverbed = 2,
-		y_min = -112,
 		y_max = 3,
+		y_min = -112,
 		heat_point = 50,
 		humidity_point = 35,
 	})
@@ -1075,8 +1075,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:sand",
 		depth_riverbed = 2,
-		y_min = 6,
 		y_max = upper_limit,
+		y_min = 6,
 		heat_point = 45,
 		humidity_point = 70,
 	})
@@ -1095,8 +1095,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:sand",
 		depth_riverbed = 2,
-		y_min = 4,
 		y_max = 5,
+		y_min = 4,
 		heat_point = 45,
 		humidity_point = 70,
 	})
@@ -1115,8 +1115,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:sand",
 		depth_riverbed = 2,
-		y_min = -112,
 		y_max = 3,
+		y_min = -112,
 		heat_point = 45,
 		humidity_point = 70,
 	})
@@ -1137,8 +1137,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:sand",
 		depth_riverbed = 2,
-		y_min = 1,
 		y_max = upper_limit,
+		y_min = 1,
 		heat_point = 60,
 		humidity_point = 68,
 	})
@@ -1157,8 +1157,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:sand",
 		depth_riverbed = 2,
-		y_min = -1,
 		y_max = 0,
+		y_min = -1,
 		heat_point = 60,
 		humidity_point = 68,
 	})
@@ -1177,8 +1177,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:sand",
 		depth_riverbed = 2,
-		y_min = -112,
 		y_max = -2,
+		y_min = -112,
 		heat_point = 60,
 		humidity_point = 68,
 	})
@@ -1199,8 +1199,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:sand",
 		depth_riverbed = 2,
-		y_min = 5,
 		y_max = upper_limit,
+		y_min = 5,
 		heat_point = 92,
 		humidity_point = 16,
 	})
@@ -1219,8 +1219,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:sand",
 		depth_riverbed = 2,
-		y_min = -112,
 		y_max = 4,
+		y_min = -112,
 		heat_point = 92,
 		humidity_point = 16,
 	})
@@ -1241,8 +1241,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:sand",
 		depth_riverbed = 2,
-		y_min = 5,
 		y_max = upper_limit,
+		y_min = 5,
 		heat_point = 60,
 		humidity_point = 0,
 	})
@@ -1261,8 +1261,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:sand",
 		depth_riverbed = 2,
-		y_min = -112,
 		y_max = 4,
+		y_min = -112,
 		heat_point = 60,
 		humidity_point = 0,
 	})
@@ -1283,8 +1283,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:sand",
 		depth_riverbed = 2,
-		y_min = 5,
 		y_max = upper_limit,
+		y_min = 5,
 		heat_point = 40,
 		humidity_point = 0,
 	})
@@ -1303,8 +1303,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:sand",
 		depth_riverbed = 2,
-		y_min = -112,
 		y_max = 4,
+		y_min = -112,
 		heat_point = 40,
 		humidity_point = 0,
 	})
@@ -1325,8 +1325,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:sand",
 		depth_riverbed = 2,
-		y_min = 1,
 		y_max = upper_limit,
+		y_min = 1,
 		heat_point = 89,
 		humidity_point = 42,
 	})
@@ -1345,8 +1345,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:sand",
 		depth_riverbed = 2,
-		y_min = -1,
 		y_max = 0,
+		y_min = -1,
 		heat_point = 89,
 		humidity_point = 42,
 	})
@@ -1365,8 +1365,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:sand",
 		depth_riverbed = 2,
-		y_min = -112,
 		y_max = -2,
+		y_min = -112,
 		heat_point = 89,
 		humidity_point = 42,
 	})
@@ -1387,8 +1387,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:sand",
 		depth_riverbed = 2,
-		y_min = 1,
 		y_max = upper_limit,
+		y_min = 1,
 		heat_point = 86,
 		humidity_point = 65,
 	})
@@ -1407,8 +1407,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:sand",
 		depth_riverbed = 2,
-		y_min = -1,
 		y_max = 0,
+		y_min = -1,
 		heat_point = 86,
 		humidity_point = 65,
 	})
@@ -1427,8 +1427,8 @@ function default.register_biomes(upper_limit)
 		--node_river_water = "",
 		node_riverbed = "default:sand",
 		depth_riverbed = 2,
-		y_min = -112,
 		y_max = -2,
+		y_min = -112,
 		heat_point = 86,
 		humidity_point = 65,
 	})
@@ -1447,8 +1447,8 @@ function default.register_biomes(upper_limit)
 		--depth_water_top = ,
 		--node_water = "",
 		--node_river_water = "",
-		y_min = -31000,
 		y_max = -113,
+		y_min = -31000,
 		heat_point = 50,
 		humidity_point = 50,
 	})
@@ -1475,8 +1475,8 @@ function default.register_floatland_biomes(floatland_level, shadow_limit)
 		--node_river_water = "",
 		--node_riverbed = "",
 		--depth_riverbed = ,
-		y_min = floatland_level + 4,
 		y_max = 31000,
+		y_min = floatland_level + 4,
 		heat_point = 50,
 		humidity_point = 50,
 	})
@@ -1495,8 +1495,8 @@ function default.register_floatland_biomes(floatland_level, shadow_limit)
 		--node_river_water = "",
 		--node_riverbed = "",
 		--depth_riverbed = ,
-		y_min = shadow_limit,
 		y_max = floatland_level + 3,
+		y_min = shadow_limit,
 		heat_point = 50,
 		humidity_point = 50,
 	})
@@ -1525,8 +1525,8 @@ function default.register_mgv6_decorations()
 			octaves = 3,
 			persist = 0.7
 		},
-		y_min = 1,
 		y_max = 1,
+		y_min = 1,
 		decoration = "default:papyrus",
 		height = 2,
 		height_max = 4,
@@ -1548,8 +1548,8 @@ function default.register_mgv6_decorations()
 			octaves = 3,
 			persist = 0.6
 		},
-		y_min = 1,
 		y_max = 30,
+		y_min = 1,
 		decoration = "default:cactus",
 		height = 3,
 	        height_max = 4,
@@ -1570,8 +1570,8 @@ function default.register_mgv6_decorations()
 				octaves = 3,
 				persist = 0.6
 			},
-			y_min = 1,
 			y_max = 30,
+			y_min = 1,
 			decoration = "default:grass_"..length,
 		})
 	end
@@ -1590,8 +1590,8 @@ function default.register_mgv6_decorations()
 			octaves = 3,
 			persist = 0.6
 		},
-		y_min = 1,
 		y_max = 30,
+		y_min = 1,
 		decoration = "default:dry_shrub",
 		param2 = 4,
 	})
@@ -1614,8 +1614,8 @@ local function register_grass_decoration(offset, scale, length)
 			persist = 0.6
 		},
 		biomes = {"grassland", "deciduous_forest", "floatland_grassland"},
-		y_min = 1,
 		y_max = 31000,
+		y_min = 1,
 		decoration = "default:grass_" .. length,
 	})
 end
@@ -1634,8 +1634,8 @@ local function register_dry_grass_decoration(offset, scale, length)
 			persist = 0.6
 		},
 		biomes = {"savanna"},
-		y_min = 1,
 		y_max = 31000,
+		y_min = 1,
 		decoration = "default:dry_grass_" .. length,
 	})
 end
@@ -1654,8 +1654,8 @@ local function register_fern_decoration(seed, length)
 			persist = 0.7
 		},
 		biomes = {"coniferous_forest"},
-		y_min = 6,
 		y_max = 31000,
+		y_min = 6,
 		decoration = "default:fern_" .. length,
 	})
 end
@@ -1678,8 +1678,8 @@ function default.register_decorations()
 			persist = 0.66
 		},
 		biomes = {"deciduous_forest"},
-		y_min = 1,
 		y_max = 31000,
+		y_min = 1,
 		schematic = minetest.get_modpath("default") .. "/schematics/apple_tree.mts",
 		flags = "place_center_x, place_center_z",
 		rotation = "random",
@@ -1698,8 +1698,8 @@ function default.register_decorations()
 			persist = 0.66
 		},
 		biomes = {"deciduous_forest"},
-		y_min = 1,
 		y_max = 31000,
+		y_min = 1,
 		schematic = minetest.get_modpath("default") .. "/schematics/apple_log.mts",
 		flags = "place_center_x",
 		rotation = "random",
@@ -1723,8 +1723,8 @@ function default.register_decorations()
 				persist = 0.7
 			},
 			biomes = {"rainforest"},
-			y_min = 1,
 			y_max = 32,
+			y_min = 1,
 			schematic = minetest.get_modpath("default") ..
 					"/schematics/emergent_jungle_tree.mts",
 			flags = "place_center_x, place_center_z",
@@ -1741,8 +1741,8 @@ function default.register_decorations()
 		sidelen = 16,
 		fill_ratio = 0.1,
 		biomes = {"rainforest", "rainforest_swamp"},
-		y_min = -1,
 		y_max = 31000,
+		y_min = -1,
 		schematic = minetest.get_modpath("default") .. "/schematics/jungle_tree.mts",
 		flags = "place_center_x, place_center_z",
 		rotation = "random",
@@ -1754,8 +1754,8 @@ function default.register_decorations()
 		sidelen = 16,
 		fill_ratio = 0.005,
 		biomes = {"rainforest", "rainforest_swamp"},
-		y_min = 1,
 		y_max = 31000,
+		y_min = 1,
 		schematic = minetest.get_modpath("default") .. "/schematics/jungle_log.mts",
 		flags = "place_center_x",
 		rotation = "random",
@@ -1776,8 +1776,8 @@ function default.register_decorations()
 			persist = 0.66
 		},
 		biomes = {"taiga", "coniferous_forest"},
-		y_min = 2,
 		y_max = 31000,
+		y_min = 2,
 		schematic = minetest.get_modpath("default") .. "/schematics/pine_tree.mts",
 		flags = "place_center_x, place_center_z",
 	})
@@ -1795,8 +1795,8 @@ function default.register_decorations()
 			persist = 0.66
 		},
 		biomes = {"taiga", "coniferous_forest"},
-		y_min = 1,
 		y_max = 31000,
+		y_min = 1,
 		schematic = minetest.get_modpath("default") .. "/schematics/pine_log.mts",
 		flags = "place_center_x",
 		rotation = "random",
@@ -1817,8 +1817,8 @@ function default.register_decorations()
 			persist = 0.66
 		},
 		biomes = {"savanna"},
-		y_min = 1,
 		y_max = 31000,
+		y_min = 1,
 		schematic = minetest.get_modpath("default") .. "/schematics/acacia_tree.mts",
 		flags = "place_center_x, place_center_z",
 		rotation = "random",
@@ -1837,8 +1837,8 @@ function default.register_decorations()
 			persist = 0.66
 		},
 		biomes = {"savanna"},
-		y_min = 1,
 		y_max = 31000,
+		y_min = 1,
 		schematic = minetest.get_modpath("default") .. "/schematics/acacia_log.mts",
 		flags = "place_center_x",
 		rotation = "random",
@@ -1859,8 +1859,8 @@ function default.register_decorations()
 			persist = 0.66
 		},
 		biomes = {"deciduous_forest"},
-		y_min = 1,
 		y_max = 31000,
+		y_min = 1,
 		schematic = minetest.get_modpath("default") .. "/schematics/aspen_tree.mts",
 		flags = "place_center_x, place_center_z",
 	})
@@ -1878,8 +1878,8 @@ function default.register_decorations()
 			persist = 0.66
 		},
 		biomes = {"deciduous_forest"},
-		y_min = 1,
 		y_max = 31000,
+		y_min = 1,
 		schematic = minetest.get_modpath("default") .. "/schematics/aspen_log.mts",
 		flags = "place_center_x",
 		rotation = "random",
@@ -1900,8 +1900,8 @@ function default.register_decorations()
 			persist = 0.6
 		},
 		biomes = {"desert"},
-		y_min = 5,
 		y_max = 31000,
+		y_min = 5,
 		schematic = minetest.get_modpath("default") .. "/schematics/large_cactus.mts",
 		flags = "place_center_x",
 		rotation = "random",
@@ -1922,8 +1922,8 @@ function default.register_decorations()
 			persist = 0.6
 		},
 		biomes = {"desert"},
-		y_min = 5,
 		y_max = 31000,
+		y_min = 5,
 		decoration = "default:cactus",
 		height = 2,
 		height_max = 5,
@@ -1944,8 +1944,8 @@ function default.register_decorations()
 			persist = 0.7
 		},
 		biomes = {"savanna_shore"},
-		y_min = 0,
 		y_max = 0,
+		y_min = 0,
 		schematic = minetest.get_modpath("default") .. "/schematics/papyrus.mts",
 	})
 
@@ -1965,8 +1965,8 @@ function default.register_decorations()
 		},
 		biomes = {"snowy_grassland", "grassland", "deciduous_forest",
 			"floatland_grassland"},
-		y_min = 1,
 		y_max = 31000,
+		y_min = 1,
 		schematic = minetest.get_modpath("default") .. "/schematics/bush.mts",
 		flags = "place_center_x, place_center_z",
 	})
@@ -1986,8 +1986,8 @@ function default.register_decorations()
 			persist = 0.7,
 		},
 		biomes = {"savanna"},
-		y_min = 1,
 		y_max = 31000,
+		y_min = 1,
 		schematic = minetest.get_modpath("default") .. "/schematics/acacia_bush.mts",
 		flags = "place_center_x, place_center_z",
 	})
@@ -2022,8 +2022,8 @@ function default.register_decorations()
 		sidelen = 16,
 		fill_ratio = 0.1,
 		biomes = {"rainforest"},
-		y_min = 1,
 		y_max = 31000,
+		y_min = 1,
 		decoration = "default:junglegrass",
 	})
 
@@ -2043,8 +2043,8 @@ function default.register_decorations()
 			persist = 0.6
 		},
 		biomes = {"desert", "sandstone_desert", "cold_desert"},
-		y_min = 2,
 		y_max = 31000,
+		y_min = 2,
 		decoration = "default:dry_shrub",
 		param2 = 4,
 	})
@@ -2065,8 +2065,8 @@ function default.register_decorations()
 			flags = "absvalue"
 		},
 		biomes = {"coniferous_forest_dunes", "grassland_dunes"},
-		y_min = 4,
 		y_max = 5,
+		y_min = 4,
 		decoration = {
 			"default:marram_grass_1",
 			"default:marram_grass_2",
@@ -2092,8 +2092,8 @@ function default.register_decorations()
 			"savanna_ocean",
 			"rainforest_ocean",
 		},
-		y_min = -8,
 		y_max = -2,
+		y_min = -8,
 		schematic = minetest.get_modpath("default") .. "/schematics/corals.mts",
 		flags = "place_center_x, place_center_z",
 		rotation = "random",
@@ -2122,8 +2122,8 @@ function default.register_decorations()
 			"deciduous_forest_ocean",
 			"sandstone_desert_ocean",
 			"cold_desert_ocean"},
-		y_min = -10,
 		y_max = -5,
+		y_min = -10,
 		flags = "force_placement",
 		decoration = "default:sand_with_kelp",
 		param2 = 48,

--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -646,7 +646,7 @@ function default.register_ores()
 		clust_scarcity = 12 * 12 * 12,
 		clust_num_ores = 4,
 		clust_size     = 3,
-		y_max          = 31000,
+		y_max          = -128,
 		y_min          = -255,
 	})
 

--- a/mods/fireflies/init.lua
+++ b/mods/fireflies/init.lua
@@ -144,8 +144,8 @@ minetest.register_decoration({
 		"rainforest",
 		"rainforest_swamp"
 	},
-	y_min = -1,
 	y_max = 31000,
+	y_min = -1,
 	decoration = "fireflies:firefly",
 })
 
@@ -166,7 +166,7 @@ minetest.register_decoration({
 		"rainforest",
 		"rainforest_swamp"
 	},
-	y_min = -1,
 	y_max = 31000,
+	y_min = -1,
 	decoration = "fireflies:firefly",
 })

--- a/mods/flowers/mapgen.lua
+++ b/mods/flowers/mapgen.lua
@@ -15,8 +15,8 @@ local function register_mgv6_flower(name)
 			octaves = 3,
 			persist = 0.6
 		},
-		y_min = 1,
 		y_max = 30,
+		y_min = 1,
 		decoration = "flowers:"..name,
 	})
 end
@@ -34,8 +34,8 @@ local function register_mgv6_mushroom(name)
 			octaves = 3,
 			persist = 0.6
 		},
-		y_min = 1,
 		y_max = 30,
+		y_min = 1,
 		decoration = "flowers:"..name,
 		spawn_by = "default:tree",
 		num_spawn_by = 1,
@@ -55,8 +55,8 @@ local function register_mgv6_waterlily()
 			octaves = 3,
 			persist = 0.7
 		},
-		y_min = 0,
 		y_max = 0,
+		y_min = 0,
 		schematic = minetest.get_modpath("flowers").."/schematics/waterlily.mts",
 		rotation = "random",
 	})
@@ -95,8 +95,8 @@ local function register_flower(seed, name)
 			persist = 0.6
 		},
 		biomes = {"grassland", "deciduous_forest", "floatland_grassland"},
-		y_min = 1,
 		y_max = 31000,
+		y_min = 1,
 		decoration = "flowers:"..name,
 	})
 end
@@ -115,8 +115,8 @@ local function register_mushroom(name)
 			persist = 0.66
 		},
 		biomes = {"deciduous_forest", "coniferous_forest"},
-		y_min = 1,
 		y_max = 31000,
+		y_min = 1,
 		decoration = "flowers:"..name,
 	})
 end
@@ -135,8 +135,8 @@ local function register_waterlily()
 			persist = 0.7
 		},
 		biomes = {"rainforest_swamp", "savanna_shore", "deciduous_forest_shore"},
-		y_min = 0,
 		y_max = 0,
+		y_min = 0,
 		schematic = minetest.get_modpath("flowers") .. "/schematics/waterlily.mts",
 		rotation = "random",
 	})


### PR DESCRIPTION
Very trivial change that doesn't affect anything, but y_max is literally above y_min, therefore it simply makes more sense to list them this way round. 
