### PR TITLE
Add food_* groups to default edibles

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -699,7 +699,7 @@ minetest.register_node("default:apple", {
 		fixed = {-3 / 16, -7 / 16, -3 / 16, 3 / 16, 4 / 16, 3 / 16}
 	},
 	groups = {fleshy = 3, dig_immediate = 3, flammable = 2,
-		leafdecay = 3, leafdecay_drop = 1},
+		leafdecay = 3, leafdecay_drop = 1, food_apple = 1},
 	on_use = minetest.item_eat(2),
 	sounds = default.node_sound_leaves_defaults(),
 

--- a/mods/farming/api.lua
+++ b/mods/farming/api.lua
@@ -330,7 +330,7 @@ farming.register_plant = function(name, def)
 	minetest.register_craftitem(":" .. mname .. ":" .. pname, {
 		description = pname:gsub("^%l", string.upper),
 		inventory_image = mname .. "_" .. pname .. ".png",
-		groups = {flammable = 2},
+		groups = def.groups or {flammable = 2},
 	})
 
 	-- Register growing steps

--- a/mods/farming/init.lua
+++ b/mods/farming/init.lua
@@ -21,12 +21,8 @@ farming.register_plant("farming:wheat", {
 	minlight = 13,
 	maxlight = default.LIGHT_MAX,
 	fertility = {"grassland"},
-	groups = {flammable = 4},
+	groups = {food_wheat = 1, flammable = 4},
 	place_param2 = 3,
-})
-
-minetest.override_item("farming:wheat", {
-	groups = {food_wheat = 1, flammable = 2},
 })
 
 minetest.register_craftitem("farming:flour", {

--- a/mods/farming/init.lua
+++ b/mods/farming/init.lua
@@ -25,17 +25,21 @@ farming.register_plant("farming:wheat", {
 	place_param2 = 3,
 })
 
+minetest.override_item("farming:wheat", {
+	groups = {food_wheat = 1, flammable = 2},
+})
+
 minetest.register_craftitem("farming:flour", {
 	description = "Flour",
 	inventory_image = "farming_flour.png",
-	groups = {flammable = 1},
+	groups = {food_flour = 1, flammable = 1},
 })
 
 minetest.register_craftitem("farming:bread", {
 	description = "Bread",
 	inventory_image = "farming_bread.png",
 	on_use = minetest.item_eat(5),
-	groups = {flammable = 2},
+	groups = {food_bread = 1, flammable = 2},
 })
 
 minetest.register_craft({

--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -212,7 +212,7 @@ minetest.register_node("flowers:mushroom_brown", {
 	sunlight_propagates = true,
 	walkable = false,
 	buildable_to = true,
-	groups = {snappy = 3, attached_node = 1, flammable = 1},
+	groups = {food_mushroom = 1, snappy = 3, attached_node = 1, flammable = 1},
 	sounds = default.node_sound_leaves_defaults(),
 	on_use = minetest.item_eat(1),
 	selection_box = {


### PR DESCRIPTION
This adds the food_* groups to edible items within default so that food crafting is easier within mods.