### PR TITLE
Use mod.conf, remove depends.txt. Move loot registration to individual mods

### DIFF
--- a/mods/beds/depends.txt
+++ b/mods/beds/depends.txt
@@ -1,2 +1,0 @@
-default
-wool

--- a/mods/beds/mod.conf
+++ b/mods/beds/mod.conf
@@ -1,0 +1,4 @@
+name = beds
+description = Minetest Game mod: beds
+depends = default, wool
+optional_depends = 

--- a/mods/binoculars/depends.txt
+++ b/mods/binoculars/depends.txt
@@ -1,2 +1,0 @@
-default
-creative?

--- a/mods/binoculars/mod.conf
+++ b/mods/binoculars/mod.conf
@@ -1,0 +1,4 @@
+name = binoculars
+description = Minetest Game mod: binoculars
+depends = default
+optional_depends = creative

--- a/mods/boats/depends.txt
+++ b/mods/boats/depends.txt
@@ -1,2 +1,0 @@
-default
-player_api

--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -31,6 +31,7 @@ end
 
 local function after_detach(name, pos)
 	local player = minetest.get_player_by_name(name)
+	
 	if player then
 		player:set_pos(pos)
 	end
@@ -39,6 +40,7 @@ end
 
 local function after_attach(name)
 	local player = minetest.get_player_by_name(name)
+	
 	if player then
 		player_api.set_animation(player, "sit" , 30)
 	end

--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -28,6 +28,25 @@ local function get_v(v)
 	return math.sqrt(v.x ^ 2 + v.z ^ 2)
 end
 
+
+local function after_detach(name, pos)
+  local player = minetest.get_player_by_name(name)
+  
+  if player then
+    player:set_pos(pos)
+  end
+end
+
+
+local function after_attach(name)
+  local player = minetest.get_player_by_name(name)
+  
+  if player then
+    player_api.set_animation(player, "sit" , 30)
+  end
+end
+
+
 --
 -- Boat entity
 --
@@ -55,7 +74,9 @@ function boat.on_rightclick(self, clicker)
 	if not clicker or not clicker:is_player() then
 		return
 	end
+  
 	local name = clicker:get_player_name()
+  
 	if self.driver and name == self.driver then
 		self.driver = nil
 		self.auto = false
@@ -64,13 +85,10 @@ function boat.on_rightclick(self, clicker)
 		player_api.set_animation(clicker, "stand" , 30)
 		local pos = clicker:get_pos()
 		pos = {x = pos.x, y = pos.y + 0.2, z = pos.z}
-		minetest.after(0.1, function()
-      if clicker then
-        clicker:set_pos(pos)
-      end
-		end)
+		minetest.after(0.1, after_detach, name, pos)
 	elseif not self.driver then
 		local attach = clicker:get_attach()
+    
 		if attach and attach:get_luaentity() then
 			local luaentity = attach:get_luaentity()
 			if luaentity.driver then
@@ -78,15 +96,12 @@ function boat.on_rightclick(self, clicker)
 			end
 			clicker:set_detach()
 		end
+    
 		self.driver = name
 		clicker:set_attach(self.object, "",
 			{x = 0.5, y = 1, z = -3}, {x = 0, y = 0, z = 0})
 		player_api.player_attached[name] = true
-		minetest.after(0.2, function()
-      if clicker then
-        player_api.set_animation(clicker, "sit" , 30)
-      end
-		end)
+		minetest.after(0.2, after_attach, name)
 		clicker:set_look_horizontal(self.object:get_yaw())
 	end
 end

--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -30,22 +30,28 @@ end
 
 
 local function after_detach(name, pos)
-  local player = minetest.get_player_by_name(name)
-  
-  if player then
-    player:set_pos(pos)
-  end
+	local player = minetest.get_player_by_name(name)
+	
+	if player then
+		player:set_pos(pos)
+	end
 end
 
 
 local function after_attach(name)
