### PR TITLE
Prevent crash if some mod inadvertently allowed doors to rotate.

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -162,6 +162,14 @@ function _doors.door_toggle(pos, node, clicker)
 	end
 
 	local dir = node.param2
+
+	-- It's possible param2 is messed up, so, validate before using
+	-- the input data. This indicates something may have rotated
+	-- the door, even though that is not supported.
+	if not transform[state + 1] or not transform[state + 1][dir + 1] then
+		return false
+	end
+
 	if state % 2 == 0 then
 		minetest.sound_play(def.door.sounds[1],
 			{pos = pos, gain = 0.3, max_hear_distance = 10})


### PR DESCRIPTION
Reported by a user in IRC. Apparently some screwdriver mod allows this. Neither the mod (xdecor) nor the standard screwdriver does this in stock 0.4.x or 0.5.x - rotation isn't permitted. It is however still possible that mods override this and the door API code will croak when it finds a param2 value that isn't `0..3`. Cheap check, so, really no big deal.