### PR TITLE
disallow beds destroying if used

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -42,6 +42,7 @@ Beds API
 		def            -- See [#Bed definition]
 	)
 
+ * `beds.can_dig(bed_pos)` Returns a boolean whether the bed at `bed_pos` may be dug
  * `beds.read_spawns() `   Returns a table containing players respawn positions
  * `beds.kick_players()`  Forces all players to leave bed
  * `beds.skip_night()`   Sets world time to morning and saves respawn position of all players currently sleeping

--- a/mods/beds/api.lua
+++ b/mods/beds/api.lua
@@ -141,6 +141,9 @@ function beds.register_bed(name, def)
 			minetest.set_node(newp, {name = name .. "_top", param2 = new_param2})
 			return true
 		end,
+		can_dig = function(pos, player)
+			return beds.can_dig(pos)
+		end,
 	})
 
 	minetest.register_node(name .. "_top", {
@@ -159,6 +162,12 @@ function beds.register_bed(name, def)
 		},
 		on_destruct = function(pos)
 			destruct_bed(pos, 2)
+		end,
+		can_dig = function(pos, player)
+			local node = minetest.get_node(pos)
+			local dir = minetest.facedir_to_dir(node.param2)
+			local p = vector.add(pos, dir)
+			return beds.can_dig(p)
 		end,
 	})
 

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -61,6 +61,7 @@ local function lay_down(player, pos, bed_pos, state, skip)
 		local p = beds.pos[name] or nil
 		if beds.player[name] ~= nil then
 			beds.player[name] = nil
+			beds.bed_position[name] = nil
 			player_in_bed = player_in_bed - 1
 		end
 		-- skip here to prevent sending player specific changes (used for leaving players)
@@ -83,6 +84,7 @@ local function lay_down(player, pos, bed_pos, state, skip)
 	else
 		beds.player[name] = 1
 		beds.pos[name] = pos
+		beds.bed_position[name] = bed_pos
 		player_in_bed = player_in_bed + 1
 
 		-- physics, eye_offset, etc
@@ -175,16 +177,9 @@ function beds.on_rightclick(pos, player)
 end
 
 function beds.can_dig(bed_pos, player)
-	-- Calculate expected player position
-	local _, param2 = get_look_yaw(bed_pos)
-	local dir = minetest.facedir_to_dir(param2)
-	local p = {x = bed_pos.x + dir.x / 2, y = bed_pos.y, z = bed_pos.z + dir.z / 2}
-
 	-- Check all players in bed which one is at the expected position
-	for playername, _ in pairs(beds.player) do
-		local bed_player = minetest.get_player_by_name(playername)
-		local bed_player_pos = bed_player:get_pos()
-		if vector.distance(p, bed_player_pos) < 0.1 then
+	for _, player_bed_pos in pairs(beds.bed_position) do
+		if vector.equals(bed_pos, player_bed_pos) then
 			return false
 		end
 	end

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -174,6 +174,14 @@ function beds.on_rightclick(pos, player)
 	end
 end
 
+function beds.can_dig(pos, player)
+	for _, used_pos in pairs(beds.pos) do
+		if vector.equals(pos, used_pos) then
+			return false
+		end
+	end
+	return true
+end
 
 -- Callbacks
 -- Only register respawn callback if respawn enabled

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -174,9 +174,17 @@ function beds.on_rightclick(pos, player)
 	end
 end
 
-function beds.can_dig(pos, player)
-	for _, used_pos in pairs(beds.pos) do
-		if vector.equals(pos, used_pos) then
+function beds.can_dig(bed_pos, player)
+	-- Calculate expected player position
+	local _, param2 = get_look_yaw(bed_pos)
+	local dir = minetest.facedir_to_dir(param2)
+	local p = {x = bed_pos.x + dir.x / 2, y = bed_pos.y, z = bed_pos.z + dir.z / 2}
+
+	-- Check all players in bed which one is at the expected position
+	for playername, _ in pairs(beds.player) do
+		local bed_player = minetest.get_player_by_name(playername)
+		local bed_player_pos = bed_player:get_pos()
+		if vector.distance(p, bed_player_pos) < 0.1 then
 			return false
 		end
 	end

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -176,7 +176,7 @@ function beds.on_rightclick(pos, player)
 	end
 end
 
-function beds.can_dig(bed_pos, player)
+function beds.can_dig(bed_pos)
 	-- Check all players in bed which one is at the expected position
 	for _, player_bed_pos in pairs(beds.bed_position) do
 		if vector.equals(bed_pos, player_bed_pos) then

--- a/mods/beds/init.lua
+++ b/mods/beds/init.lua
@@ -1,5 +1,6 @@
 beds = {}
 beds.player = {}
+beds.bed_position = {}
 beds.pos = {}
 beds.spawn = {}
 


### PR DESCRIPTION
fix for #836 
Same behaviour like for chest or furnances, dissallow destroying if in use