-  local player = minetest.get_player_by_name(name)
-  
-  if player then
-    player_api.set_animation(player, "sit" , 30)
-  end
+	local player = minetest.get_player_by_name(name)
+	
+	if player then
+		player_api.set_animation(player, "sit" , 30)
+	end
 end
 
+
+local function after_remove(object)
+	if object then
+		object:remove()
+	end
+end
 
 --
 -- Boat entity
@@ -74,9 +80,7 @@ function boat.on_rightclick(self, clicker)
 	if not clicker or not clicker:is_player() then
 		return
 	end
-  
 	local name = clicker:get_player_name()
-  
 	if self.driver and name == self.driver then
 		self.driver = nil
 		self.auto = false
@@ -88,7 +92,6 @@ function boat.on_rightclick(self, clicker)
 		minetest.after(0.1, after_detach, name, pos)
 	elseif not self.driver then
 		local attach = clicker:get_attach()
-    
 		if attach and attach:get_luaentity() then
 			local luaentity = attach:get_luaentity()
 			if luaentity.driver then
@@ -96,7 +99,6 @@ function boat.on_rightclick(self, clicker)
 			end
 			clicker:set_detach()
 		end
-    
 		self.driver = name
 		clicker:set_attach(self.object, "",
 			{x = 0.5, y = 1, z = -3}, {x = 0, y = 0, z = 0})
@@ -152,9 +154,7 @@ function boat.on_punch(self, puncher)
 			end
 		end
 		-- delay remove to ensure player is detached
-		minetest.after(0.1, function()
-			self.object:remove()
-		end)
+		minetest.after(0.1, after_remove, self.object)
 	end
 end
 

--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -65,9 +65,7 @@ function boat.on_rightclick(self, clicker)
 		local pos = clicker:get_pos()
 		pos = {x = pos.x, y = pos.y + 0.2, z = pos.z}
 		minetest.after(0.1, function()
-      if clicker then
-        clicker:set_pos(pos)
-      end
+			clicker:set_pos(pos)
 		end)
 	elseif not self.driver then
 		local attach = clicker:get_attach()
@@ -83,9 +81,7 @@ function boat.on_rightclick(self, clicker)
 			{x = 0.5, y = 1, z = -3}, {x = 0, y = 0, z = 0})
 		player_api.player_attached[name] = true
 		minetest.after(0.2, function()
-      if clicker then
-        player_api.set_animation(clicker, "sit" , 30)
-      end
+			player_api.set_animation(clicker, "sit" , 30)
 		end)
 		clicker:set_look_horizontal(self.object:get_yaw())
 	end

--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -65,7 +65,9 @@ function boat.on_rightclick(self, clicker)
 		local pos = clicker:get_pos()
 		pos = {x = pos.x, y = pos.y + 0.2, z = pos.z}
 		minetest.after(0.1, function()
-			clicker:set_pos(pos)
+      if clicker then
+        clicker:set_pos(pos)
+      end
 		end)
 	elseif not self.driver then
 		local attach = clicker:get_attach()
@@ -81,7 +83,9 @@ function boat.on_rightclick(self, clicker)
 			{x = 0.5, y = 1, z = -3}, {x = 0, y = 0, z = 0})
 		player_api.player_attached[name] = true
 		minetest.after(0.2, function()
-			player_api.set_animation(clicker, "sit" , 30)
+      if clicker then
+        player_api.set_animation(clicker, "sit" , 30)
+      end
 		end)
 		clicker:set_look_horizontal(self.object:get_yaw())
 	end

--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -30,28 +30,22 @@ end
 
 
 local function after_detach(name, pos)
-	local player = minetest.get_player_by_name(name)
-	
-	if player then
-		player:set_pos(pos)
-	end
+  local player = minetest.get_player_by_name(name)
+  
+  if player then
+    player:set_pos(pos)
+  end
 end
 
 
 local function after_attach(name)
