### PR TITLE
Remove cave ice from creative inventory

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -627,7 +627,8 @@ minetest.register_node("default:cave_ice", {
 	description = "Cave Ice",
 	tiles = {"default_ice.png"},
 	paramtype = "light",
-	groups = {cracky = 3, puts_out_fire = 1, cools_lava = 1, slippery = 3},
+	groups = {cracky = 3, puts_out_fire = 1, cools_lava = 1, slippery = 3,
+		not_in_creative_inventory = 1},
 	drop = "default:ice",
 	sounds = default.node_sound_glass_defaults(),
 })


### PR DESCRIPTION
It has no meaningful difference from regular ice nodes as far as the player is concerned, and so removing it from creative prevents some clutter and possible confusion (since it drops the regular node). 