### PR TITLE
Enable regrowth of apples

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -741,7 +741,7 @@ minetest.register_node("default:apple", {
 	after_dig_node = function(pos, oldnode, oldmetadata, digger)
 		if oldnode.param2 == 0 then
 			minetest.set_node(pos, {name = "default:apple_mark"})
-			minetest.get_node_timer(pos):start(math.random(2400, 4800))
+			minetest.get_node_timer(pos):start(math.random(300, 1500))
 		end
 	end,
 })
@@ -761,7 +761,7 @@ minetest.register_node("default:apple_mark", {
 		if not minetest.find_node_near(pos, 1, "default:leaves") then
 			minetest.remove_node(pos)
 		elseif minetest.get_node_light(pos) < 13 then
-			minetest.get_node_timer(pos):start(300)
+			minetest.get_node_timer(pos):start(200)
 		else
 			minetest.set_node(pos, {name = "default:apple"})
 		end

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -760,7 +760,7 @@ minetest.register_node("default:apple_mark", {
 	on_timer = function(pos, elapsed)
 		if not minetest.find_node_near(pos, 1, "default:leaves") then
 			minetest.remove_node(pos)
-		elseif minetest.get_node_light(pos) < 13 then
+		elseif minetest.get_node_light(pos) < 11 then
 			minetest.get_node_timer(pos):start(200)
 		else
 			minetest.set_node(pos, {name = "default:apple"})

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -737,6 +737,35 @@ minetest.register_node("default:apple", {
 	after_place_node = function(pos, placer, itemstack)
 		minetest.set_node(pos, {name = "default:apple", param2 = 1})
 	end,
+
+	after_dig_node = function(pos, oldnode, oldmetadata, digger)
+		if oldnode.param2 == 0 then
+			minetest.set_node(pos, {name = "default:apple_mark"})
+			minetest.get_node_timer(pos):start(math.random(2400, 4800))
+		end
+	end,
+})
+
+minetest.register_node("default:apple_mark", {
+	description = "Apple Marker",
+	drawtype = "airlike",
+	paramtype = "light",
+	sunlight_propagates = true,
+	walkable = false,
+	pointable = false,
+	diggable = false,
+	buildable_to = true,
+	drop = "",
+	groups = {not_in_creative_inventory = 1},
+	on_timer = function(pos, elapsed)
+		if not minetest.find_node_near(pos, 1, "default:leaves") then
+			minetest.remove_node(pos)
+		elseif minetest.get_node_light(pos) < 13 then
+			minetest.get_node_timer(pos):start(300)
+		else
+			minetest.set_node(pos, {name = "default:apple"})
+		end
+	end
 })
 
 


### PR DESCRIPTION
Makes new apples grow after players remove the original ones from trees.

- Apples only regrow where they first appear on trees, either on mapgen or when grown from saplings (meaning apples that were placed by players won't regrow).
- Once the tree is cut down in full (leaves removed), regrowth will stop.
- New apples only grow in daylight, and take at least two days to grow.