### PR TITLE
Ore distribution: Deeper iron, diamond and mese block, tune gold 

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -576,7 +576,7 @@ function default.register_ores()
 		clust_scarcity = 7 * 7 * 7,
 		clust_num_ores = 5,
 		clust_size     = 3,
-		y_max          = 0,
+		y_max          = -64,
 		y_min          = -127,
 	})
 
@@ -682,7 +682,7 @@ function default.register_ores()
 		clust_num_ores = 3,
 		clust_size     = 2,
 		y_max          = -256,
-		y_min          = -1023,
+		y_min          = -511,
 	})
 
 	minetest.register_ore({
@@ -692,42 +692,7 @@ function default.register_ores()
 		clust_scarcity = 13 * 13 * 13,
 		clust_num_ores = 5,
 		clust_size     = 3,
-		y_max          = -1024,
-		y_min          = -31000,
-	})
-
-	-- Diamond
-
-	minetest.register_ore({
-		ore_type       = "scatter",
-		ore            = "default:stone_with_diamond",
-		wherein        = "default:stone",
-		clust_scarcity = 15 * 15 * 15,
-		clust_num_ores = 4,
-		clust_size     = 3,
-		y_max          = 31000,
-		y_min          = 1025,
-	})
-
-	minetest.register_ore({
-		ore_type       = "scatter",
-		ore            = "default:stone_with_diamond",
-		wherein        = "default:stone",
-		clust_scarcity = 17 * 17 * 17,
-		clust_num_ores = 4,
-		clust_size     = 3,
 		y_max          = -512,
-		y_min          = -1023,
-	})
-
-	minetest.register_ore({
-		ore_type       = "scatter",
-		ore            = "default:stone_with_diamond",
-		wherein        = "default:stone",
-		clust_scarcity = 15 * 15 * 15,
-		clust_num_ores = 4,
-		clust_size     = 3,
-		y_max          = -1024,
 		y_min          = -31000,
 	})
 
@@ -766,6 +731,41 @@ function default.register_ores()
 		y_min          = -31000,
 	})
 
+	-- Diamond
+
+	minetest.register_ore({
+		ore_type       = "scatter",
+		ore            = "default:stone_with_diamond",
+		wherein        = "default:stone",
+		clust_scarcity = 15 * 15 * 15,
+		clust_num_ores = 4,
+		clust_size     = 3,
+		y_max          = 31000,
+		y_min          = 1025,
+	})
+
+	minetest.register_ore({
+		ore_type       = "scatter",
+		ore            = "default:stone_with_diamond",
+		wherein        = "default:stone",
+		clust_scarcity = 17 * 17 * 17,
+		clust_num_ores = 4,
+		clust_size     = 3,
+		y_max          = -1024,
+		y_min          = -2047,
+	})
+
+	minetest.register_ore({
+		ore_type       = "scatter",
+		ore            = "default:stone_with_diamond",
+		wherein        = "default:stone",
+		clust_scarcity = 15 * 15 * 15,
+		clust_num_ores = 4,
+		clust_size     = 3,
+		y_max          = -2048,
+		y_min          = -31000,
+	})
+
 	-- Mese block
 
 	minetest.register_ore({
@@ -786,8 +786,8 @@ function default.register_ores()
 		clust_scarcity = 36 * 36 * 36,
 		clust_num_ores = 3,
 		clust_size     = 2,
-		y_max          = -1024,
-		y_min          = -2047,
+		y_max          = -2048,
+		y_min          = -4095,
 	})
 
 	minetest.register_ore({
@@ -797,7 +797,7 @@ function default.register_ores()
 		clust_scarcity = 28 * 28 * 28,
 		clust_num_ores = 5,
 		clust_size     = 3,
-		y_max          = -2048,
+		y_max          = -4096,
 		y_min          = -31000,
 	})
 end


### PR DESCRIPTION
Affects non-mgv6 mapgens only.

Relevant to #1168 and #1681
Makes progression less ridiculously easy while also encouraging digging deeper.
Compensates for the 3D noise tunnels which make vertical travel easier.

Iron at y = 0 was far too easy to find.
Adjust gold lower region to be twice the depth of highest level, like
all other ores.
Diamond at y = -500 was too easy to progress to.
Make diamond and mese block deeper to create a depth progression from
mese crystal to diamond, to reflect tool progression.
This all creates a satisfying 2^n depth progression, with lower regions
being at twice the depth of highest levels.

The new depths are:

Ore. Highest. Density increase
Coal 64 -128
Iron -64 -128
Tin -128 -256
Copper -128 -256
Gold -256 -512
Mese crystal -512 -1024
Diamond -1024 -2048
Mese block -2048 -4096

Apart from the special case of coal, the depths progress as 2^n numbers doubling per value level of ore:
Iron -64
Tin, Copper (for bronze) -128
Gold -256
Mese crystal -512
Diamond -1024
Mese block -2048

The y of density increase is now double these depths for each.

Another advantage to not having iron at y = 0 is that the depths of iron->steel and tin/copper->bronze could be reversed in future to represent steel tools being more valuable than bronze tools, as they should be (but are not). This would have to wait for steel tools to be made more capable than bronze tools, as they should be (but are not).