### PR TITLE
Boats: Add cruise mode (autoforward)

### DIFF
--- a/mods/boats/README.txt
+++ b/mods/boats/README.txt
@@ -13,3 +13,19 @@ Textures: Zeg9 (CC BY-SA 3.0)
 Model: thetoon and Zeg9 (CC BY-SA 3.0),
   modified by PavelS(SokolovPavel) (CC BY-SA 3.0),
   modified by sofar (CC BY-SA 3.0)
+
+Controls
+--------
+Right mouse button = Enter or exit boat when pointing at boat.
+Forward            = Speed up.
+                     Slow down when moving backwards.
+Forward + backward = Enable cruise mode: Boat will accelerate to maximum forward
+                     speed and remain at that speed without needing to hold the
+                     forward key.
+Backward           = Slow down.
+                     Speed up when moving backwards.
+                     Disable cruise mode.
+Left               = Turn to the left.
+                     Turn to the right when moving backwards.
+Right              = Turn to the right.
+                     Turn to the left when moving backwards.


### PR DESCRIPTION
I was disappointed to discover that player autoforward does not work for boats. The feature would be useful for avoiding finger stress on long water journeys.

I tried implementing this by detecting the 'continuous forward' setting but couldn't make it work. However that required frequent 'getting' of the setting, using the forward and backward controls is simpler, more lightweight and the keys are under the fingers so this is more comfortable than using the autoforward key. Many players do not have autoforward bound to a key anyway (it is not bound by default).

Press forward and backward simultaneously to switch cruise on (full speed). This is best done by first holding forward to accelerate and while holding that key press backward.
Press backward to switch cruise off.
Cruise is automatically switched off when exiting the boat to avoid runaway boats.
Chat messages are sent to the driver for feedback.

I have also removed the early-initialised 'yaw' variable and used 'get yaw' only if needed and as close as possible to 'set yaw', this helps to make turning a little smoother.