-	local player = minetest.get_player_by_name(name)
-	
-	if player then
-		player_api.set_animation(player, "sit" , 30)
-	end
+  local player = minetest.get_player_by_name(name)
+  
+  if player then
+    player_api.set_animation(player, "sit" , 30)
+  end
 end
 
-
-local function after_remove(object)
-	if object then
-		object:remove()
-	end
-end
 
 --
 -- Boat entity
@@ -80,7 +74,9 @@ function boat.on_rightclick(self, clicker)
 	if not clicker or not clicker:is_player() then
 		return
 	end
+  
 	local name = clicker:get_player_name()
+  
 	if self.driver and name == self.driver then
 		self.driver = nil
 		self.auto = false
@@ -92,6 +88,7 @@ function boat.on_rightclick(self, clicker)
 		minetest.after(0.1, after_detach, name, pos)
 	elseif not self.driver then
 		local attach = clicker:get_attach()
+    
 		if attach and attach:get_luaentity() then
 			local luaentity = attach:get_luaentity()
 			if luaentity.driver then
@@ -99,6 +96,7 @@ function boat.on_rightclick(self, clicker)
 			end
 			clicker:set_detach()
 		end
+    
 		self.driver = name
 		clicker:set_attach(self.object, "",
 			{x = 0.5, y = 1, z = -3}, {x = 0, y = 0, z = 0})
@@ -154,7 +152,9 @@ function boat.on_punch(self, puncher)
 			end
 		end
 		-- delay remove to ensure player is detached
-		minetest.after(0.1, after_remove, self.object)
+		minetest.after(0.1, function()
+			self.object:remove()
+		end)
 	end
 end
 

--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -31,7 +31,6 @@ end
 
 local function after_detach(name, pos)
 	local player = minetest.get_player_by_name(name)
-	
 	if player then
 		player:set_pos(pos)
 	end
@@ -40,7 +39,6 @@ end
 
 local function after_attach(name)
 	local player = minetest.get_player_by_name(name)
-	
 	if player then
 		player_api.set_animation(player, "sit" , 30)
 	end

--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -28,25 +28,6 @@ local function get_v(v)
 	return math.sqrt(v.x ^ 2 + v.z ^ 2)
 end
 
-
-local function after_detach(name, pos)
-  local player = minetest.get_player_by_name(name)
-  
-  if player then
-    player:set_pos(pos)
-  end
-end
-
-
-local function after_attach(name)
-  local player = minetest.get_player_by_name(name)
-  
-  if player then
-    player_api.set_animation(player, "sit" , 30)
-  end
-end
-
-
 --
 -- Boat entity
 --
@@ -74,9 +55,7 @@ function boat.on_rightclick(self, clicker)
 	if not clicker or not clicker:is_player() then
 		return
 	end
-  
 	local name = clicker:get_player_name()
-  
 	if self.driver and name == self.driver then
 		self.driver = nil
 		self.auto = false
@@ -85,10 +64,13 @@ function boat.on_rightclick(self, clicker)
 		player_api.set_animation(clicker, "stand" , 30)
 		local pos = clicker:get_pos()
 		pos = {x = pos.x, y = pos.y + 0.2, z = pos.z}
-		minetest.after(0.1, after_detach, name, pos)
+		minetest.after(0.1, function()
+      if clicker then
+        clicker:set_pos(pos)
+      end
+		end)
 	elseif not self.driver then
 		local attach = clicker:get_attach()
-    
 		if attach and attach:get_luaentity() then
 			local luaentity = attach:get_luaentity()
 			if luaentity.driver then
@@ -96,12 +78,15 @@ function boat.on_rightclick(self, clicker)
 			end
 			clicker:set_detach()
 		end
-    
 		self.driver = name
 		clicker:set_attach(self.object, "",
 			{x = 0.5, y = 1, z = -3}, {x = 0, y = 0, z = 0})
 		player_api.player_attached[name] = true
-		minetest.after(0.2, after_attach, name)
+		minetest.after(0.2, function()
+      if clicker then
+        player_api.set_animation(clicker, "sit" , 30)
+      end
+		end)
 		clicker:set_look_horizontal(self.object:get_yaw())
 	end
 end

