### PR TITLE
Restrict waving liquid shader to normal water

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -2188,6 +2188,7 @@ minetest.register_node("default:coral_skeleton", {
 minetest.register_node("default:water_source", {
 	description = "Water Source",
 	drawtype = "liquid",
+	waving = 3,
 	tiles = {
 		{
 			name = "default_water_source_animated.png",
@@ -2231,6 +2232,7 @@ minetest.register_node("default:water_source", {
 minetest.register_node("default:water_flowing", {
 	description = "Flowing Water",
 	drawtype = "flowingliquid",
+	waving = 3,
 	tiles = {"default_water.png"},
 	special_tiles = {
 		{


### PR DESCRIPTION
![screenshot_20190327_021200](https://user-images.githubusercontent.com/3686677/55045477-d34c6a00-5035-11e9-94f0-f133ab38671a.png)

Necessary change due to https://github.com/minetest/minetest/pull/8418
Now the true edge of lava is clear, and river water doesn't have ocean waves.