### PR TITLE
can_interact_with_node check for group key

### DIFF
--- a/mods/default/craftitems.lua
+++ b/mods/default/craftitems.lua
@@ -201,7 +201,6 @@ end)
 minetest.register_craftitem("default:skeleton_key", {
 	description = "Skeleton Key",
 	inventory_image = "default_key_skeleton.png",
-	groups = {key = 1},
 	on_use = function(itemstack, user, pointed_thing)
 		if pointed_thing.type ~= "node" then
 			return itemstack

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -585,7 +585,8 @@ function default.can_interact_with_node(player, pos)
 
 	-- Is player wielding the right key?
 	local item = player:get_wielded_item()
-	if minetest.registered_items[item:get_name()].groups.key == 1 then
+	local def = minetest.registered_items[item:get_name()]
+	if def and def.groups and def.groups.key == 1 then
 		local key_meta = item:get_meta()
 
 		if key_meta:get_string("secret") == "" then

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -585,7 +585,7 @@ function default.can_interact_with_node(player, pos)
 
 	-- Is player wielding the right key?
 	local item = player:get_wielded_item()
-	if item:get_name() == "default:key" then
+	if minetest.registered_items[item:get_name()].groups.key == 1 then
 		local key_meta = item:get_meta()
 
 		if key_meta:get_string("secret") == "" then

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -585,8 +585,7 @@ function default.can_interact_with_node(player, pos)
 
 	-- Is player wielding the right key?
 	local item = player:get_wielded_item()
-	local def = minetest.registered_items[item:get_name()]
-	if def and def.groups and def.groups.key == 1 then
+	if minetest.get_item_group(item:get_name(), "key") == 1 then
 		local key_meta = item:get_meta()
 
 		if key_meta:get_string("secret") == "" then


### PR DESCRIPTION
This change allows mods to add other keys instead of overriding the default one.
I recognized this Problem when creating the [adv_keys](https://forum.minetest.net/viewtopic.php?f=11&t=21609) mod.
Also needed for #1490