### PR TITLE
cook coral into skeleton coral

### DIFF
--- a/mods/default/crafting.lua
+++ b/mods/default/crafting.lua
@@ -868,6 +868,17 @@ minetest.register_craft({
 	cooktime = 5,
 })
 
+minetest.register_craft({
+	type = "cooking",
+	recipe = "default:coral_brown",
+	output = "default:coral_skeleton",
+})
+
+minetest.register_craft({
+	type = "cooking",
+	recipe = "default:coral_orange",
+	output = "default:coral_skeleton",
+})
 
 --
 -- Fuels


### PR DESCRIPTION
Since removing the abm that changes orange and brown coral into skeleton coral we need another way of obtaining it, so this pull adds cooking recipes to bake them both into white skeleton coral instead.