### PR TITLE
Settings: Add missing settings to settingtypes.txt 

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -8,10 +8,10 @@
 #creative_mode = false
 
 # Sets the behaviour of the inventory items when a player dies.
-#  "bones": Store items in a bone node but drop items if inside protected area.
-#  "drop": Drop items on the ground.
-#  "keep": Player keeps items.
-#bones_mode = "bones"
+#   bones: Store items in a bone node but drop items if inside protected area.
+#   drop: Drop items on the ground.
+#   keep: Player keeps items.
+#bones_mode = bones
 
 # The time in seconds after which the bones of a dead player can be looted by
 # everyone.

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -39,10 +39,21 @@ enable_tnt (TNT) bool true
 #    The radius in which nodes will be destroyed by a TNT explosion.
 tnt_radius (TNT radius) int 3 0
 
+#    Sets the behaviour of the inventory items when a player dies.
+#    bones: Store items in a bone node but drop items if inside protected area.
+#    drop: Drop items on the ground.
+#    keep: Player keeps items.
+bones_mode (Bones mode) enum bones bones,drop,keep
+
 #    The time in seconds after which the bones of a dead player can be looted
 #    by everyone.
 #    Setting this to 0 will disable sharing of bones completely.
-share_bones_time (Bone share time) int 1200 0
+share_bones_time (Bones share time) int 1200 0
+
+#    How much earlier the bones of a dead player can be looted by
+#    everyone if the player dies in a protected area they don't own.
+#    0 to disable. By default it is "share_bones_time" divide by four.
+share_bones_time_early (Earlier bones share time) int 300 0
 
 #    Inform player of condition and location of new bones.
 bones_position_message (Inform player about bones) bool false


### PR DESCRIPTION
Conf.example: Remove quotes from bones modes. Setting does not work
if quotes are used.
///////////////////

Didn't add the 'give initial stuff' list as suspect it would not work.