--- a/mods/boats/mod.conf
+++ b/mods/boats/mod.conf
@@ -1,0 +1,4 @@
+name = boats
+description = Minetest Game mod: boats
+depends = default, player_api
+optional_depends = 

--- a/mods/bones/depends.txt
+++ b/mods/bones/depends.txt
@@ -1,1 +1,0 @@
-default

--- a/mods/bones/mod.conf
+++ b/mods/bones/mod.conf
@@ -1,0 +1,4 @@
+name = bones
+description = Minetest Game mod: bones
+depends = default
+optional_depends = 

--- a/mods/bucket/depends.txt
+++ b/mods/bucket/depends.txt
@@ -1,2 +1,2 @@
 default
-
+dungeon_loot?

--- a/mods/bucket/depends.txt
+++ b/mods/bucket/depends.txt
@@ -1,2 +1,0 @@
-default
-dungeon_loot?

--- a/mods/bucket/init.lua
+++ b/mods/bucket/init.lua
@@ -231,5 +231,5 @@ if dungeon_loot and dungeon_loot.register then
 	}
 	for _,loot in pairs(loot_list) do
 		dungeon_loot.register(loot)
-    end
+	end
 end

--- a/mods/bucket/init.lua
+++ b/mods/bucket/init.lua
@@ -220,3 +220,16 @@ minetest.register_craft({
 	replacements = {{"bucket:bucket_lava", "bucket:bucket_empty"}},
 })
 
+-- register buckets as dungeon loot
+if dungeon_loot and dungeon_loot.register then
+	local loot_list = {
+		{name = "bucket:bucket_empty", chance = 0.55},
+		-- water in deserts or above ground, lava otherwise
+		{name = "bucket:bucket_water", chance = 0.45, types = {"sandstone", "desert"}},
+		{name = "bucket:bucket_water", chance = 0.45, y = {0, 32768}, types = {"normal"}},
+		{name = "bucket:bucket_lava", chance = 0.45, y = {-32768, -1}, types = {"normal"}}
+	}
+	for _,loot in pairs(loot_list) do
+		dungeon_loot.register(loot)
+    end
+end

--- a/mods/bucket/mod.conf
+++ b/mods/bucket/mod.conf
@@ -1,0 +1,4 @@
+name = bucket
+description = Minetest Game mod: bucket
+depends = default
+optional_depends = dungeon_loot

--- a/mods/butterflies/depends.txt
+++ b/mods/butterflies/depends.txt
@@ -1,2 +1,0 @@
-default
-flowers

--- a/mods/butterflies/mod.conf
+++ b/mods/butterflies/mod.conf
@@ -1,0 +1,4 @@
+name = butterflies
+description = Minetest Game mod: Butterflies
+depends = default, flowers
+optional_depends = 

--- a/mods/carts/depends.txt
+++ b/mods/carts/depends.txt
@@ -1,3 +1,0 @@
-default
-player_api
-dungeon_loot?

--- a/mods/carts/depends.txt
+++ b/mods/carts/depends.txt
@@ -1,2 +1,3 @@
 default
 player_api
+dungeon_loot?

--- a/mods/carts/init.lua
+++ b/mods/carts/init.lua
@@ -22,5 +22,5 @@ if dungeon_loot and dungeon_loot.register then
 	}
 	for _,loot in pairs(loot_list) do
 		dungeon_loot.register(loot)
-    end
+	end
 end

--- a/mods/carts/init.lua
+++ b/mods/carts/init.lua
@@ -14,3 +14,13 @@ carts.path_distance_max = 3
 dofile(carts.modpath.."/functions.lua")
 dofile(carts.modpath.."/rails.lua")
 dofile(carts.modpath.."/cart_entity.lua")
+
+-- register cart as dungeon loot
+if dungeon_loot and dungeon_loot.register then
+	local loot_list = {
+		{name = "carts:rail", chance = 0.35, count = {1, 6}},
+	}
+	for _,loot in pairs(loot_list) do
+		dungeon_loot.register(loot)
+    end
+end

