### PR TITLE
Use stratum ore to add the missing sandstone types

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -422,8 +422,15 @@ function default.register_ores()
 		ore             = "default:silver_sandstone",
 		wherein         = {"default:stone"},
 		clust_scarcity  = 1,
-		y_max           = 31,
-		y_min           = 28,
+		y_max           = 46,
+		y_min           = 10,
+		noise_params    = {
+			offset = 28,
+			scale = 16,
+			spread = {x = 128, y = 128, z = 128},
+			seed = 90122,
+			octaves = 1,
+		},
 		stratum_thickness = 4,
 		biomes = {"cold_desert"},
 	})
@@ -433,23 +440,17 @@ function default.register_ores()
 		ore             = "default:silver_sandstone",
 		wherein         = {"default:stone"},
 		clust_scarcity  = 1,
-		y_max           = 25,
-		y_min           = 24,
+		y_max           = 42,
+		y_min           = 6,
+		noise_params    = {
+			offset = 24,
+			scale = 16,
+			spread = {x = 128, y = 128, z = 128},
+			seed = 90122,
+			octaves = 1,
+		},
 		stratum_thickness = 2,
 		biomes = {"cold_desert"},
-	})
-
-	-- Sandstone
-
-	minetest.register_ore({
-		ore_type        = "stratum",
-		ore             = "default:sandstone",
-		wherein         = {"default:desert_stone"},
-		clust_scarcity  = 1,
-		y_max           = 25,
-		y_min           = 24,
-		stratum_thickness = 2,
-		biomes = {"desert"},
 	})
 
 	-- Desert sandstone
@@ -459,8 +460,15 @@ function default.register_ores()
 		ore             = "default:desert_sandstone",
 		wherein         = {"default:desert_stone"},
 		clust_scarcity  = 1,
-		y_max           = 35,
-		y_min           = 32,
+		y_max           = 46,
+		y_min           = 10,
+		noise_params    = {
+			offset = 28,
+			scale = 16,
+			spread = {x = 128, y = 128, z = 128},
+			seed = 90122,
+			octaves = 1,
+		},
 		stratum_thickness = 4,
 		biomes = {"desert"},
 	})
@@ -470,8 +478,35 @@ function default.register_ores()
 		ore             = "default:desert_sandstone",
 		wherein         = {"default:desert_stone"},
 		clust_scarcity  = 1,
-		y_max           = 29,
-		y_min           = 28,
+		y_max           = 42,
+		y_min           = 6,
+		noise_params    = {
+			offset = 24,
+			scale = 16,
+			spread = {x = 128, y = 128, z = 128},
+			seed = 90122,
+			octaves = 1,
+		},
+		stratum_thickness = 2,
+		biomes = {"desert"},
+	})
+
+	-- Sandstone
+
+	minetest.register_ore({
+		ore_type        = "stratum",
+		ore             = "default:sandstone",
+		wherein         = {"default:desert_stone"},
+		clust_scarcity  = 1,
+		y_max           = 39,
+		y_min           = 3,
+		noise_params    = {
+			offset = 21,
+			scale = 16,
+			spread = {x = 128, y = 128, z = 128},
+			seed = 90122,
+			octaves = 1,
+		},
 		stratum_thickness = 2,
 		biomes = {"desert"},
 	})

--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -412,11 +412,74 @@ end
 
 function default.register_ores()
 
-	-- Blob ore
-	-- These first to avoid other ores in blobs
+	-- Stratum ores.
+	-- These obviously first.
+
+	-- Silver sandstone
+
+	minetest.register_ore({
+		ore_type        = "stratum",
+		ore             = "default:silver_sandstone",
+		wherein         = {"default:stone"},
+		clust_scarcity  = 1,
+		y_max           = 31,
+		y_min           = 28,
+		stratum_thickness = 4,
+		biomes = {"cold_desert"},
+	})
+
+	minetest.register_ore({
+		ore_type        = "stratum",
+		ore             = "default:silver_sandstone",
+		wherein         = {"default:stone"},
+		clust_scarcity  = 1,
+		y_max           = 25,
+		y_min           = 24,
+		stratum_thickness = 2,
+		biomes = {"cold_desert"},
+	})
+
+	-- Sandstone
+
+	minetest.register_ore({
+		ore_type        = "stratum",
+		ore             = "default:sandstone",
+		wherein         = {"default:desert_stone"},
+		clust_scarcity  = 1,
+		y_max           = 25,
+		y_min           = 24,
+		stratum_thickness = 2,
+		biomes = {"desert"},
+	})
+
+	-- Desert sandstone
+
+	minetest.register_ore({
+		ore_type        = "stratum",
+		ore             = "default:desert_sandstone",
+		wherein         = {"default:desert_stone"},
+		clust_scarcity  = 1,
+		y_max           = 35,
+		y_min           = 32,
+		stratum_thickness = 4,
+		biomes = {"desert"},
+	})
+
+	minetest.register_ore({
+		ore_type        = "stratum",
+		ore             = "default:desert_sandstone",
+		wherein         = {"default:desert_stone"},
+		clust_scarcity  = 1,
+		y_max           = 29,
+		y_min           = 28,
+		stratum_thickness = 2,
+		biomes = {"desert"},
+	})
+
+	-- Blob ore.
+	-- These before scatter ores to avoid other ores in blobs.
 
 	-- Clay
-	-- This first to avoid clay in sand blobs
 
 	minetest.register_ore({
 		ore_type        = "blob",


### PR DESCRIPTION
Add silver sandstone strata to cold desert.
Add sandstone and desert_sandstone strata to desert.
///////////////////

![screenshot_20180423_062755](https://user-images.githubusercontent.com/3686677/39108313-84b5d988-46bf-11e8-8b86-b94f1e096239.png)

![screenshot_20180423_060417](https://user-images.githubusercontent.com/3686677/39107867-06f73d4a-46bd-11e8-8478-2968e836ad30.png)

New version of #1998 
+-16 nodes of gentle undulation over a scale of 256 nodes.
I have minimised noise calculations by making sure this ore generation only happens in the surface layer of mapchunks (-32 to 47) instead of in 2 layers of mapchunks.
The strata appear from y = 3 to y = 46.
Profiling details below.