### PR TITLE
Flowers mod: Light check optimisation in mushroom spread

### DIFF
--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -221,8 +221,10 @@ minetest.register_node("flowers:mushroom_brown", {
 -- Mushroom spread and death
 
 function flowers.mushroom_spread(pos, node)
-	if minetest.get_node_light(pos, nil) == 15 then
-		minetest.remove_node(pos)
+	if minetest.get_node_light(pos, 0.5) > 3 then
+		if minetest.get_node_light(pos, nil) == 15 then
+			minetest.remove_node(pos)
+		end
 		return
 	end
 	local positions = minetest.find_nodes_in_area_under_air(
@@ -234,8 +236,7 @@ function flowers.mushroom_spread(pos, node)
 	end
 	local pos2 = positions[math.random(#positions)]
 	pos2.y = pos2.y + 1
-	if minetest.get_node_light(pos, 0.5) <= 3 and
-			minetest.get_node_light(pos2, 0.5) <= 3 then
+	if minetest.get_node_light(pos2, 0.5) <= 3 then
 		minetest.set_node(pos2, {name = node.name})
 	end
 end


### PR DESCRIPTION
Flowers are small, so many items can be carried in one stack.
mushroom_spread searched for nodes even when no nodes are grown due to low light at pos.