### PR TITLE
safer slab name check

### DIFF
--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -185,7 +185,7 @@ function stairs.register_slab(subname, recipeitem, groups, images, description, 
 			local creative_enabled = (creative and creative.is_enabled_for
 					and creative.is_enabled_for(player_name))
 
-			if under and under.name:find("stairs:slab_") then
+			if under and under.name:find("^stairs:slab_") then
 				-- place slab using under node orientation
 				local dir = minetest.dir_to_facedir(vector.subtract(
 					pointed_thing.above, pointed_thing.under), true)


### PR DESCRIPTION
When placing a slab, the game checks if the node it was placed on has a name containing "stairs:slab_".
This could detect things like "xxxxxstairs:slab_xxxx".
Changed the pattern to "^stairs:slab_" so there can't be anything before the match.