--- a/mods/carts/mod.conf
+++ b/mods/carts/mod.conf
@@ -1,0 +1,4 @@
+name = carts
+description = Carts (formerly boost_cart)
+depends = default, player_api
+optional_depends = dungeon_loot

--- a/mods/creative/depends.txt
+++ b/mods/creative/depends.txt
@@ -1,2 +1,0 @@
-default
-sfinv

--- a/mods/creative/mod.conf
+++ b/mods/creative/mod.conf
@@ -1,0 +1,4 @@
+name = creative
+description = Minetest Game mod: creative
+depends = default, sfinv
+optional_depends = 

--- a/mods/default/depends.txt
+++ b/mods/default/depends.txt
@@ -1,1 +1,0 @@
-player_api?

--- a/mods/default/mod.conf
+++ b/mods/default/mod.conf
@@ -1,0 +1,4 @@
+name = default
+description = Minetest Game mod: default
+depends = 
+optional_depends = player_api

--- a/mods/doors/depends.txt
+++ b/mods/doors/depends.txt
@@ -1,2 +1,0 @@
-default
-screwdriver?

--- a/mods/doors/mod.conf
+++ b/mods/doors/mod.conf
@@ -1,0 +1,4 @@
+name = doors
+description = Minetest Game mod: doors
+depends = default
+optional_depends = screwdriver

--- a/mods/dungeon_loot/default_loot_registration.lua
+++ b/mods/dungeon_loot/default_loot_registration.lua
@@ -1,0 +1,28 @@
+-- register items as dungeon loot
+local loot_list = {
+	-- various items
+	{name = "default:stick", chance = 0.6, count = {3, 6}},
+	{name = "default:flint", chance = 0.4, count = {1, 3}},
+	-- farming / consumable
+	{name = "default:apple", chance = 0.4, count = {1, 4}},
+	{name = "default:cactus", chance = 0.4, count = {1, 4}, types = {"sandstone", "desert"}},
+	-- minerals
+	{name = "default:coal_lump", chance = 0.9, count = {1, 12}},
+	{name = "default:gold_ingot", chance = 0.5},
+	{name = "default:steel_ingot", chance = 0.4, count = {1, 6}},
+	{name = "default:mese_crystal", chance = 0.1, count = {2, 3}},
+	-- tools
+	{name = "default:sword_wood", chance = 0.6},
+	{name = "default:pick_stone", chance = 0.3},
+	{name = "default:axe_diamond", chance = 0.05},
+	-- natural materials
+	{name = "default:sand", chance = 0.8, count = {4, 32}, y = {-64, 32768}, types = {"normal"}},
+	{name = "default:desert_sand", chance = 0.8, count = {4, 32}, y = {-64, 32768}, types = {"sandstone"}},
+	{name = "default:desert_cobble", chance = 0.8, count = {4, 32}, types = {"desert"}},
+	{name = "default:dirt", chance = 0.6, count = {2, 16}, y = {-64, 32768}},
+	{name = "default:obsidian", chance = 0.25, count = {1, 3}, y = {-32768, -512}},
+	{name = "default:mese", chance = 0.15, y = {-32768, -512}},
+}
+for _,loot in pairs(loot_list) do
+	dungeon_loot.register(loot)
+end

--- a/mods/dungeon_loot/depends.txt
+++ b/mods/dungeon_loot/depends.txt
@@ -1,1 +1,0 @@
-default

--- a/mods/dungeon_loot/init.lua
+++ b/mods/dungeon_loot/init.lua
@@ -6,3 +6,4 @@ dungeon_loot.STACKS_PER_CHEST_MAX = 8
 
 dofile(minetest.get_modpath("dungeon_loot") .. "/loot.lua")
 dofile(minetest.get_modpath("dungeon_loot") .. "/mapgen.lua")
