### PR TITLE
Farming: Deprecate bronze, mese and diamond hoes. Tune steel uses

### DIFF
--- a/mods/farming/api.lua
+++ b/mods/farming/api.lua
@@ -83,13 +83,6 @@ farming.register_hoe = function(name, def)
 	if def.inventory_image == nil then
 		def.inventory_image = "unknown_item.png"
 	end
-	if def.recipe == nil then
-		def.recipe = {
-			{"air","air",""},
-			{"","group:stick",""},
-			{"","group:stick",""}
-		}
-	end
 	if def.max_uses == nil then
 		def.max_uses = 30
 	end
@@ -104,12 +97,12 @@ farming.register_hoe = function(name, def)
 		sound = {breaks = "default_tool_breaks"},
 	})
 	-- Register its recipe
-	if def.material == nil then
+	if def.recipe then
 		minetest.register_craft({
 			output = name:sub(2),
 			recipe = def.recipe
 		})
-	else
+	elseif def.material then
 		minetest.register_craft({
 			output = name:sub(2),
 			recipe = {

--- a/mods/farming/hoes.lua
+++ b/mods/farming/hoes.lua
@@ -16,27 +16,32 @@ farming.register_hoe(":farming:hoe_stone", {
 farming.register_hoe(":farming:hoe_steel", {
 	description = "Steel Hoe",
 	inventory_image = "farming_tool_steelhoe.png",
-	max_uses = 200,
+	max_uses = 500,
 	material = "default:steel_ingot"
 })
+
+-- The following are deprecated by removing the 'material' field to prevent
+-- crafting and removing from creative inventory, to cause them to eventually
+-- disappear from worlds. The registrations should be removed in a future
+-- release.
 
 farming.register_hoe(":farming:hoe_bronze", {
 	description = "Bronze Hoe",
 	inventory_image = "farming_tool_bronzehoe.png",
 	max_uses = 220,
-	material = "default:bronze_ingot"
+	groups = {not_in_creative_inventory = 1},
 })
 
 farming.register_hoe(":farming:hoe_mese", {
 	description = "Mese Hoe",
 	inventory_image = "farming_tool_mesehoe.png",
 	max_uses = 350,
-	material = "default:mese_crystal"
+	groups = {not_in_creative_inventory = 1},
 })
 
 farming.register_hoe(":farming:hoe_diamond", {
 	description = "Diamond Hoe",
 	inventory_image = "farming_tool_diamondhoe.png",
 	max_uses = 500,
-	material = "default:diamond"
+	groups = {not_in_creative_inventory = 1},
 })


### PR DESCRIPTION
Attends to #1252 and partially attends to #1681 
Simpifies the long-criticised excessive number of hoe tiers.

"The following are deprecated by removing the 'material' field to prevent
crafting and removing from creative inventory, to cause them to eventually
disappear from worlds. The registrations should be removed in a future
release."

Gives steel hoes 500 uses, equal to previous diamond hoes, to compensate for the extra work needed to create a steel hoe. This attends to the issue of more valuable materials not being worth using #1252 

Hoes are fairly insignificant so i doubt there will be much mod breakage (if mods rely on certain hoes in recipes). There is, amazingly, an API for registering hoes so it's easy for mods to register what they want.
If merged i will add a news thread to the forum to warn of the change.