### PR TITLE
Beds: Do not require red wool to craft beds

### DIFF
--- a/mods/beds/beds.lua
+++ b/mods/beds/beds.lua
@@ -44,7 +44,7 @@ beds.register_bed("beds:fancy_bed", {
 	selectionbox = {-0.5, -0.5, -0.5, 0.5, 0.06, 1.5},
 	recipe = {
 		{"", "", "group:stick"},
-		{"wool:red", "wool:red", "wool:white"},
+		{"wool:white", "wool:white", "wool:white"},
 		{"group:wood", "group:wood", "group:wood"},
 	},
 })
@@ -79,7 +79,7 @@ beds.register_bed("beds:bed", {
 	},
 	selectionbox = {-0.5, -0.5, -0.5, 0.5, 0.06, 1.5},
 	recipe = {
-		{"wool:red", "wool:red", "wool:white"},
+		{"wool:white", "wool:white", "wool:white"},
 		{"group:wood", "group:wood", "group:wood"}
 	},
 })


### PR DESCRIPTION
Closes #475 the oldest issue.

Mgv6 is no longer the most used mapgen, it has a small number of small biomes, 1/3rd of which have flowers, and all flower types spawn together. The newer mapgens have patchy flower types distributed on a larger scale and a larger number of larger biomes, a smaller proportion of which have flowers. It's quite possible to not find a rose for 1000s of nodes.

The mattress is the bulk of the item and it is reasonable to craft this using 3 white wool. Requiring dye is potentially frustrating as it is a non-essential and trivial part of a bed.
This also makes beds craftable in a larger number of special circumstances, where roses or dye may not be available.

Coloured bed mods have been checked, the only recipe conflict is an experimental mod meant to be a replacement for the beds mod.

@Ezhh 