### PR TITLE
Pass texture table to wall.register function.

### DIFF
--- a/mods/walls/init.lua
+++ b/mods/walls/init.lua
@@ -1,6 +1,6 @@
 walls = {}
 
-walls.register = function(wall_name, wall_desc, wall_texture, wall_mat, wall_sounds)
+walls.register = function(wall_name, wall_desc, wall_texture_table, wall_mat, wall_sounds)
 	-- inventory node, and pole-type wall start item
 	minetest.register_node(wall_name, {
 		description = wall_desc,
@@ -17,7 +17,7 @@ walls.register = function(wall_name, wall_desc, wall_texture, wall_mat, wall_sou
 		connects_to = { "group:wall", "group:stone", "group:fence" },
 		paramtype = "light",
 		is_ground_content = false,
-		tiles = { wall_texture, },
+		tiles = wall_texture_table,
 		walkable = true,
 		groups = { cracky = 3, wall = 1, stone = 2 },
 		sounds = wall_sounds,
@@ -35,12 +35,12 @@ walls.register = function(wall_name, wall_desc, wall_texture, wall_mat, wall_sou
 
 end
 
-walls.register("walls:cobble", "Cobblestone Wall", "default_cobble.png",
+walls.register("walls:cobble", "Cobblestone Wall", {"default_cobble.png"},
 		"default:cobble", default.node_sound_stone_defaults())
 
-walls.register("walls:mossycobble", "Mossy Cobblestone Wall", "default_mossycobble.png",
+walls.register("walls:mossycobble", "Mossy Cobblestone Wall", {"default_mossycobble.png"},
 		"default:mossycobble", default.node_sound_stone_defaults())
 
-walls.register("walls:desertcobble", "Desert Cobblestone Wall", "default_desert_cobble.png",
+walls.register("walls:desertcobble", "Desert Cobblestone Wall", {"default_desert_cobble.png"},
 		"default:desert_cobble", default.node_sound_stone_defaults())
 

--- a/mods/walls/init.lua
+++ b/mods/walls/init.lua
@@ -1,6 +1,10 @@
 walls = {}
 
 walls.register = function(wall_name, wall_desc, wall_texture_table, wall_mat, wall_sounds)
+	--make wall_texture_table paramenter backwards compatible for mods passing single texture
+	if type(wall_texture_table) ~= "table" then
+             wall_texture_table = { wall_texture_table }
+        end
 	-- inventory node, and pole-type wall start item
 	minetest.register_node(wall_name, {
 		description = wall_desc,

--- a/mods/walls/init.lua
+++ b/mods/walls/init.lua
@@ -3,8 +3,8 @@ walls = {}
 walls.register = function(wall_name, wall_desc, wall_texture_table, wall_mat, wall_sounds)
 	--make wall_texture_table paramenter backwards compatible for mods passing single texture
 	if type(wall_texture_table) ~= "table" then
-             wall_texture_table = { wall_texture_table }
-        end
+		wall_texture_table = { wall_texture_table }
+	end
 	-- inventory node, and pole-type wall start item
 	minetest.register_node(wall_name, {
 		description = wall_desc,


### PR DESCRIPTION
Registration function will take texture table instead of individual texture. Would break registrations by other mods.