### PR TITLE
Multiple trapdoor face textures option

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -630,7 +630,7 @@ function doors.register_trapdoor(name, def)
 	if not def.sound_close then
 		def.sound_close = "doors_door_close"
 	end
-		
+
 	if not def.tile_back then
 		def.tile_back = def.tile_front
 	end
@@ -646,7 +646,7 @@ function doors.register_trapdoor(name, def)
 		type = "fixed",
 		fixed = {-0.5, -0.5, -0.5, 0.5, -6/16, 0.5}
 	}
-	
+
 	def_closed.tiles = {
 		def.tile_back,
 		def.tile_front .. '^[transformFY',

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -630,6 +630,10 @@ function doors.register_trapdoor(name, def)
 	if not def.sound_close then
 		def.sound_close = "doors_door_close"
 	end
+		
+	if not def.tile_back then
+		def.tile_back = "doors_trapdoor.png"
+	end
 
 	local def_opened = table.copy(def)
 	local def_closed = table.copy(def)
@@ -642,8 +646,9 @@ function doors.register_trapdoor(name, def)
 		type = "fixed",
 		fixed = {-0.5, -0.5, -0.5, 0.5, -6/16, 0.5}
 	}
+	
 	def_closed.tiles = {
-		def.tile_front,
+		def.tile_back,
 		def.tile_front .. '^[transformFY',
 		def.tile_side,
 		def.tile_side,
@@ -659,12 +664,13 @@ function doors.register_trapdoor(name, def)
 		type = "fixed",
 		fixed = {-0.5, -0.5, 6/16, 0.5, 0.5, 0.5}
 	}
+
 	def_opened.tiles = {
 		def.tile_side,
 		def.tile_side .. '^[transform2',
 		def.tile_side .. '^[transform3',
 		def.tile_side .. '^[transform1',
-		def.tile_front .. '^[transform46',
+		def.tile_back .. '^[transform2',
 		def.tile_front .. '^[transform6'
 	}
 
@@ -684,6 +690,7 @@ doors.register_trapdoor("doors:trapdoor", {
 	wield_image = "doors_trapdoor.png",
 	tile_front = "doors_trapdoor.png",
 	tile_side = "doors_trapdoor_side.png",
+	tile_back = "doors_trapdoor.png",
 	groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 2, door = 1},
 })
 
@@ -693,6 +700,7 @@ doors.register_trapdoor("doors:trapdoor_steel", {
 	wield_image = "doors_trapdoor_steel.png",
 	tile_front = "doors_trapdoor_steel.png",
 	tile_side = "doors_trapdoor_steel_side.png",
+	tile_back = "doors_trapdoor_steel.png",
 	protected = true,
 	sounds = default.node_sound_metal_defaults(),
 	sound_open = "doors_steel_door_open",

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -632,7 +632,7 @@ function doors.register_trapdoor(name, def)
 	end
 		
 	if not def.tile_back then
-		def.tile_back = "doors_trapdoor.png"
+		def.tile_back = def.tile_front
 	end
 
 	local def_opened = table.copy(def)
@@ -690,7 +690,6 @@ doors.register_trapdoor("doors:trapdoor", {
 	wield_image = "doors_trapdoor.png",
 	tile_front = "doors_trapdoor.png",
 	tile_side = "doors_trapdoor_side.png",
-	tile_back = "doors_trapdoor.png",
 	groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 2, door = 1},
 })
 
@@ -700,7 +699,6 @@ doors.register_trapdoor("doors:trapdoor_steel", {
 	wield_image = "doors_trapdoor_steel.png",
 	tile_front = "doors_trapdoor_steel.png",
 	tile_side = "doors_trapdoor_steel_side.png",
-	tile_back = "doors_trapdoor_steel.png",
 	protected = true,
 	sounds = default.node_sound_metal_defaults(),
 	sound_open = "doors_steel_door_open",


### PR DESCRIPTION
This adds support for `tile_back` (optional) so that trapdoors can use a different texture on the back face of the trapdoor. If it isn't specified, `tile_front` is used instead.
Instead of adding an extra area for the back texture (like the door), this will allow an extra texture and not ruin any texturepacks.

![test1](https://user-images.githubusercontent.com/49789044/58653432-98a0cf80-830d-11e9-9918-4f2aa14d38ad.png)
![test2](https://user-images.githubusercontent.com/49789044/58653433-98a0cf80-830d-11e9-9a18-70e6500d4c57.png)