### PR TITLE
Fix builtin item metatable.

### DIFF
--- a/mods/default/item_entity.lua
+++ b/mods/default/item_entity.lua
@@ -70,5 +70,5 @@ local item = {
 }
 
 -- set defined item as new __builtin:item, with the old one as fallback table
-setmetatable(item, builtin_item)
+setmetatable(item, { __index = builtin_item })
 minetest.register_entity(":__builtin:item", item)


### PR DESCRIPTION
This is a cleaned up version of #2286 , applied on top of `stable-5`.