### PR TITLE
Sfinv creative tweaks

### DIFF
--- a/mods/creative/inventory.lua
+++ b/mods/creative/inventory.lua
@@ -108,8 +108,6 @@ function creative.register_tab(name, title, items)
 				[[
 					image[4.06,3.4;0.8,0.8;creative_trash_icon.png]
 					listcolors[#00000069;#5A5A5A;#141318;#30434C;#FFF]
-					list[current_player;main;0,4.7;8,1;]
-					list[current_player;main;0,5.85;8,3;8]
 					list[detached:creative_trash;main;4,3.3;1,1;]
 					listring[]
 					image_button[5.4,3.25;0.8,0.8;creative_prev_icon.png;creative_prev;]
@@ -126,7 +124,7 @@ function creative.register_tab(name, title, items)
 				"field[0.3,3.5;2.2,1;creative_filter;;" .. minetest.formspec_escape(inv.filter) .. "]" ..
 				"listring[detached:creative_" .. player_name .. ";main]" ..
 				"list[detached:creative_" .. player_name .. ";main;0,0;8,3;" .. tostring(start_i) .. "]" ..
-				default.get_hotbar_bg(0,4.7) .. creative.formspec_add, false)
+				creative.formspec_add, true)
 		end,
 		on_enter = function(self, player, context)
 			local player_name = player:get_player_name()

--- a/mods/sfinv/api.lua
+++ b/mods/sfinv/api.lua
@@ -37,6 +37,14 @@ function sfinv.get_nav_fs(player, context, nav, current_idx)
 end
 
 local theme_inv = [[
+		image[0,4.7;1,1;gui_hb_bg.png]
+		image[1,4.7;1,1;gui_hb_bg.png]
+		image[2,4.7;1,1;gui_hb_bg.png]
+		image[3,4.7;1,1;gui_hb_bg.png]
+		image[4,4.7;1,1;gui_hb_bg.png]
+		image[5,4.7;1,1;gui_hb_bg.png]
+		image[6,4.7;1,1;gui_hb_bg.png]
+		image[7,4.7;1,1;gui_hb_bg.png]
 		list[current_player;main;0,4.7;8,1;]
 		list[current_player;main;0,5.85;8,3;8]
 	]]
@@ -45,11 +53,9 @@ function sfinv.make_formspec(player, context, content, show_inv, size)
 	local tmp = {
 		size or "size[8,8.6]",
 		sfinv.get_nav_fs(player, context, context.nav_titles, context.nav_idx),
+		show_inv and theme_inv or "",
 		content
 	}
-	if show_inv then
-		tmp[#tmp + 1] = theme_inv
-	end
 	return table.concat(tmp, "")
 end
 

--- a/mods/sfinv/init.lua
+++ b/mods/sfinv/init.lua
@@ -9,14 +9,6 @@ sfinv.register_page("sfinv:crafting", {
 				image[4.75,1.5;1,1;gui_furnace_arrow_bg.png^[transformR270]
 				listring[current_player;main]
 				listring[current_player;craft]
-				image[0,4.7;1,1;gui_hb_bg.png]
-				image[1,4.7;1,1;gui_hb_bg.png]
-				image[2,4.7;1,1;gui_hb_bg.png]
-				image[3,4.7;1,1;gui_hb_bg.png]
-				image[4,4.7;1,1;gui_hb_bg.png]
-				image[5,4.7;1,1;gui_hb_bg.png]
-				image[6,4.7;1,1;gui_hb_bg.png]
-				image[7,4.7;1,1;gui_hb_bg.png]
 			]], true)
 	end
 })


### PR DESCRIPTION
This PR does unify the inventory lists for sfinv and creative. 
The creative mod uses the "main" lists and hotbar_bg from sfinv instead of own and default.

In sfinv the hotbar_bg textures are a part of "theme_inv" now.

Functional change is the "theme_inv" is above the "content" that should be ok in all use cases.