### PR TITLE
Flora spread: Reduce maximum density

### DIFF
--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -139,12 +139,9 @@ function flowers.flower_spread(pos, node)
 
 	local pos0 = vector.subtract(pos, 4)
 	local pos1 = vector.add(pos, 4)
-	-- Maximum flower density created by mapgen is 13 per 9x9 area.
-	-- The limit of 7 below was tuned by in-game testing to result in a maximum
-	-- flower density by ABM spread of 13 per 9x9 area.
-	-- Warning: Setting this limit theoretically without in-game testing
-	-- results in a maximum flower density by ABM spread that is far too high.
-	if #minetest.find_nodes_in_area(pos0, pos1, "group:flora") > 7 then
+	-- Testing shows that a threshold of 3 results in an appropriate maximum
+	-- density of approximately 7 flora per 9x9 area.
+	if #minetest.find_nodes_in_area(pos0, pos1, "group:flora") > 3 then
 		return
 	end
 


### PR DESCRIPTION
Flora spread: Reduce maximum density

Previously, maximum flora density was chosen based on the extremely rare
occurrence of all 8 flowers being at high density at one location. This
caused flora everywhere to spread to an unacceptably high density.

Revert the threshold to 3, which in testing results in a more acceptable
maximum density of 7 flora per 9x9 area.
//////////////////////

Closes #2177 

Absolute maximum possible flower density created by mapgen is 13 per 9x9 area, but that is very rare so half that for a more likely maximum density.
The threshold value is reverted to 3 as it was originally, but because we now add 3 flora at a time the maximum density becomes 3 + 3 = 6 per 9x9 area.
However, because the value is reverted to 3, areas that have previously reached a steady state with no further spread will remain that way until some flora are removed, minimising changes to existing worlds.