### PR TITLE
'permafrost_with_stones/moss' drops itself instead of permafrost

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -511,7 +511,6 @@ minetest.register_node("default:permafrost_with_stones", {
 		"default_permafrost.png",
 		"default_permafrost.png^default_stones_side.png"},
 	groups = {cracky = 3},
-	drop = "default:permafrost",
 	sounds = default.node_sound_gravel_defaults(),
 })
 
@@ -521,7 +520,6 @@ minetest.register_node("default:permafrost_with_moss", {
 		{name = "default_permafrost.png^default_moss_side.png",
 			tileable_vertical = false}},
 	groups = {cracky = 3},
-	drop = "default:permafrost",
 	sounds = default.node_sound_dirt_defaults({
 		footstep = {name = "default_grass_footstep", gain = 0.25},
 	}),


### PR DESCRIPTION
Previously they were not collectable or creatable.
A simple temporary solution for MTG 5.0.0.
/////////////////

Trivial and agreed with Ezhh https://github.com/minetest/minetest_game/issues/2297#issuecomment-460443722