### PR TITLE
Disable crafting large cactus seedling

### DIFF
--- a/mods/default/crafting.lua
+++ b/mods/default/crafting.lua
@@ -779,15 +779,6 @@ minetest.register_craft({
 	}
 })
 
-minetest.register_craft({
-	output = "default:large_cactus_seedling",
-	recipe = {
-		{"", "default:cactus", ""},
-		{"default:cactus", "default:cactus", "default:cactus"},
-		{"", "default:cactus", ""},
-	}
-})
-
 
 --
 -- Crafting (tool repair)


### PR DESCRIPTION
This will prevent mass cactus manufacturing and possibility of burdening system if planted in large quantity. Otherwise mass manufacturing will be meaningless.