### PR TITLE
Enable colored Luacheck output on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: generic
-sudo: false
 addons:
   apt:
     packages:
     - luarocks
 before_install:
   - luarocks install --local luacheck
-script: 
-- $HOME/.luarocks/bin/luacheck --no-color ./mods
+script:
+- $HOME/.luarocks/bin/luacheck ./mods
 notifications:
   email: false


### PR DESCRIPTION
This also removes the deprecated `sudo: false` option, as [Travis CI is phasing out the container-based infrastructure](https://docs.travis-ci.com/user/reference/trusty/#container-based-infrastructure).

Colored console output has been supported by Travis CI for a while now.