+dofile(minetest.get_modpath("dungeon_loot") .. "/default_loot_registration.lua")

--- a/mods/dungeon_loot/loot.lua
+++ b/mods/dungeon_loot/loot.lua
@@ -1,43 +1,4 @@
-dungeon_loot.registered_loot = {
-	-- buckets
-	{name = "bucket:bucket_empty", chance = 0.55},
-	-- water in deserts or above ground, lava otherwise
-	{name = "bucket:bucket_water", chance = 0.45, types = {"sandstone", "desert"}},
-	{name = "bucket:bucket_water", chance = 0.45, y = {0, 32768}, types = {"normal"}},
-	{name = "bucket:bucket_lava", chance = 0.45, y = {-32768, -1}, types = {"normal"}},
-
-	-- various items
-	{name = "default:stick", chance = 0.6, count = {3, 6}},
-	{name = "default:flint", chance = 0.4, count = {1, 3}},
-	{name = "vessels:glass_fragments", chance = 0.35, count = {1, 4}},
-	{name = "carts:rail", chance = 0.35, count = {1, 6}},
-
-	-- farming / consumable
-	{name = "farming:string", chance = 0.5, count = {1, 8}},
-	{name = "farming:wheat", chance = 0.5, count = {2, 5}},
-	{name = "default:apple", chance = 0.4, count = {1, 4}},
-	{name = "farming:seed_cotton", chance = 0.4, count = {1, 4}, types = {"normal"}},
-	{name = "default:cactus", chance = 0.4, count = {1, 4}, types = {"sandstone", "desert"}},
-
-	-- minerals
-	{name = "default:coal_lump", chance = 0.9, count = {1, 12}},
-	{name = "default:gold_ingot", chance = 0.5},
-	{name = "default:steel_ingot", chance = 0.4, count = {1, 6}},
-	{name = "default:mese_crystal", chance = 0.1, count = {2, 3}},
-
-	-- tools
-	{name = "default:sword_wood", chance = 0.6},
-	{name = "default:pick_stone", chance = 0.3},
-	{name = "default:axe_diamond", chance = 0.05},
-
-	-- natural materials
-	{name = "default:sand", chance = 0.8, count = {4, 32}, y = {-64, 32768}, types = {"normal"}},
-	{name = "default:desert_sand", chance = 0.8, count = {4, 32}, y = {-64, 32768}, types = {"sandstone"}},
-	{name = "default:desert_cobble", chance = 0.8, count = {4, 32}, types = {"desert"}},
-	{name = "default:dirt", chance = 0.6, count = {2, 16}, y = {-64, 32768}},
-	{name = "default:obsidian", chance = 0.25, count = {1, 3}, y = {-32768, -512}},
-	{name = "default:mese", chance = 0.15, y = {-32768, -512}},
-}
+dungeon_loot.registered_loot = {}
 
 function dungeon_loot.register(t)
 	if t.name ~= nil then

--- a/mods/dungeon_loot/mod.conf
+++ b/mods/dungeon_loot/mod.conf
@@ -1,0 +1,4 @@
+name = dungeon_loot
+description = Minetest Game mod: dungeon_loot
+depends = default
+optional_depends = 

--- a/mods/dye/mod.conf
+++ b/mods/dye/mod.conf
@@ -1,0 +1,4 @@
+name = dye
+description = Minetest Game mod: dye
+depends = 
+optional_depends = 

--- a/mods/farming/depends.txt
+++ b/mods/farming/depends.txt
@@ -1,3 +1,4 @@
 default
 wool
 stairs
+dungeon_loot?

--- a/mods/farming/depends.txt
+++ b/mods/farming/depends.txt
@@ -1,4 +1,0 @@
-default
-wool
-stairs
-dungeon_loot?

--- a/mods/farming/init.lua
+++ b/mods/farming/init.lua
@@ -148,5 +148,5 @@ if dungeon_loot and dungeon_loot.register then
 	}
 	for _,loot in pairs(loot_list) do
 		dungeon_loot.register(loot)
