### PR TITLE
Remove extra empty strings in craft recipes

### DIFF
--- a/mods/farming/api.lua
+++ b/mods/farming/api.lua
@@ -106,9 +106,9 @@ farming.register_hoe = function(name, def)
 		minetest.register_craft({
 			output = name:sub(2),
 			recipe = {
-				{def.material, def.material, ""},
-				{"", "group:stick", ""},
-				{"", "group:stick", ""}
+				{def.material, def.material},
+				{"", "group:stick"},
+				{"", "group:stick"}
 			}
 		})
 	end

--- a/mods/fireflies/init.lua
+++ b/mods/fireflies/init.lua
@@ -111,9 +111,9 @@ minetest.register_tool("fireflies:bug_net", {
 minetest.register_craft( {
 	output = "fireflies:bug_net",
 	recipe = {
-		{"farming:string", "farming:string", ""},
-		{"farming:string", "farming:string", ""},
-		{"default:stick", "", ""}
+		{"farming:string", "farming:string"},
+		{"farming:string", "farming:string"},
+		{"default:stick", ""}
 	}
 })
 
@@ -171,9 +171,8 @@ minetest.register_node("fireflies:firefly_bottle", {
 minetest.register_craft( {
 	output = "fireflies:firefly_bottle",
 	recipe = {
-		{"", "", ""},
-		{"", "fireflies:firefly", ""},
-		{"", "vessels:glass_bottle", ""}
+		{"fireflies:firefly"},
+		{"vessels:glass_bottle"}
 	}
 })
 

--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -337,8 +337,8 @@ function stairs.register_stair_inner(subname, recipeitem, groups, images,
 		minetest.register_craft({
 			output = 'stairs:stair_inner_' .. subname .. ' 7',
 			recipe = {
-				{ "", recipeitem, ""},
-				{ recipeitem, "", recipeitem},
+				{"", recipeitem, ""},
+				{recipeitem, "", recipeitem},
 				{recipeitem, recipeitem, recipeitem},
 			},
 		})
@@ -417,8 +417,7 @@ function stairs.register_stair_outer(subname, recipeitem, groups, images,
 		minetest.register_craft({
 			output = 'stairs:stair_outer_' .. subname .. ' 6',
 			recipe = {
-				{ "", "", ""},
-				{ "", recipeitem, ""},
+				{"", recipeitem, ""},
 				{recipeitem, recipeitem, recipeitem},
 			},
 		})


### PR DESCRIPTION
They are unnecessary and in some cases result in an incorrect width returned by `minetest.get_craft_recipe`.