### PR TITLE
Reset spawn position on bed destruction

### DIFF
--- a/mods/beds/api.lua
+++ b/mods/beds/api.lua
@@ -17,6 +17,8 @@ local function destruct_bed(pos, n)
 		reverse = not reverse
 		minetest.remove_node(other)
 		minetest.check_for_falling(other)
+		beds.remove_spawns_at(pos)
+		beds.remove_spawns_at(other)
 	else
 		reverse = not reverse
 	end

--- a/mods/beds/spawns.lua
+++ b/mods/beds/spawns.lua
@@ -61,3 +61,12 @@ function beds.set_spawns()
 	end
 	beds.save_spawns()
 end
+
+function beds.remove_spawns_at(pos)
+	for name, p in pairs(beds.spawn) do
+		if vector.equals(vector.round(p), pos) then
+			beds.spawn[name] = nil
+		end
+	end
+	beds.save_spawns()
+end


### PR DESCRIPTION
Fixes #2300.

This only works for spawn positions as they are set currently. Respawn positions i.e. next to the bed are not removed.
This might be not perfect.