### PR TITLE
Add dedicated mgv6 register_decoration for fireflies

### DIFF
--- a/mods/fireflies/init.lua
+++ b/mods/fireflies/init.lua
@@ -137,7 +137,7 @@ if minetest.get_mapgen_setting("mg_name") == "v6" then
 		sidelen = 80,
 		fill_ratio = 0.0002,
 		y_max = 31000,
-		y_min = -1,
+		y_min = 1,
 		decoration = "fireflies:firefly",
 	})
 
@@ -148,7 +148,7 @@ if minetest.get_mapgen_setting("mg_name") == "v6" then
 		sidelen = 80,
 		fill_ratio = 0.0002,
 		y_max = 31000,
-		y_min = -1,
+		y_min = 1,
 		decoration = "fireflies:firefly",
 	})
 

--- a/mods/fireflies/init.lua
+++ b/mods/fireflies/init.lua
@@ -127,46 +127,75 @@ minetest.register_craft( {
 
 
 -- register fireflies as decorations
-minetest.register_decoration({
-	deco_type = "simple",
-	place_on = {
-		"default:dirt_with_grass",
-		"default:dirt_with_coniferous_litter",
-		"default:dirt_with_rainforest_litter",
-		"default:dirt"
-	},
-	place_offset_y = 2,
-	sidelen = 80,
-	fill_ratio = 0.002,
-	biomes = {
-		"deciduous_forest",
-		"coniferous_forest",
-		"rainforest",
-		"rainforest_swamp"
-	},
-	y_max = 31000,
-	y_min = -1,
-	decoration = "fireflies:firefly",
-})
 
-minetest.register_decoration({
-	deco_type = "simple",
-	place_on = {
-		"default:dirt_with_grass",
-		"default:dirt_with_coniferous_litter",
-		"default:dirt_with_rainforest_litter",
-		"default:dirt"
-	},
-	place_offset_y = 3,
-	sidelen = 80,
-	fill_ratio = 0.002,
-	biomes = {
-		"deciduous_forest",
-		"coniferous_forest",
-		"rainforest",
-		"rainforest_swamp"
-	},
-	y_max = 31000,
-	y_min = -1,
-	decoration = "fireflies:firefly",
-})
+if minetest.get_mapgen_setting("mg_name") == "v6" then
+
+	minetest.register_decoration({
+		deco_type = "simple",
+		place_on = "default:dirt_with_grass",
+		place_offset_y = 2,
+		sidelen = 80,
+		fill_ratio = 0.0002,
+		y_max = 31000,
+		y_min = -1,
+		decoration = "fireflies:firefly",
+	})
+
+	minetest.register_decoration({
+		deco_type = "simple",
+		place_on = "default:dirt_with_grass",
+		place_offset_y = 3,
+		sidelen = 80,
+		fill_ratio = 0.0002,
+		y_max = 31000,
+		y_min = -1,
+		decoration = "fireflies:firefly",
+	})
+
+else
+
+	minetest.register_decoration({
+		deco_type = "simple",
+		place_on = {
+			"default:dirt_with_grass",
+			"default:dirt_with_coniferous_litter",
+			"default:dirt_with_rainforest_litter",
+			"default:dirt"
+		},
+		place_offset_y = 2,
+		sidelen = 80,
+		fill_ratio = 0.002,
+		biomes = {
+			"deciduous_forest",
+			"coniferous_forest",
+			"rainforest",
+			"rainforest_swamp"
+		},
+		y_max = 31000,
+		y_min = -1,
+		decoration = "fireflies:firefly",
+	})
+
+	minetest.register_decoration({
+		deco_type = "simple",
+		place_on = {
+			"default:dirt_with_grass",
+			"default:dirt_with_coniferous_litter",
+			"default:dirt_with_rainforest_litter",
+			"default:dirt"
+		},
+		place_offset_y = 3,
+		sidelen = 80,
+		fill_ratio = 0.002,
+		biomes = {
+			"deciduous_forest",
+			"coniferous_forest",
+			"rainforest",
+			"rainforest_swamp"
+		},
+		y_max = 31000,
+		y_min = -1,
+		decoration = "fireflies:firefly",
+	})
+
+end


### PR DESCRIPTION
Fixes #2059 by adding register_decoration just for mgv6 which doesn't include biomes, only places fireflies on dirt_with_grass and reduces fill_ratio. 

This gives fewer fireflies in one place when using mgv6, but since we can't limit them to specific biomes  I think this is preferable. 