### PR TITLE
Stairs: Add field to registration to determine world-aligned textures

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -672,31 +672,55 @@ Stairs API
 The stairs API lets you register stairs and slabs and ensures that they are registered the same way as those
 delivered with Minetest Game, to keep them compatible with other mods.
 
-`stairs.register_stair(subname, recipeitem, groups, images, description, sounds)`
+`stairs.register_stair(subname, recipeitem, groups, images, description, sounds, worldaligntex)`
 
- * Registers a stair.
+ * Registers a stair
  * `subname`: Basically the material name (e.g. cobble) used for the stair name. Nodename pattern: "stairs:stair_subname"
  * `recipeitem`: Item used in the craft recipe, e.g. "default:cobble", may be `nil`
- * `groups`: see [Known damage and digging time defining groups]
- * `images`: see [Tile definition]
- * `description`: used for the description field in the stair's definition
- * `sounds`: see [#Default sounds]
+ * `groups`: See [Known damage and digging time defining groups]
+ * `images`: See [Tile definition]
+ * `description`: Used for the description field in the stair's definition
+ * `sounds`: See [#Default sounds]
+ * `worldaligntex`: A bool to set all textures world-aligned. Default false. See [Tile definition]
 
-`stairs.register_slab(subname, recipeitem, groups, images, description, sounds)`
+`stairs.register_slab(subname, recipeitem, groups, images, description, sounds, worldaligntex)`
 
- * Registers a slabs
- * `subname`: Basically the material name (e.g. cobble) used for the stair name. Nodename pattern: "stairs:stair_subname"
+ * Registers a slab
+ * `subname`: Basically the material name (e.g. cobble) used for the slab name. Nodename pattern: "stairs:slab_subname"
  * `recipeitem`: Item used in the craft recipe, e.g. "default:cobble"
- * `groups`: see [Known damage and digging time defining groups]
- * `images`: see [Tile definition]
- * `description`: used for the description field in the stair's definition
- * `sounds`: see [#Default sounds]
+ * `groups`: See [Known damage and digging time defining groups]
+ * `images`: See [Tile definition]
+ * `description`: Used for the description field in the slab's definition
+ * `sounds`: See [#Default sounds]
+ * `worldaligntex`: A bool to set all textures world-aligned. Default false. See [Tile definition]
 
-`stairs.register_stair_and_slab(subname, recipeitem, groups, images, desc_stair, desc_slab, sounds)`
+`stairs.register_stair_inner(subname, recipeitem, groups, images, description, sounds, worldaligntex)`
 
- * A wrapper for stairs.register_stair and stairs.register_slab
+ * Registers an inner corner stair
+ * `subname`: Basically the material name (e.g. cobble) used for the stair name. Nodename pattern: "stairs:stair_inner_subname"
+ * `recipeitem`: Item used in the craft recipe, e.g. "default:cobble", may be `nil`
+ * `groups`: See [Known damage and digging time defining groups]
+ * `images`: See [Tile definition]
+ * `description`: Used for the description field in the stair's definition
+ * `sounds`: See [#Default sounds]
+ * `worldaligntex`: A bool to set all textures world-aligned. Default false. See [Tile definition]
+
+`stairs.register_stair_outer(subname, recipeitem, groups, images, description, sounds, worldaligntex)`
+
+ * Registers an outer corner stair
+ * `subname`: Basically the material name (e.g. cobble) used for the stair name. Nodename pattern: "stairs:stair_outer_subname"
+ * `recipeitem`: Item used in the craft recipe, e.g. "default:cobble", may be `nil`
+ * `groups`: See [Known damage and digging time defining groups]
+ * `images`: See [Tile definition]
+ * `description`: Used for the description field in the stair's definition
+ * `sounds`: See [#Default sounds]
+ * `worldaligntex`: A bool to set all textures world-aligned. Default false. See [Tile definition]
+
+`stairs.register_stair_and_slab(subname, recipeitem, groups, images, desc_stair, desc_slab, sounds, worldaligntex)`
+
+ * A wrapper for stairs.register_stair, stairs.register_slab, stairs.register_stair_inner, stairs.register_stair_outer
  * Uses almost the same arguments as stairs.register_stair
- * `desc_stair`: Description for stair node
+ * `desc_stair`: Description for stair nodes. For corner stairs 'Inner' or 'Outer' will be prefixed
  * `desc_slab`: Description for slab node
 
 

--- a/mods/farming/nodes.lua
+++ b/mods/farming/nodes.lua
@@ -113,7 +113,8 @@ stairs.register_stair_and_slab(
 	{"farming_straw.png"},
 	"Straw Stair",
 	"Straw Slab",
-	default.node_sound_leaves_defaults()
+	default.node_sound_leaves_defaults(),
+	true
 )
 
 minetest.register_abm({

--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -48,7 +48,8 @@ end
 -- Register stair
 -- Node will be called stairs:stair_<subname>
 
-function stairs.register_stair(subname, recipeitem, groups, images, description, sounds)
+function stairs.register_stair(subname, recipeitem, groups, images, description,
+		sounds, worldaligntex)
 	-- Set backface culling and world-aligned textures
 	local stair_images = {}
 	for i, image in ipairs(images) do
@@ -56,14 +57,16 @@ function stairs.register_stair(subname, recipeitem, groups, images, description,
 			stair_images[i] = {
 				name = image,
 				backface_culling = true,
-				align_style = "world",
 			}
+			if worldaligntex then
+				stair_images[i].align_style = "world"
+			end
 		else
 			stair_images[i] = table.copy(image)
 			if stair_images[i].backface_culling == nil then
 				stair_images[i].backface_culling = true
 			end
-			if stair_images[i].align_style == nil then
+			if worldaligntex and stair_images[i].align_style == nil then
 				stair_images[i].align_style = "world"
 			end
 		end
@@ -147,18 +150,21 @@ local slab_trans_dir = {[0] = 8, 0, 2, 1, 3, 4}
 -- Register slab
 -- Node will be called stairs:slab_<subname>
 
-function stairs.register_slab(subname, recipeitem, groups, images, description, sounds)
+function stairs.register_slab(subname, recipeitem, groups, images, description,
+		sounds, worldaligntex)
 	-- Set world-aligned textures
 	local slab_images = {}
 	for i, image in ipairs(images) do
 		if type(image) == "string" then
 			slab_images[i] = {
 				name = image,
-				align_style = "world",
 			}
+			if worldaligntex then
+				slab_images[i].align_style = "world"
+			end
 		else
 			slab_images[i] = table.copy(image)
-			if image.align_style == nil then
+			if worldaligntex and image.align_style == nil then
 				slab_images[i].align_style = "world"
 			end
 		end
@@ -300,7 +306,8 @@ end
 -- Register inner stair
 -- Node will be called stairs:stair_inner_<subname>
 
-function stairs.register_stair_inner(subname, recipeitem, groups, images, description, sounds)
+function stairs.register_stair_inner(subname, recipeitem, groups, images,
+		description, sounds, worldaligntex)
 	-- Set backface culling and world-aligned textures
 	local stair_images = {}
 	for i, image in ipairs(images) do
@@ -308,14 +315,16 @@ function stairs.register_stair_inner(subname, recipeitem, groups, images, descri
 			stair_images[i] = {
 				name = image,
 				backface_culling = true,
-				align_style = "world",
 			}
+			if worldaligntex then
+				stair_images[i].align_style = "world"
+			end
 		else
 			stair_images[i] = table.copy(image)
 			if stair_images[i].backface_culling == nil then
 				stair_images[i].backface_culling = true
 			end
-			if stair_images[i].align_style == nil then
+			if worldaligntex and stair_images[i].align_style == nil then
 				stair_images[i].align_style = "world"
 			end
 		end
@@ -378,7 +387,8 @@ end
 -- Register outer stair
 -- Node will be called stairs:stair_outer_<subname>
 
-function stairs.register_stair_outer(subname, recipeitem, groups, images, description, sounds)
+function stairs.register_stair_outer(subname, recipeitem, groups, images,
+		description, sounds, worldaligntex)
 	-- Set backface culling and world-aligned textures
 	local stair_images = {}
 	for i, image in ipairs(images) do
@@ -386,14 +396,16 @@ function stairs.register_stair_outer(subname, recipeitem, groups, images, descri
 			stair_images[i] = {
 				name = image,
 				backface_culling = true,
-				align_style = "world",
 			}
+			if worldaligntex then
+				stair_images[i].align_style = "world"
+			end
 		else
 			stair_images[i] = table.copy(image)
 			if stair_images[i].backface_culling == nil then
 				stair_images[i].backface_culling = true
 			end
-			if stair_images[i].align_style == nil then
+			if worldaligntex and stair_images[i].align_style == nil then
 				stair_images[i].align_style = "world"
 			end
 		end
@@ -455,11 +467,16 @@ end
 -- Stair/slab registration function.
 -- Nodes will be called stairs:{stair,slab}_<subname>
 
-function stairs.register_stair_and_slab(subname, recipeitem, groups, images, desc_stair, desc_slab, sounds)
-	stairs.register_stair(subname, recipeitem, groups, images, desc_stair, sounds)
-	stairs.register_stair_inner(subname, recipeitem, groups, images, desc_stair, sounds)
-	stairs.register_stair_outer(subname, recipeitem, groups, images, desc_stair, sounds)
-	stairs.register_slab(subname, recipeitem, groups, images, desc_slab, sounds)
+function stairs.register_stair_and_slab(subname, recipeitem, groups, images,
+		desc_stair, desc_slab, sounds, worldaligntex)
+	stairs.register_stair(subname, recipeitem, groups, images, desc_stair,
+		sounds, worldaligntex)
+	stairs.register_stair_inner(subname, recipeitem, groups, images, desc_stair,
+		sounds, worldaligntex)
+	stairs.register_stair_outer(subname, recipeitem, groups, images, desc_stair,
+		sounds, worldaligntex)
+	stairs.register_slab(subname, recipeitem, groups, images, desc_slab,
+		sounds, worldaligntex)
 end
 
 
@@ -472,7 +489,8 @@ stairs.register_stair_and_slab(
 	{"default_wood.png"},
 	"Wooden Stair",
 	"Wooden Slab",
-	default.node_sound_wood_defaults()
+	default.node_sound_wood_defaults(),
+	false
 )
 
 stairs.register_stair_and_slab(
@@ -482,7 +500,8 @@ stairs.register_stair_and_slab(
 	{"default_junglewood.png"},
 	"Jungle Wood Stair",
 	"Jungle Wood Slab",
-	default.node_sound_wood_defaults()
+	default.node_sound_wood_defaults(),
+	false
 )
 
 stairs.register_stair_and_slab(
@@ -492,7 +511,8 @@ stairs.register_stair_and_slab(
 	{"default_pine_wood.png"},
 	"Pine Wood Stair",
 	"Pine Wood Slab",
-	default.node_sound_wood_defaults()
+	default.node_sound_wood_defaults(),
+	false
 )
 
 stairs.register_stair_and_slab(
@@ -502,7 +522,8 @@ stairs.register_stair_and_slab(
 	{"default_acacia_wood.png"},
 	"Acacia Wood Stair",
 	"Acacia Wood Slab",
-	default.node_sound_wood_defaults()
+	default.node_sound_wood_defaults(),
+	false
 )
 
 stairs.register_stair_and_slab(
@@ -512,7 +533,8 @@ stairs.register_stair_and_slab(
 	{"default_aspen_wood.png"},
 	"Aspen Wood Stair",
 	"Aspen Wood Slab",
-	default.node_sound_wood_defaults()
+	default.node_sound_wood_defaults(),
+	false
 )
 
 stairs.register_stair_and_slab(
@@ -522,7 +544,8 @@ stairs.register_stair_and_slab(
 	{"default_stone.png"},
 	"Stone Stair",
 	"Stone Slab",
-	default.node_sound_stone_defaults()
+	default.node_sound_stone_defaults(),
+	true
 )
 
 stairs.register_stair_and_slab(
@@ -532,7 +555,8 @@ stairs.register_stair_and_slab(
 	{"default_cobble.png"},
 	"Cobblestone Stair",
 	"Cobblestone Slab",
-	default.node_sound_stone_defaults()
+	default.node_sound_stone_defaults(),
+	true
 )
 
 stairs.register_stair_and_slab(
@@ -542,7 +566,8 @@ stairs.register_stair_and_slab(
 	{"default_mossycobble.png"},
 	"Mossy Cobblestone Stair",
 	"Mossy Cobblestone Slab",
-	default.node_sound_stone_defaults()
+	default.node_sound_stone_defaults(),
+	true
 )
 
 stairs.register_stair_and_slab(
@@ -552,7 +577,8 @@ stairs.register_stair_and_slab(
 	{"default_stone_brick.png"},
 	"Stone Brick Stair",
 	"Stone Brick Slab",
-	default.node_sound_stone_defaults()
+	default.node_sound_stone_defaults(),
+	false
 )
 
 stairs.register_stair_and_slab(
@@ -562,7 +588,8 @@ stairs.register_stair_and_slab(
 	{"default_stone_block.png"},
 	"Stone Block Stair",
 	"Stone Block Slab",
-	default.node_sound_stone_defaults()
+	default.node_sound_stone_defaults(),
+	true
 )
 
 stairs.register_stair_and_slab(
@@ -572,7 +599,8 @@ stairs.register_stair_and_slab(
 	{"default_desert_stone.png"},
 	"Desert Stone Stair",
 	"Desert Stone Slab",
-	default.node_sound_stone_defaults()
+	default.node_sound_stone_defaults(),
+	true
 )
 
 stairs.register_stair_and_slab(
@@ -582,7 +610,8 @@ stairs.register_stair_and_slab(
 	{"default_desert_cobble.png"},
 	"Desert Cobblestone Stair",
 	"Desert Cobblestone Slab",
-	default.node_sound_stone_defaults()
+	default.node_sound_stone_defaults(),
+	true
 )
 
 stairs.register_stair_and_slab(
@@ -592,7 +621,8 @@ stairs.register_stair_and_slab(
 	{"default_desert_stone_brick.png"},
 	"Desert Stone Brick Stair",
 	"Desert Stone Brick Slab",
-	default.node_sound_stone_defaults()
+	default.node_sound_stone_defaults(),
+	false
 )
 
 stairs.register_stair_and_slab(
@@ -602,7 +632,8 @@ stairs.register_stair_and_slab(
 	{"default_desert_stone_block.png"},
 	"Desert Stone Block Stair",
 	"Desert Stone Block Slab",
-	default.node_sound_stone_defaults()
+	default.node_sound_stone_defaults(),
+	true
 )
 
 stairs.register_stair_and_slab(
@@ -612,7 +643,8 @@ stairs.register_stair_and_slab(
 	{"default_sandstone.png"},
 	"Sandstone Stair",
 	"Sandstone Slab",
-	default.node_sound_stone_defaults()
+	default.node_sound_stone_defaults(),
+	true
 )
 
 stairs.register_stair_and_slab(
@@ -622,7 +654,8 @@ stairs.register_stair_and_slab(
 	{"default_sandstone_brick.png"},
 	"Sandstone Brick Stair",
 	"Sandstone Brick Slab",
-	default.node_sound_stone_defaults()
+	default.node_sound_stone_defaults(),
+	false
 )
 
 stairs.register_stair_and_slab(
@@ -632,7 +665,8 @@ stairs.register_stair_and_slab(
 	{"default_sandstone_block.png"},
 	"Sandstone Block Stair",
 	"Sandstone Block Slab",
-	default.node_sound_stone_defaults()
+	default.node_sound_stone_defaults(),
+	true
 )
 
 stairs.register_stair_and_slab(
@@ -642,7 +676,8 @@ stairs.register_stair_and_slab(
 	{"default_desert_sandstone.png"},
 	"Desert Sandstone Stair",
 	"Desert Sandstone Slab",
-	default.node_sound_stone_defaults()
+	default.node_sound_stone_defaults(),
+	true
 )
 
 stairs.register_stair_and_slab(
@@ -652,7 +687,8 @@ stairs.register_stair_and_slab(
 	{"default_desert_sandstone_brick.png"},
 	"Desert Sandstone Brick Stair",
 	"Desert Sandstone Brick Slab",
-	default.node_sound_stone_defaults()
+	default.node_sound_stone_defaults(),
+	false
 )
 
 stairs.register_stair_and_slab(
@@ -662,7 +698,8 @@ stairs.register_stair_and_slab(
 	{"default_desert_sandstone_block.png"},
 	"Desert Sandstone Block Stair",
 	"Desert Sandstone Block Slab",
-	default.node_sound_stone_defaults()
+	default.node_sound_stone_defaults(),
+	true
 )
 
 stairs.register_stair_and_slab(
@@ -672,7 +709,8 @@ stairs.register_stair_and_slab(
 	{"default_silver_sandstone.png"},
 	"Silver Sandstone Stair",
 	"Silver Sandstone Slab",
-	default.node_sound_stone_defaults()
+	default.node_sound_stone_defaults(),
+	true
 )
 
 stairs.register_stair_and_slab(
@@ -682,7 +720,8 @@ stairs.register_stair_and_slab(
 	{"default_silver_sandstone_brick.png"},
 	"Silver Sandstone Brick Stair",
 	"Silver Sandstone Brick Slab",
-	default.node_sound_stone_defaults()
+	default.node_sound_stone_defaults(),
+	false
 )
 
 stairs.register_stair_and_slab(
@@ -692,7 +731,8 @@ stairs.register_stair_and_slab(
 	{"default_silver_sandstone_block.png"},
 	"Silver Sandstone Block Stair",
 	"Silver Sandstone Block Slab",
-	default.node_sound_stone_defaults()
+	default.node_sound_stone_defaults(),
+	true
 )
 
 stairs.register_stair_and_slab(
@@ -702,7 +742,8 @@ stairs.register_stair_and_slab(
 	{"default_obsidian.png"},
 	"Obsidian Stair",
 	"Obsidian Slab",
-	default.node_sound_stone_defaults()
+	default.node_sound_stone_defaults(),
+	true
 )
 
 stairs.register_stair_and_slab(
@@ -712,7 +753,8 @@ stairs.register_stair_and_slab(
 	{"default_obsidian_brick.png"},
 	"Obsidian Brick Stair",
 	"Obsidian Brick Slab",
-	default.node_sound_stone_defaults()
+	default.node_sound_stone_defaults(),
+	false
 )
 
 stairs.register_stair_and_slab(
@@ -722,7 +764,8 @@ stairs.register_stair_and_slab(
 	{"default_obsidian_block.png"},
 	"Obsidian Block Stair",
 	"Obsidian Block Slab",
-	default.node_sound_stone_defaults()
+	default.node_sound_stone_defaults(),
+	true
 )
 
 stairs.register_stair_and_slab(
@@ -732,7 +775,8 @@ stairs.register_stair_and_slab(
 	{"default_brick.png"},
 	"Brick Stair",
 	"Brick Slab",
-	default.node_sound_stone_defaults()
+	default.node_sound_stone_defaults(),
+	false
 )
 
 stairs.register_stair_and_slab(
@@ -742,7 +786,8 @@ stairs.register_stair_and_slab(
 	{"default_steel_block.png"},
 	"Steel Block Stair",
 	"Steel Block Slab",
-	default.node_sound_metal_defaults()
+	default.node_sound_metal_defaults(),
+	true
 )
 
 stairs.register_stair_and_slab(
@@ -752,7 +797,8 @@ stairs.register_stair_and_slab(
 	{"default_tin_block.png"},
 	"Tin Block Stair",
 	"Tin Block Slab",
-	default.node_sound_metal_defaults()
+	default.node_sound_metal_defaults(),
+	true
 )
 
 stairs.register_stair_and_slab(
@@ -762,7 +808,8 @@ stairs.register_stair_and_slab(
 	{"default_copper_block.png"},
 	"Copper Block Stair",
 	"Copper Block Slab",
-	default.node_sound_metal_defaults()
+	default.node_sound_metal_defaults(),
+	true
 )
 
 stairs.register_stair_and_slab(
@@ -772,7 +819,8 @@ stairs.register_stair_and_slab(
 	{"default_bronze_block.png"},
 	"Bronze Block Stair",
 	"Bronze Block Slab",
-	default.node_sound_metal_defaults()
+	default.node_sound_metal_defaults(),
+	true
 )
 
 stairs.register_stair_and_slab(
@@ -782,7 +830,8 @@ stairs.register_stair_and_slab(
 	{"default_gold_block.png"},
 	"Gold Block Stair",
 	"Gold Block Slab",
-	default.node_sound_metal_defaults()
+	default.node_sound_metal_defaults(),
+	true
 )
 
 stairs.register_stair_and_slab(
@@ -792,7 +841,8 @@ stairs.register_stair_and_slab(
 	{"default_ice.png"},
 	"Ice Stair",
 	"Ice Slab",
-	default.node_sound_glass_defaults()
+	default.node_sound_glass_defaults(),
+	true
 )
 
 stairs.register_stair_and_slab(
@@ -802,5 +852,6 @@ stairs.register_stair_and_slab(
 	{"default_snow.png"},
 	"Snow Block Stair",
 	"Snow Block Slab",
-	default.node_sound_snow_defaults()
+	default.node_sound_snow_defaults(),
+	true
 )


### PR DESCRIPTION
 Stairs: Add field to registration to determine world-aligned textures

All stair nodes with parent nodes that are rotatable (wood and bricks)
are reverted to not having world-aligned textures, to fix the breakage
of node appearence in worlds.
//////////////////

Closes #2216 

Needs testing. Remember to also test a node that has the texture specified as a table, to test the 'else' action.