### PR TITLE
Snow: Make players sink in by 3/16 node

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -581,6 +581,12 @@ minetest.register_node("default:snow", {
 			{-0.5, -0.5, -0.5, 0.5, -0.25, 0.5},
 		},
 	},
+	collision_box = {
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, -7 / 16, 0.5},
+		},
+	},
 	groups = {crumbly = 3, falling_node = 1, puts_out_fire = 1, snowy = 1},
 	sounds = default.node_sound_snow_defaults(),
 


### PR DESCRIPTION
![screenshot_20180530_215337](https://user-images.githubusercontent.com/3686677/40747292-bf02f56e-6454-11e8-8f5d-abb1d3cbd4c4.png)

For part of #2132 
A custom collision box is used to sink a player while still triggering the correct footstep sound.
Players sink 3/4 of the way through a snow slab (3 texture pixels with 16px textures).
Looks cute having player's feet sunk into snow.
dirt_with_snow is considered to be a very thin layer of snow on a solid dirt node so is left unchanged.