### PR TITLE
map: Use wood group crafting recipe

### DIFF
--- a/mods/map/init.lua
+++ b/mods/map/init.lua
@@ -67,7 +67,7 @@ minetest.register_craft({
 	recipe = {
 		{"default:glass", "default:paper", "default:stick"},
 		{"default:steel_ingot", "default:paper", "default:steel_ingot"},
-		{"default:wood", "default:paper", "dye:black"},
+		{"group:wood", "default:paper", "dye:black"},
 	}
 })
 


### PR DESCRIPTION
Reported by an IRC-user who spawned in a large biome without any apple trees around. Trivial PR to take any kind of wood to craft the map.