### PR TITLE
Fix crash on empty key metadata

### DIFF
--- a/mods/default/chests.lua
+++ b/mods/default/chests.lua
@@ -147,6 +147,10 @@ function default.chest.register_chest(name, d)
 			local itemstack = player:get_wielded_item()
 			local key_meta = itemstack:get_meta()
 
+			if itemstack:get_metadata() == "" then
+				return
+			end
+
 			if key_meta:get_string("secret") == "" then
 				key_meta:set_string("secret", minetest.parse_json(itemstack:get_metadata()).secret)
 				itemstack:set_metadata("")


### PR DESCRIPTION
Fixes #2244
Code supplied by @JurajVajda in https://github.com/minetest/minetest_game/issues/2244#issuecomment-430429248