### PR TITLE
comment out combine slabs code

### DIFF
--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -198,7 +198,7 @@ function stairs.register_slab(subname, recipeitem, groups, images, description,
 
 				local p2 = under.param2
 
-				-- combine two slabs if possible
+--[[				-- combine two slabs if possible
 				if slab_trans_dir[math.floor(p2 / 4)] == dir
 						and wield_item == under.name then
 
@@ -222,7 +222,7 @@ function stairs.register_slab(subname, recipeitem, groups, images, description,
 						itemstack:take_item()
 					end
 					return itemstack
-				end
+				end]]--
 
 				-- Placing a slab on an upside down slab should make it right-side up.
 				if p2 >= 20 and dir == 8 then

--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -143,10 +143,6 @@ function stairs.register_stair(subname, recipeitem, groups, images, description,
 end
 
 
--- Slab facedir to placement 6d matching table
-local slab_trans_dir = {[0] = 8, 0, 2, 1, 3, 4}
-
-
 -- Register slab
 -- Node will be called stairs:slab_<subname>
 
@@ -197,32 +193,6 @@ function stairs.register_slab(subname, recipeitem, groups, images, description,
 					pointed_thing.above, pointed_thing.under), true)
 
 				local p2 = under.param2
-
---[[				-- combine two slabs if possible
-				if slab_trans_dir[math.floor(p2 / 4)] == dir
-						and wield_item == under.name then
-
-					if not recipeitem then
-						return itemstack
-					end
-					if minetest.is_protected(pointed_thing.under, player_name) and not
-							minetest.check_player_privs(player_name, "protection_bypass") then
-						minetest.record_protection_violation(pointed_thing.under,
-							player_name)
-						return
-					end
-					-- If paramtype2 of cubic version is not 'facedir' set its
-					-- param2 to 0 to avoid bugs such as liquid in connected
-					-- framed glass.
-					if minetest.registered_nodes[recipeitem].paramtype2 ~= "facedir" then
-						p2 = 0
-					end
-					minetest.set_node(pointed_thing.under, {name = recipeitem, param2 = p2})
-					if not creative_enabled then
-						itemstack:take_item()
-					end
-					return itemstack
-				end]]--
 
 				-- Placing a slab on an upside down slab should make it right-side up.
 				if p2 >= 20 and dir == 8 then


### PR DESCRIPTION
We had talked about removing the code to combine slabs, in the last PR.

I think it best to simply 'comment out' those lines of code, so it leaves the feature accessible to server owners, and even end users, without having to rewrite the code.