### PR TITLE
wool to make use of global dye.dyes

### DIFF
--- a/mods/wool/depends.txt
+++ b/mods/wool/depends.txt
@@ -1,1 +1,2 @@
 default
+dye

--- a/mods/wool/init.lua
+++ b/mods/wool/init.lua
@@ -1,20 +1,4 @@
-local dyes = {
-	{"white",      "White"},
-	{"grey",       "Grey"},
-	{"black",      "Black"},
-	{"red",        "Red"},
-	{"yellow",     "Yellow"},
-	{"green",      "Green"},
-	{"cyan",       "Cyan"},
-	{"blue",       "Blue"},
-	{"magenta",    "Magenta"},
-	{"orange",     "Orange"},
-	{"violet",     "Violet"},
-	{"brown",      "Brown"},
-	{"pink",       "Pink"},
-	{"dark_grey",  "Dark Grey"},
-	{"dark_green", "Dark Green"},
-}
+local dyes = dye.dyes
 
 for i = 1, #dyes do
 	local name, desc = unpack(dyes[i])


### PR DESCRIPTION
affects two files:
  * mods/wool/depends.txt
  * mods/wool/init.lua

I see no reason why 'wool' should establish local dye definitions by ignoring the global `dye.dyes`