### PR TITLE
Ores: Remove region overlaps. Make some regions deeper

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -542,17 +542,17 @@ function default.register_ores()
 		clust_num_ores = 8,
 		clust_size     = 3,
 		y_max          = 64,
-		y_min          = -31000,
+		y_min          = -127,
 	})
 
 	minetest.register_ore({
 		ore_type       = "scatter",
 		ore            = "default:stone_with_coal",
 		wherein        = "default:stone",
-		clust_scarcity = 24 * 24 * 24,
-		clust_num_ores = 27,
-		clust_size     = 6,
-		y_max          = 0,
+		clust_scarcity = 12 * 12 * 12,
+		clust_num_ores = 30,
+		clust_size     = 5,
+		y_max          = -128,
 		y_min          = -31000,
 	})
 
@@ -577,17 +577,17 @@ function default.register_ores()
 		clust_num_ores = 5,
 		clust_size     = 3,
 		y_max          = 0,
-		y_min          = -31000,
+		y_min          = -127,
 	})
 
 	minetest.register_ore({
 		ore_type       = "scatter",
 		ore            = "default:stone_with_iron",
 		wherein        = "default:stone",
-		clust_scarcity = 24 * 24 * 24,
-		clust_num_ores = 27,
-		clust_size     = 6,
-		y_max          = -64,
+		clust_scarcity = 12 * 12 * 12,
+		clust_num_ores = 29,
+		clust_size     = 5,
+		y_max          = -128,
 		y_min          = -31000,
 	})
 
@@ -611,8 +611,8 @@ function default.register_ores()
 		clust_scarcity = 13 * 13 * 13,
 		clust_num_ores = 4,
 		clust_size     = 3,
-		y_max          = -64,
-		y_min          = -127,
+		y_max          = -128,
+		y_min          = -255,
 	})
 
 	minetest.register_ore({
@@ -622,7 +622,7 @@ function default.register_ores()
 		clust_scarcity = 10 * 10 * 10,
 		clust_num_ores = 5,
 		clust_size     = 3,
-		y_max          = -128,
+		y_max          = -256,
 		y_min          = -31000,
 	})
 


### PR DESCRIPTION
#2047 rebased, no other changes.
/////////////////

Remove overlapping coal/iron ore regions for consistency with all
other ores.
In lower coal/iron regions increase number of clusters to compensate for
removed overlaps.
Decrease dimension of these clusters to better match the 'ores to cluster
volume' ratio of the small clusters.

Move density increase for coal and iron to y = -127.
Make tin deeper with region depths identical to copper.
////////////////

Mgv6 is not affected by this change.

Previously for both coal and iron:
The top region of small clusters continued down to world base, overlapping the deeper region of large clusters. This is from early MTG which had few ores, now we have many more making ore generation more intensive. This PR removes this overlap but preserves the ore density in the lower region by making the large clusters more common.
Removing the overlap will make ore generation a little less intensive.
The small clusters of the upper region is unchanged so this doesn't affect gameplay for beginners.

Previously the lower regions for coal and iron started at a much too easy y = 0 and y = -64, move the lower region down to start at y = -128.

Make tin deeper, since it is equivalent to copper in the progression of ores make the depths of its regions identical to copper: upper starts at y = -128, lower starts at y = -256.

This PR is therefore the second part of the 'make ores deeper' task started in #1813 In that PR i didn't alter coal and iron regions, so this PR does that.

The ore progression of value and depth is now (same line = same value/depth):

Coal, Iron
Tin, Copper
Gold
Diamond, Mese crystal
Mese block