### PR TITLE
Move duplicate recipe from books to default.register_duplicate_recipe()

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -1055,3 +1055,11 @@ for the wielded skeleton key.
 
 if `nil` is returned, it is assumed that the wielder did not have
 permissions to create a key for this node, and no key is created.
+
+`default.register_craft_metadata_copy(ingredient, result)`
+----------------------------------------------------------
+
+This function registers a shapeless recipe that takes `ingredient`
+and `result` as input and outputs `result`.
+
+The metadata of the input `result` is copied to the output `result`.

--- a/mods/default/craftitems.lua
+++ b/mods/default/craftitems.lua
@@ -145,29 +145,6 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 	player:set_wielded_item(stack)
 end)
 
-minetest.register_on_craft(function(itemstack, player, old_craft_grid, craft_inv)
-	if itemstack:get_name() ~= "default:book_written" then
-		return
-	end
-
-	local original
-	local index
-	for i = 1, player:get_inventory():get_size("craft") do
-		if old_craft_grid[i]:get_name() == "default:book_written" then
-			original = old_craft_grid[i]
-			index = i
-		end
-	end
-	if not original then
-		return
-	end
-	local copymeta = original:get_meta():to_table()
-	-- copy of the book held by player's mouse cursor
-	itemstack:get_meta():from_table(copymeta)
-	-- put the book with metadata back in the craft grid
-	craft_inv:set_stack("craft", index, original)
-end)
-
 minetest.register_craftitem("default:skeleton_key", {
 	description = S("Skeleton Key"),
 	inventory_image = "default_key_skeleton.png",
@@ -361,11 +338,7 @@ minetest.register_craft({
 	}
 })
 
-minetest.register_craft({
-	type = "shapeless",
-	output = "default:book_written",
-	recipe = {"default:book", "default:book_written"}
-})
+default.register_craft_metadata_copy("default:book", "default:book_written")
 
 minetest.register_craft({
 	output = "default:bronze_ingot 9",

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -581,6 +581,40 @@ minetest.register_abm({
 	end
 })
 
+--
+-- Register a craft to copy the metadata of items
+--
+
+function default.register_craft_metadata_copy(ingredient, result)
+	minetest.register_craft({
+		type = "shapeless",
+		output = result,
+		recipe = {ingredient, result}
+	})
+
+	minetest.register_on_craft(function(itemstack, player, old_craft_grid, craft_inv)
+		if itemstack:get_name() ~= result then
+			return
+		end
+
+		local original
+		local index
+		for i = 1, #old_craft_grid do
+			if old_craft_grid[i]:get_name() == result then
+				original = old_craft_grid[i]
+				index = i
+			end
+		end
+		if not original then
+			return
+		end
+		local copymeta = original:get_meta():to_table()
+		itemstack:get_meta():from_table(copymeta)
+		-- put the book with metadata back in the craft grid
+		craft_inv:set_stack("craft", index, original)
+	end)
+end
+
 
 --
 -- NOTICE: This method is not an official part of the API yet.


### PR DESCRIPTION
This allows mods to easily implement the same behaviour, e.g. for letters.
In my opinion, this is quite a trivial change for Minetest Game, but it allows to reduce code duplication in mods.

Tested and seems to work.