-    end
+	end
 end

--- a/mods/farming/init.lua
+++ b/mods/farming/init.lua
@@ -137,3 +137,16 @@ minetest.register_craft({
 	recipe = "farming:hoe_wood",
 	burntime = 5,
 })
+
+-- register farming items as dungeon loot
+if dungeon_loot and dungeon_loot.register then
+	local loot_list = {
+		-- farming / consumable
+		{name = "farming:string", chance = 0.5, count = {1, 8}},
+		{name = "farming:wheat", chance = 0.5, count = {2, 5}},
+		{name = "farming:seed_cotton", chance = 0.4, count = {1, 4}, types = {"normal"}},
+	}
+	for _,loot in pairs(loot_list) do
+		dungeon_loot.register(loot)
+    end
+end

--- a/mods/farming/mod.conf
+++ b/mods/farming/mod.conf
@@ -1,0 +1,4 @@
+name = farming
+description = Minetest Game mod: farming
+depends = default, wool, stairs
+optional_depends = dungeon_loot

--- a/mods/fire/depends.txt
+++ b/mods/fire/depends.txt
@@ -1,1 +1,0 @@
-default

--- a/mods/fire/mod.conf
+++ b/mods/fire/mod.conf
@@ -1,0 +1,4 @@
+name = fire
+description = Minetest Game mod: fire
+depends = default
+optional_depends = 

--- a/mods/fireflies/depends.txt
+++ b/mods/fireflies/depends.txt
@@ -1,2 +1,0 @@
-default
-vessels

--- a/mods/fireflies/mod.conf
+++ b/mods/fireflies/mod.conf
@@ -1,0 +1,4 @@
+name = fireflies
+description = Minetest Game mod: fireflies
+depends = default, vessels
+optional_depends = 

--- a/mods/flowers/depends.txt
+++ b/mods/flowers/depends.txt
@@ -1,1 +1,0 @@
-default

--- a/mods/flowers/mod.conf
+++ b/mods/flowers/mod.conf
@@ -1,0 +1,4 @@
+name = flowers
+description = Minetest Game mod: flowers
+depends = default
+optional_depends = 

--- a/mods/game_commands/mod.conf
+++ b/mods/game_commands/mod.conf
@@ -1,0 +1,4 @@
+name = game_commands
+description = Minetest Game mod: game_commands
+depends = 
+optional_depends = 

--- a/mods/give_initial_stuff/depends.txt
+++ b/mods/give_initial_stuff/depends.txt
@@ -1,2 +1,0 @@
-default
-

--- a/mods/give_initial_stuff/mod.conf
+++ b/mods/give_initial_stuff/mod.conf
@@ -1,0 +1,4 @@
+name = give_initial_stuff
+description = Minetest Game mod: give_initial_stuff
+depends = default
+optional_depends = 

--- a/mods/map/depends.txt
+++ b/mods/map/depends.txt
@@ -1,3 +1,0 @@
-default
-dye
-creative?

--- a/mods/map/mod.conf
+++ b/mods/map/mod.conf
@@ -1,0 +1,4 @@
+name = map
+description = Minetest Game mod: map
+depends = default, dye
+optional_depends = creative

--- a/mods/player_api/mod.conf
+++ b/mods/player_api/mod.conf
@@ -1,0 +1,4 @@
+name = player_api
+description = Minetest Game mod: player_api
+depends = 
+optional_depends = 

--- a/mods/screwdriver/mod.conf
+++ b/mods/screwdriver/mod.conf
@@ -1,0 +1,4 @@
+name = screwdriver
+description = Minetest Game mod: screwdriver
+depends = 
+optional_depends = 

--- a/mods/sethome/mod.conf
+++ b/mods/sethome/mod.conf
@@ -1,0 +1,4 @@
+name = sethome
+description = Minetest Game mod: sethome
+depends = 
+optional_depends = 

