### PR TITLE
Remove uses of default.gui_bg/bg_img/slots

### DIFF
--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -13,9 +13,6 @@ end
 
 local bones_formspec =
 	"size[8,9]" ..
-	default.gui_bg ..
-	default.gui_bg_img ..
-	default.gui_slots ..
 	"list[current_name;main;0,0.3;8,4;]" ..
 	"list[current_player;main;0,4.85;8,1;]" ..
 	"list[current_player;main;0,6.08;8,3;8]" ..

--- a/mods/creative/inventory.lua
+++ b/mods/creative/inventory.lua
@@ -126,9 +126,7 @@ function creative.register_tab(name, title, items)
 				"field[0.3,3.5;2.2,1;creative_filter;;" .. minetest.formspec_escape(inv.filter) .. "]" ..
 				"listring[detached:creative_" .. player_name .. ";main]" ..
 				"list[detached:creative_" .. player_name .. ";main;0,0;8,3;" .. tostring(start_i) .. "]" ..
-				default.get_hotbar_bg(0,4.7) ..
-				default.gui_bg .. default.gui_bg_img .. default.gui_slots
-				.. creative.formspec_add, false)
+				default.get_hotbar_bg(0,4.7) .. creative.formspec_add, false)
 		end,
 		on_enter = function(self, player, context)
 			local player_name = player:get_player_name()

--- a/mods/default/chests.lua
+++ b/mods/default/chests.lua
@@ -4,9 +4,6 @@ function default.chest.get_chest_formspec(pos)
 	local spos = pos.x .. "," .. pos.y .. "," .. pos.z
 	local formspec =
 		"size[8,9]" ..
-		default.gui_bg ..
-		default.gui_bg_img ..
-		default.gui_slots ..
 		"list[nodemeta:" .. spos .. ";main;0,0.3;8,4;]" ..
 		"list[current_player;main;0,4.85;8,1;]" ..
 		"list[current_player;main;0,6.08;8,3;8]" ..

--- a/mods/default/craftitems.lua
+++ b/mods/default/craftitems.lua
@@ -50,16 +50,14 @@ local function book_on_use(itemstack, user)
 
 	local formspec
 	if owner == player_name then
-		formspec = "size[8,8]" .. default.gui_bg ..
-			default.gui_bg_img ..
+		formspec = "size[8,8]" ..
 			"field[0.5,1;7.5,0;title;Title:;" ..
 				minetest.formspec_escape(title) .. "]" ..
 			"textarea[0.5,1.5;7.5,7;text;Contents:;" ..
 				minetest.formspec_escape(text) .. "]" ..
 			"button_exit[2.5,7.5;3,1;save;Save]"
 	else
-		formspec = "size[8,8]" .. default.gui_bg ..
-			default.gui_bg_img ..
+		formspec = "size[8,8]" ..
 			"label[0.5,0.5;by " .. owner .. "]" ..
 			"tablecolumns[color;text]" ..
 			"tableoptions[background=#00000000;highlight=#00000000;border=false]" ..

--- a/mods/default/furnace.lua
+++ b/mods/default/furnace.lua
@@ -5,9 +5,6 @@
 
 function default.get_furnace_active_formspec(fuel_percent, item_percent)
 	return "size[8,8.5]"..
-		default.gui_bg..
-		default.gui_bg_img..
-		default.gui_slots..
 		"list[context;src;2.75,0.5;1,1;]"..
 		"list[context;fuel;2.75,2.5;1,1;]"..
 		"image[2.75,1.5;1,1;default_furnace_fire_bg.png^[lowpart:"..
@@ -28,9 +25,6 @@ end
 
 function default.get_furnace_inactive_formspec()
 	return "size[8,8.5]"..
-		default.gui_bg..
-		default.gui_bg_img..
-		default.gui_slots..
 		"list[context;src;2.75,0.5;1,1;]"..
 		"list[context;fuel;2.75,2.5;1,1;]"..
 		"image[2.75,1.5;1,1;default_furnace_fire_bg.png]"..

--- a/mods/default/init.lua
+++ b/mods/default/init.lua
@@ -9,10 +9,6 @@ default = {}
 default.LIGHT_MAX = 14
 
 -- GUI related stuff
-default.gui_bg     = ""
-default.gui_bg_img = ""
-default.gui_slots  = ""
-
 minetest.register_on_joinplayer(function(player)
 	player:set_formspec_prepend([[
 			bgcolor[#080808BB;true]
@@ -29,9 +25,6 @@ function default.get_hotbar_bg(x,y)
 end
 
 default.gui_survival_form = "size[8,8.5]"..
-			default.gui_bg..
-			default.gui_bg_img..
-			default.gui_slots..
 			"list[current_player;main;0,4.25;8,1;]"..
 			"list[current_player;main;0,5.5;8,3;8]"..
 			"list[current_player;craft;1.75,0.5;3,3;]"..

--- a/mods/default/legacy.lua
+++ b/mods/default/legacy.lua
@@ -23,6 +23,9 @@ LIGHT_MAX = default.LIGHT_MAX
 
 -- Formspecs
 default.gui_suvival_form = default.gui_survival_form
+default.gui_bg     = ""
+default.gui_bg_img = ""
+default.gui_slots  = ""
 
 -- Players
 if minetest.get_modpath("player_api") then

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -2449,9 +2449,6 @@ minetest.register_node("default:lava_flowing", {
 
 local bookshelf_formspec =
 	"size[8,7;]" ..
-	default.gui_bg ..
-	default.gui_bg_img ..
-	default.gui_slots ..
 	"list[context;books;0,0.3;8,2;]" ..
 	"list[current_player;main;0,2.85;8,1;]" ..
 	"list[current_player;main;0,4.08;8,3;8]" ..

--- a/mods/vessels/init.lua
+++ b/mods/vessels/init.lua
@@ -3,9 +3,6 @@
 
 local vessels_shelf_formspec =
 	"size[8,7;]" ..
-	default.gui_bg ..
-	default.gui_bg_img ..
-	default.gui_slots ..
 	"list[context;vessels;0,0.3;8,2;]" ..
 	"list[current_player;main;0,2.85;8,1;]" ..
 	"list[current_player;main;0,4.08;8,3;8]" ..


### PR DESCRIPTION
Keep their definitions, to not break mods, but move them to legacy.lua.
////////////////////

Closes #2280 