### PR TITLE
Beds: Improve on_rotate function

### DIFF
--- a/mods/beds/api.lua
+++ b/mods/beds/api.lua
@@ -121,7 +121,9 @@ function beds.register_bed(name, def)
 				minetest.record_protection_violation(p, user:get_player_name())
 				return false
 			end
-			if new_param2 % 32 > 3 then return false end
+			if new_param2 % 32 > 3 then
+				return false
+			end
 			local newp = vector.add(pos, minetest.facedir_to_dir(new_param2))
 			local node3 = minetest.get_node_or_nil(newp)
 			local node_def = node3 and minetest.registered_nodes[node3.name]

--- a/mods/beds/api.lua
+++ b/mods/beds/api.lua
@@ -109,7 +109,7 @@ function beds.register_bed(name, def)
 			return itemstack
 		end,
 
-		on_rotate = function(pos, node, user, mode, new_param2)
+		on_rotate = function(pos, node, user, _, new_param2)
 			local dir = minetest.facedir_to_dir(node.param2)
 			local p = vector.add(pos, dir)
 			local node2 = minetest.get_node_or_nil(p)
@@ -121,9 +121,7 @@ function beds.register_bed(name, def)
 				minetest.record_protection_violation(p, user:get_player_name())
 				return false
 			end
-			if mode ~= screwdriver.ROTATE_FACE then
-				return false
-			end
+			if new_param2 % 32 > 3 then return false end
 			local newp = vector.add(pos, minetest.facedir_to_dir(new_param2))
 			local node3 = minetest.get_node_or_nil(newp)
 			local node_def = node3 and minetest.registered_nodes[node3.name]


### PR DESCRIPTION
The `on_rotate` function now checks the new param2 value to determine if a rotation is valid, rather than checking the rotation mode.
This is so screwdriver-like items with different rotation modes will not be able to rotate the bed into invalid orientations.