--- a/mods/sfinv/mod.conf
+++ b/mods/sfinv/mod.conf
@@ -1,0 +1,4 @@
+name = sfinv
+description = Minetest Game mod: sfinv
+depends = 
+optional_depends = 

--- a/mods/spawn/depends.txt
+++ b/mods/spawn/depends.txt
@@ -1,2 +1,0 @@
-default
-beds?

--- a/mods/spawn/mod.conf
+++ b/mods/spawn/mod.conf
@@ -1,0 +1,4 @@
+name = spawn
+description = Minetest Game mod: spawn
+depends = default
+optional_depends = beds

--- a/mods/stairs/depends.txt
+++ b/mods/stairs/depends.txt
@@ -1,1 +1,0 @@
-default

--- a/mods/stairs/mod.conf
+++ b/mods/stairs/mod.conf
@@ -1,0 +1,4 @@
+name = stairs
+description = Minetest Game mod: stairs
+depends = default
+optional_depends = 

--- a/mods/tnt/depends.txt
+++ b/mods/tnt/depends.txt
@@ -1,3 +1,0 @@
-default
-fire
-

--- a/mods/tnt/mod.conf
+++ b/mods/tnt/mod.conf
@@ -1,0 +1,4 @@
+name = tnt
+description = Minetest Game mod: tnt
+depends = default, fire
+optional_depends = 

--- a/mods/vessels/depends.txt
+++ b/mods/vessels/depends.txt
@@ -1,1 +1,2 @@
 default
+dungeon_loot?

--- a/mods/vessels/depends.txt
+++ b/mods/vessels/depends.txt
@@ -1,2 +1,0 @@
-default
-dungeon_loot?

--- a/mods/vessels/init.lua
+++ b/mods/vessels/init.lua
@@ -219,5 +219,5 @@ if dungeon_loot and dungeon_loot.register then
 	}
 	for _,loot in pairs(loot_list) do
 		dungeon_loot.register(loot)
-    end
+	end
 end

--- a/mods/vessels/init.lua
+++ b/mods/vessels/init.lua
@@ -211,3 +211,13 @@ minetest.register_craft({
 	recipe = "vessels:shelf",
 	burntime = 30,
 })
+
+-- register glass_fragments as dungeon loot
+if dungeon_loot and dungeon_loot.register then
+	local loot_list = {
+		{name = "vessels:glass_fragments", chance = 0.35, count = {1, 4}},
+	}
+	for _,loot in pairs(loot_list) do
+		dungeon_loot.register(loot)
+    end
+end

--- a/mods/vessels/mod.conf
+++ b/mods/vessels/mod.conf
@@ -1,0 +1,4 @@
+name = vessels
+description = Minetest Game mod: vessels
+depends = default
+optional_depends = dungeon_loot

--- a/mods/walls/depends.txt
+++ b/mods/walls/depends.txt
@@ -1,1 +1,0 @@
-default

--- a/mods/walls/mod.conf
+++ b/mods/walls/mod.conf
@@ -1,0 +1,4 @@
+name = walls
+description = Minetest Game mod: walls
+depends = default
+optional_depends = 

--- a/mods/wool/depends.txt
+++ b/mods/wool/depends.txt
@@ -1,1 +1,0 @@
-default

--- a/mods/wool/mod.conf
+++ b/mods/wool/mod.conf
@@ -1,0 +1,4 @@
+name = wool
+description = Minetest Game mod: wool
+depends = default
+optional_depends = 

--- a/mods/xpanes/depends.txt
+++ b/mods/xpanes/depends.txt
@@ -1,1 +1,0 @@
-default

--- a/mods/xpanes/mod.conf
+++ b/mods/xpanes/mod.conf
@@ -1,0 +1,4 @@
+name = xpanes
+description = Minetest Game mod: xpanes
+depends = default
+optional_depends = 


### PR DESCRIPTION
Fixes #2340 and #2334 

Added all of the mod.conf files, moved dungeon loot registration from dungeon_loot to respective mods (except for default's which dungeon_loot depends on).