### PR TITLE
Player_api: Give laying players a low selection/collisionbox

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -412,6 +412,9 @@ The player API can register player models and update the player's appearence
 	* Any of the fields of the returned table may be nil.
 	* player: PlayerRef
 
+* `player_api.reset_box(player)`
+	* Resets player collisionbox to the stand/walk/mine collisionbox.
+
 ### Model Definition
 
 	{

--- a/game_api.txt
+++ b/game_api.txt
@@ -376,8 +376,8 @@ Give Initial Stuff API
 ^ Adds items to the list of items to be given
 
 
-Players API
------------
+Player API
+----------
 
 The player API can register player models and update the player's appearence
 
@@ -425,6 +425,9 @@ The player API can register player models and update the player's appearence
 		-- ...
 		},
 		collisionbox = {-0.3, 0.0, -0.3, 0.3, 1.7, 0.3}, -- In nodes from feet position
+		-- A low and wide collision box for a dead or laying player.
+		-- In nodes from centrepoint of model underside.
+		collisionbox_lay = {-0.6, 0.0, -0.6, 0.6, 0.3, 0.6},
 		stepheight = 0.6, -- In nodes
 		eye_height = 1.47, -- In nodes above feet position
 	}

--- a/mods/player_api/api.lua
+++ b/mods/player_api/api.lua
@@ -64,15 +64,6 @@ function player_api.set_model(player, model_name)
 	player_model[name] = model_name
 end
 
-function player_api.reset_boxes(player, model_name)
-	local model = models[model_name]
-	if model then
-		player:set_properties({
-			collisionbox = model.collisionbox or model_collisionbox_default,
-		})
-	end
-end
-
 function player_api.set_textures(player, textures)
 	local name = player:get_player_name()
 	local model = models[player_model[name]]
@@ -93,6 +84,15 @@ function player_api.set_animation(player, anim_name, speed)
 	local anim = model.animations[anim_name]
 	player_anim[name] = anim_name
 	player:set_animation(anim, speed or model.animation_speed, animation_blend)
+end
+
+function player_api.reset_box(player)
+	local model = player_model[player:get_player_name()]
+	if model then
+		player:set_properties({
+			collisionbox = model.collisionbox or model_collisionbox_default,
+		})
+	end
 end
 
 minetest.register_on_leaveplayer(function(player)

--- a/mods/player_api/api.lua
+++ b/mods/player_api/api.lua
@@ -7,6 +7,8 @@ player_api = {}
 -- Note: This is currently broken due to a bug in Irrlicht, leave at 0
 local animation_blend = 0
 
+local model_collisionbox_default = {-0.3, 0.0, -0.3, 0.3, 1.7, 0.3}
+
 player_api.registered_models = { }
 
 -- Local for speed.
@@ -45,7 +47,7 @@ function player_api.set_model(player, model_name)
 			textures = player_textures[name] or model.textures,
 			visual = "mesh",
 			visual_size = model.visual_size or {x = 1, y = 1},
-			collisionbox = model.collisionbox or {-0.3, 0.0, -0.3, 0.3, 1.7, 0.3},
+			collisionbox = model.collisionbox or model_collisionbox_default,
 			stepheight = model.stepheight or 0.6,
 			eye_height = model.eye_height or 1.47,
 		})
@@ -60,6 +62,15 @@ function player_api.set_model(player, model_name)
 		})
 	end
 	player_model[name] = model_name
+end
+
+function player_api.reset_boxes(player, model_name)
+	local model = models[model_name]
+	if model then
+		player:set_properties({
+			collisionbox = model.collisionbox or model_collisionbox_default,
+		})
+	end
 end
 
 function player_api.set_textures(player, textures)
@@ -119,6 +130,10 @@ minetest.register_globalstep(function(dtime)
 			-- Apply animations based on what the player is doing
 			if player:get_hp() == 0 then
 				player_set_animation(player, "lay")
+				player:set_properties({
+					collisionbox = model.collisionbox_lay or
+						{-0.6, 0.0, -0.6, 0.6, 0.3, 0.6},
+				})
 			elseif walking then
 				if player_sneak[name] ~= controls.sneak then
 					player_anim[name] = nil

--- a/mods/player_api/init.lua
+++ b/mods/player_api/init.lua
@@ -34,7 +34,7 @@ minetest.register_on_joinplayer(function(player)
 	player:hud_set_hotbar_selected_image("gui_hotbar_selected.png")
 end)
 
--- Reset collision and selection boxes to be upright on player respawn
+-- Reset collisionbox to be upright on player respawn
 minetest.register_on_respawnplayer(function(player)
-	player_api.reset_boxes(player, "character.b3d")
+	player_api.reset_box(player)
 end)

--- a/mods/player_api/init.lua
+++ b/mods/player_api/init.lua
@@ -14,6 +14,7 @@ player_api.register_model("character.b3d", {
 		sit       = {x = 81,  y = 160},
 	},
 	collisionbox = {-0.3, 0.0, -0.3, 0.3, 1.7, 0.3},
+	collisionbox_lay = {-0.6, 0.0, -0.6, 0.6, 0.3, 0.6},
 	stepheight = 0.6,
 	eye_height = 1.47,
 })
@@ -31,4 +32,9 @@ minetest.register_on_joinplayer(function(player)
 	)
 	player:hud_set_hotbar_image("gui_hotbar.png")
 	player:hud_set_hotbar_selected_image("gui_hotbar_selected.png")
+end)
+
+-- Reset collision and selection boxes to be upright on player respawn
+minetest.register_on_respawnplayer(function(player)
+	player_api.reset_boxes(player, "character.b3d")
 end)


### PR DESCRIPTION
![screenshot_20180724_160334](https://user-images.githubusercontent.com/3686677/43147706-8cf19b48-8f5b-11e8-967d-58aa9a974c2d.png)

^ Killing player

![screenshot_20180724_160354](https://user-images.githubusercontent.com/3686677/43147724-96074a5c-8f5b-11e8-982c-981b75e0ded0.png)

^ Dead

![screenshot_20180724_160435](https://user-images.githubusercontent.com/3686677/43147744-a1dc0c1e-8f5b-11e8-9075-e41b57018736.png)

^ Boxes are sized to diagonally laying player to not be excessively large, quite a nice fit

![screenshot_20180724_160502](https://user-images.githubusercontent.com/3686677/43147775-bedb04b4-8f5b-11e8-99c0-840d61b952e1.png)

^ Dead player respawns, boxes reset

Attends to https://github.com/minetest/minetest/issues/7510