### PR TITLE
Limit sign length to 512 (~6 lines of 80 char or so).

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -2575,12 +2575,19 @@ local function register_sign(material, desc, def)
 				minetest.record_protection_violation(pos, player_name)
 				return
 			end
-			local meta = minetest.get_meta(pos)
-			if not fields.text then return end
+			local text = fields.text
+			if not text then
+				return
+			end
+			if string.len(text) > 512 then
+				minetest.chat_send_player(player_name, "Text too long")
+				return
+			end
 			minetest.log("action", (player_name or "") .. " wrote \"" ..
-				fields.text .. "\" to sign at " .. minetest.pos_to_string(pos))
-			meta:set_string("text", fields.text)
-			meta:set_string("infotext", '"' .. fields.text .. '"')
+				text .. "\" to sign at " .. minetest.pos_to_string(pos))
+			local meta = minetest.get_meta(pos)
+			meta:set_string("text", text)
+			meta:set_string("infotext", '"' .. text .. '"')
 		end,
 	})
 end


### PR DESCRIPTION
Players can enter unlimited text into the field, causing lag and
potentially locking up clients. I have not found any negative effects
server side, other than the large storage needed to store the long
text.