### PR TITLE
Add groups for tools/ores/flowers

### DIFF
--- a/mods/bucket/init.lua
+++ b/mods/bucket/init.lua
@@ -114,6 +114,7 @@ minetest.register_craftitem("bucket:bucket_empty", {
 	description = "Empty Bucket",
 	inventory_image = "bucket.png",
 	stack_max = 99,
+	groups = {tool = 1},
 	liquids_pointable = true,
 	on_use = function(itemstack, user, pointed_thing)
 		if pointed_thing.type == "object" then
@@ -186,7 +187,7 @@ bucket.register_liquid(
 	"bucket:bucket_water",
 	"bucket_water.png",
 	"Water Bucket",
-	{water_bucket = 1}
+	{tool = 1, water_bucket = 1}
 )
 
 -- River water source is 'liquid_renewable = false' to avoid horizontal spread
@@ -201,7 +202,7 @@ bucket.register_liquid(
 	"bucket:bucket_river_water",
 	"bucket_river_water.png",
 	"River Water Bucket",
-	{water_bucket = 1},
+	{tool = 1, water_bucket = 1},
 	true
 )
 
@@ -210,7 +211,8 @@ bucket.register_liquid(
 	"default:lava_flowing",
 	"bucket:bucket_lava",
 	"bucket_lava.png",
-	"Lava Bucket"
+	"Lava Bucket",
+	{tool = 1}
 )
 
 minetest.register_craft({

--- a/mods/default/craftitems.lua
+++ b/mods/default/craftitems.lua
@@ -263,16 +263,19 @@ minetest.register_craftitem("default:coal_lump", {
 minetest.register_craftitem("default:iron_lump", {
 	description = "Iron Lump",
 	inventory_image = "default_iron_lump.png",
+	groups = {ore = 1}
 })
 
 minetest.register_craftitem("default:copper_lump", {
 	description = "Copper Lump",
 	inventory_image = "default_copper_lump.png",
+	groups = {ore = 1}
 })
 
 minetest.register_craftitem("default:tin_lump", {
 	description = "Tin Lump",
 	inventory_image = "default_tin_lump.png",
+	groups = {ore = 1}
 })
 
 minetest.register_craftitem("default:mese_crystal", {
@@ -283,6 +286,7 @@ minetest.register_craftitem("default:mese_crystal", {
 minetest.register_craftitem("default:gold_lump", {
 	description = "Gold Lump",
 	inventory_image = "default_gold_lump.png",
+	groups = {ore = 1}
 })
 
 minetest.register_craftitem("default:diamond", {
@@ -298,26 +302,31 @@ minetest.register_craftitem("default:clay_lump", {
 minetest.register_craftitem("default:steel_ingot", {
 	description = "Steel Ingot",
 	inventory_image = "default_steel_ingot.png",
+	groups = {ingot = 1}
 })
 
 minetest.register_craftitem("default:copper_ingot", {
 	description = "Copper Ingot",
 	inventory_image = "default_copper_ingot.png",
+	groups = {ingot = 1}
 })
 
 minetest.register_craftitem("default:tin_ingot", {
 	description = "Tin Ingot",
 	inventory_image = "default_tin_ingot.png",
+	groups = {ingot = 1}
 })
 
 minetest.register_craftitem("default:bronze_ingot", {
 	description = "Bronze Ingot",
 	inventory_image = "default_bronze_ingot.png",
+	groups = {ingot = 1}
 })
 
 minetest.register_craftitem("default:gold_ingot", {
 	description = "Gold Ingot",
-	inventory_image = "default_gold_ingot.png"
+	inventory_image = "default_gold_ingot.png",
+	groups = {ingot = 1}
 })
 
 minetest.register_craftitem("default:mese_crystal_fragment", {

--- a/mods/default/craftitems.lua
+++ b/mods/default/craftitems.lua
@@ -262,20 +262,17 @@ minetest.register_craftitem("default:coal_lump", {
 
 minetest.register_craftitem("default:iron_lump", {
 	description = "Iron Lump",
-	inventory_image = "default_iron_lump.png",
-	groups = {ore = 1}
+	inventory_image = "default_iron_lump.png"
 })
 
 minetest.register_craftitem("default:copper_lump", {
 	description = "Copper Lump",
-	inventory_image = "default_copper_lump.png",
-	groups = {ore = 1}
+	inventory_image = "default_copper_lump.png"
 })
 
 minetest.register_craftitem("default:tin_lump", {
 	description = "Tin Lump",
-	inventory_image = "default_tin_lump.png",
-	groups = {ore = 1}
+	inventory_image = "default_tin_lump.png"
 })
 
 minetest.register_craftitem("default:mese_crystal", {
@@ -285,8 +282,7 @@ minetest.register_craftitem("default:mese_crystal", {
 
 minetest.register_craftitem("default:gold_lump", {
 	description = "Gold Lump",
-	inventory_image = "default_gold_lump.png",
-	groups = {ore = 1}
+	inventory_image = "default_gold_lump.png"
 })
 
 minetest.register_craftitem("default:diamond", {
@@ -301,32 +297,27 @@ minetest.register_craftitem("default:clay_lump", {
 
 minetest.register_craftitem("default:steel_ingot", {
 	description = "Steel Ingot",
-	inventory_image = "default_steel_ingot.png",
-	groups = {ingot = 1}
+	inventory_image = "default_steel_ingot.png"
 })
 
 minetest.register_craftitem("default:copper_ingot", {
 	description = "Copper Ingot",
-	inventory_image = "default_copper_ingot.png",
-	groups = {ingot = 1}
+	inventory_image = "default_copper_ingot.png"
 })
 
 minetest.register_craftitem("default:tin_ingot", {
 	description = "Tin Ingot",
-	inventory_image = "default_tin_ingot.png",
-	groups = {ingot = 1}
+	inventory_image = "default_tin_ingot.png"
 })
 
 minetest.register_craftitem("default:bronze_ingot", {
 	description = "Bronze Ingot",
-	inventory_image = "default_bronze_ingot.png",
-	groups = {ingot = 1}
+	inventory_image = "default_bronze_ingot.png"
 })
 
 minetest.register_craftitem("default:gold_ingot", {
 	description = "Gold Ingot",
-	inventory_image = "default_gold_ingot.png",
-	groups = {ingot = 1}
+	inventory_image = "default_gold_ingot.png"
 })
 
 minetest.register_craftitem("default:mese_crystal_fragment", {

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1138,7 +1138,7 @@ minetest.register_node("default:aspen_sapling", {
 minetest.register_node("default:stone_with_coal", {
 	description = "Coal Ore",
 	tiles = {"default_stone.png^default_mineral_coal.png"},
-	groups = {cracky = 3},
+	groups = {stone_with_ore = 1, cracky = 3},
 	drop = 'default:coal_lump',
 	sounds = default.node_sound_stone_defaults(),
 })
@@ -1155,7 +1155,7 @@ minetest.register_node("default:coalblock", {
 minetest.register_node("default:stone_with_iron", {
 	description = "Iron Ore",
 	tiles = {"default_stone.png^default_mineral_iron.png"},
-	groups = {cracky = 2},
+	groups = {stone_with_ore = 1, cracky = 2},
 	drop = 'default:iron_lump',
 	sounds = default.node_sound_stone_defaults(),
 })
@@ -1172,7 +1172,7 @@ minetest.register_node("default:steelblock", {
 minetest.register_node("default:stone_with_copper", {
 	description = "Copper Ore",
 	tiles = {"default_stone.png^default_mineral_copper.png"},
-	groups = {cracky = 2},
+	groups = {stone_with_ore = 1, cracky = 2},
 	drop = 'default:copper_lump',
 	sounds = default.node_sound_stone_defaults(),
 })
@@ -1189,7 +1189,7 @@ minetest.register_node("default:copperblock", {
 minetest.register_node("default:stone_with_tin", {
 	description = "Tin Ore",
 	tiles = {"default_stone.png^default_mineral_tin.png"},
-	groups = {cracky = 2},
+	groups = {stone_with_ore = 1, cracky = 2},
 	drop = "default:tin_lump",
 	sounds = default.node_sound_stone_defaults(),
 })
@@ -1215,7 +1215,7 @@ minetest.register_node("default:bronzeblock", {
 minetest.register_node("default:stone_with_mese", {
 	description = "Mese Ore",
 	tiles = {"default_stone.png^default_mineral_mese.png"},
-	groups = {cracky = 1},
+	groups = {stone_with_ore = 1, cracky = 1},
 	drop = "default:mese_crystal",
 	sounds = default.node_sound_stone_defaults(),
 })
@@ -1233,7 +1233,7 @@ minetest.register_node("default:mese", {
 minetest.register_node("default:stone_with_gold", {
 	description = "Gold Ore",
 	tiles = {"default_stone.png^default_mineral_gold.png"},
-	groups = {cracky = 2},
+	groups = {stone_with_ore = 1, cracky = 2},
 	drop = "default:gold_lump",
 	sounds = default.node_sound_stone_defaults(),
 })
@@ -1250,7 +1250,7 @@ minetest.register_node("default:goldblock", {
 minetest.register_node("default:stone_with_diamond", {
 	description = "Diamond Ore",
 	tiles = {"default_stone.png^default_mineral_diamond.png"},
-	groups = {cracky = 1},
+	groups = {stone_with_ore = 1, cracky = 1},
 	drop = "default:diamond",
 	sounds = default.node_sound_stone_defaults(),
 })

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1138,7 +1138,7 @@ minetest.register_node("default:aspen_sapling", {
 minetest.register_node("default:stone_with_coal", {
 	description = "Coal Ore",
 	tiles = {"default_stone.png^default_mineral_coal.png"},
-	groups = {stone_with_ore = 1, cracky = 3},
+	groups = {cracky = 3},
 	drop = 'default:coal_lump',
 	sounds = default.node_sound_stone_defaults(),
 })
@@ -1155,7 +1155,7 @@ minetest.register_node("default:coalblock", {
 minetest.register_node("default:stone_with_iron", {
 	description = "Iron Ore",
 	tiles = {"default_stone.png^default_mineral_iron.png"},
-	groups = {stone_with_ore = 1, cracky = 2},
+	groups = {cracky = 2},
 	drop = 'default:iron_lump',
 	sounds = default.node_sound_stone_defaults(),
 })
@@ -1172,7 +1172,7 @@ minetest.register_node("default:steelblock", {
 minetest.register_node("default:stone_with_copper", {
 	description = "Copper Ore",
 	tiles = {"default_stone.png^default_mineral_copper.png"},
-	groups = {stone_with_ore = 1, cracky = 2},
+	groups = {cracky = 2},
 	drop = 'default:copper_lump',
 	sounds = default.node_sound_stone_defaults(),
 })
@@ -1189,7 +1189,7 @@ minetest.register_node("default:copperblock", {
 minetest.register_node("default:stone_with_tin", {
 	description = "Tin Ore",
 	tiles = {"default_stone.png^default_mineral_tin.png"},
-	groups = {stone_with_ore = 1, cracky = 2},
+	groups = {cracky = 2},
 	drop = "default:tin_lump",
 	sounds = default.node_sound_stone_defaults(),
 })
@@ -1215,7 +1215,7 @@ minetest.register_node("default:bronzeblock", {
 minetest.register_node("default:stone_with_mese", {
 	description = "Mese Ore",
 	tiles = {"default_stone.png^default_mineral_mese.png"},
-	groups = {stone_with_ore = 1, cracky = 1},
+	groups = {cracky = 1},
 	drop = "default:mese_crystal",
 	sounds = default.node_sound_stone_defaults(),
 })
@@ -1233,7 +1233,7 @@ minetest.register_node("default:mese", {
 minetest.register_node("default:stone_with_gold", {
 	description = "Gold Ore",
 	tiles = {"default_stone.png^default_mineral_gold.png"},
-	groups = {stone_with_ore = 1, cracky = 2},
+	groups = {cracky = 2},
 	drop = "default:gold_lump",
 	sounds = default.node_sound_stone_defaults(),
 })
@@ -1250,7 +1250,7 @@ minetest.register_node("default:goldblock", {
 minetest.register_node("default:stone_with_diamond", {
 	description = "Diamond Ore",
 	tiles = {"default_stone.png^default_mineral_diamond.png"},
-	groups = {stone_with_ore = 1, cracky = 1},
+	groups = {cracky = 1},
 	drop = "default:diamond",
 	sounds = default.node_sound_stone_defaults(),
 })

--- a/mods/default/tools.lua
+++ b/mods/default/tools.lua
@@ -32,8 +32,8 @@ minetest.register_tool("default:pick_wood", {
 		},
 		damage_groups = {fleshy=2},
 	},
-	groups = {flammable = 2},
 	sound = {breaks = "default_tool_breaks"},
+	groups = {pickaxe = 1, flammable = 2}
 })
 
 minetest.register_tool("default:pick_stone", {
@@ -48,6 +48,7 @@ minetest.register_tool("default:pick_stone", {
 		damage_groups = {fleshy=3},
 	},
 	sound = {breaks = "default_tool_breaks"},
+	groups = {pickaxe = 1}
 })
 
 minetest.register_tool("default:pick_bronze", {
@@ -62,6 +63,7 @@ minetest.register_tool("default:pick_bronze", {
 		damage_groups = {fleshy=4},
 	},
 	sound = {breaks = "default_tool_breaks"},
+	groups = {pickaxe = 1}
 })
 
 minetest.register_tool("default:pick_steel", {
@@ -76,6 +78,7 @@ minetest.register_tool("default:pick_steel", {
 		damage_groups = {fleshy=4},
 	},
 	sound = {breaks = "default_tool_breaks"},
+	groups = {pickaxe = 1}
 })
 
 minetest.register_tool("default:pick_mese", {
@@ -90,6 +93,7 @@ minetest.register_tool("default:pick_mese", {
 		damage_groups = {fleshy=5},
 	},
 	sound = {breaks = "default_tool_breaks"},
+	groups = {pickaxe = 1}
 })
 
 minetest.register_tool("default:pick_diamond", {
@@ -104,6 +108,7 @@ minetest.register_tool("default:pick_diamond", {
 		damage_groups = {fleshy=5},
 	},
 	sound = {breaks = "default_tool_breaks"},
+	groups = {pickaxe = 1}
 })
 
 --
@@ -122,8 +127,8 @@ minetest.register_tool("default:shovel_wood", {
 		},
 		damage_groups = {fleshy=2},
 	},
-	groups = {flammable = 2},
 	sound = {breaks = "default_tool_breaks"},
+	groups = {shovel = 1, flammable = 2}
 })
 
 minetest.register_tool("default:shovel_stone", {
@@ -139,6 +144,7 @@ minetest.register_tool("default:shovel_stone", {
 		damage_groups = {fleshy=2},
 	},
 	sound = {breaks = "default_tool_breaks"},
+	groups = {shovel = 1}
 })
 
 minetest.register_tool("default:shovel_bronze", {
@@ -154,6 +160,7 @@ minetest.register_tool("default:shovel_bronze", {
 		damage_groups = {fleshy=3},
 	},
 	sound = {breaks = "default_tool_breaks"},
+	groups = {shovel = 1}
 })
 
 minetest.register_tool("default:shovel_steel", {
@@ -169,6 +176,7 @@ minetest.register_tool("default:shovel_steel", {
 		damage_groups = {fleshy=3},
 	},
 	sound = {breaks = "default_tool_breaks"},
+	groups = {shovel = 1}
 })
 
 minetest.register_tool("default:shovel_mese", {
@@ -184,6 +192,7 @@ minetest.register_tool("default:shovel_mese", {
 		damage_groups = {fleshy=4},
 	},
 	sound = {breaks = "default_tool_breaks"},
+	groups = {shovel = 1}
 })
 
 minetest.register_tool("default:shovel_diamond", {
@@ -199,6 +208,7 @@ minetest.register_tool("default:shovel_diamond", {
 		damage_groups = {fleshy=4},
 	},
 	sound = {breaks = "default_tool_breaks"},
+	groups = {shovel = 1}
 })
 
 --
@@ -216,8 +226,8 @@ minetest.register_tool("default:axe_wood", {
 		},
 		damage_groups = {fleshy=2},
 	},
-	groups = {flammable = 2},
 	sound = {breaks = "default_tool_breaks"},
+	groups = {axe = 1, flammable = 2}
 })
 
 minetest.register_tool("default:axe_stone", {
@@ -232,6 +242,7 @@ minetest.register_tool("default:axe_stone", {
 		damage_groups = {fleshy=3},
 	},
 	sound = {breaks = "default_tool_breaks"},
+	groups = {axe = 1}
 })
 
 minetest.register_tool("default:axe_bronze", {
@@ -246,6 +257,7 @@ minetest.register_tool("default:axe_bronze", {
 		damage_groups = {fleshy=4},
 	},
 	sound = {breaks = "default_tool_breaks"},
+	groups = {axe = 1}
 })
 
 minetest.register_tool("default:axe_steel", {
@@ -260,6 +272,7 @@ minetest.register_tool("default:axe_steel", {
 		damage_groups = {fleshy=4},
 	},
 	sound = {breaks = "default_tool_breaks"},
+	groups = {axe = 1}
 })
 
 minetest.register_tool("default:axe_mese", {
@@ -274,6 +287,7 @@ minetest.register_tool("default:axe_mese", {
 		damage_groups = {fleshy=6},
 	},
 	sound = {breaks = "default_tool_breaks"},
+	groups = {axe = 1}
 })
 
 minetest.register_tool("default:axe_diamond", {
@@ -288,6 +302,7 @@ minetest.register_tool("default:axe_diamond", {
 		damage_groups = {fleshy=7},
 	},
 	sound = {breaks = "default_tool_breaks"},
+	groups = {axe = 1}
 })
 
 --
@@ -305,8 +320,8 @@ minetest.register_tool("default:sword_wood", {
 		},
 		damage_groups = {fleshy=2},
 	},
-	groups = {flammable = 2},
 	sound = {breaks = "default_tool_breaks"},
+	groups = {sword = 1, flammable = 2}
 })
 
 minetest.register_tool("default:sword_stone", {
@@ -321,6 +336,7 @@ minetest.register_tool("default:sword_stone", {
 		damage_groups = {fleshy=4},
 	},
 	sound = {breaks = "default_tool_breaks"},
+	groups = {sword = 1}
 })
 
 minetest.register_tool("default:sword_bronze", {
@@ -335,6 +351,7 @@ minetest.register_tool("default:sword_bronze", {
 		damage_groups = {fleshy=6},
 	},
 	sound = {breaks = "default_tool_breaks"},
+	groups = {sword = 1}
 })
 
 minetest.register_tool("default:sword_steel", {
@@ -349,6 +366,7 @@ minetest.register_tool("default:sword_steel", {
 		damage_groups = {fleshy=6},
 	},
 	sound = {breaks = "default_tool_breaks"},
+	groups = {sword = 1}
 })
 
 minetest.register_tool("default:sword_mese", {
@@ -363,6 +381,7 @@ minetest.register_tool("default:sword_mese", {
 		damage_groups = {fleshy=7},
 	},
 	sound = {breaks = "default_tool_breaks"},
+	groups = {sword = 1}
 })
 
 minetest.register_tool("default:sword_diamond", {
@@ -377,6 +396,7 @@ minetest.register_tool("default:sword_diamond", {
 		damage_groups = {fleshy=8},
 	},
 	sound = {breaks = "default_tool_breaks"},
+	groups = {sword = 1}
 })
 
 minetest.register_tool("default:key", {

--- a/mods/farming/hoes.lua
+++ b/mods/farming/hoes.lua
@@ -3,21 +3,23 @@ farming.register_hoe(":farming:hoe_wood", {
 	inventory_image = "farming_tool_woodhoe.png",
 	max_uses = 30,
 	material = "group:wood",
-	groups = {flammable = 2},
+	groups = {hoe = 1, flammable = 2},
 })
 
 farming.register_hoe(":farming:hoe_stone", {
 	description = "Stone Hoe",
 	inventory_image = "farming_tool_stonehoe.png",
 	max_uses = 90,
-	material = "group:stone"
+	material = "group:stone",
+	groups = {hoe = 1}
 })
 
 farming.register_hoe(":farming:hoe_steel", {
 	description = "Steel Hoe",
 	inventory_image = "farming_tool_steelhoe.png",
 	max_uses = 500,
-	material = "default:steel_ingot"
+	material = "default:steel_ingot",
+	groups = {hoe = 1}
 })
 
 -- The following are deprecated by removing the 'material' field to prevent
@@ -29,19 +31,19 @@ farming.register_hoe(":farming:hoe_bronze", {
 	description = "Bronze Hoe",
 	inventory_image = "farming_tool_bronzehoe.png",
 	max_uses = 220,
-	groups = {not_in_creative_inventory = 1},
+	groups = {hoe = 1, not_in_creative_inventory = 1},
 })
 
 farming.register_hoe(":farming:hoe_mese", {
 	description = "Mese Hoe",
 	inventory_image = "farming_tool_mesehoe.png",
 	max_uses = 350,
-	groups = {not_in_creative_inventory = 1},
+	groups = {hoe = 1, not_in_creative_inventory = 1},
 })
 
 farming.register_hoe(":farming:hoe_diamond", {
 	description = "Diamond Hoe",
 	inventory_image = "farming_tool_diamondhoe.png",
 	max_uses = 500,
-	groups = {not_in_creative_inventory = 1},
+	groups = {hoe = 1, not_in_creative_inventory = 1},
 })

--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -60,49 +60,49 @@ flowers.datas = {
 		"rose",
 		"Red Rose",
 		{-2 / 16, -0.5, -2 / 16, 2 / 16, 5 / 16, 2 / 16},
-		{flower = 1, color_red = 1, flammable = 1}
+		{color_red = 1, flammable = 1}
 	},
 	{
 		"tulip",
 		"Orange Tulip",
 		{-2 / 16, -0.5, -2 / 16, 2 / 16, 3 / 16, 2 / 16},
-		{flower = 1, color_orange = 1, flammable = 1}
+		{color_orange = 1, flammable = 1}
 	},
 	{
 		"dandelion_yellow",
 		"Yellow Dandelion",
 		{-4 / 16, -0.5, -4 / 16, 4 / 16, -2 / 16, 4 / 16},
-		{flower = 1, color_yellow = 1, flammable = 1}
+		{color_yellow = 1, flammable = 1}
 	},
 	{
 		"chrysanthemum_green",
 		"Green Chrysanthemum",
 		{-4 / 16, -0.5, -4 / 16, 4 / 16, -1 / 16, 4 / 16},
-		{flower = 1, color_green = 1, flammable = 1}
+		{color_green = 1, flammable = 1}
 	},
 	{
 		"geranium",
 		"Blue Geranium",
 		{-2 / 16, -0.5, -2 / 16, 2 / 16, 2 / 16, 2 / 16},
-		{flower = 1, color_blue = 1, flammable = 1}
+		{color_blue = 1, flammable = 1}
 	},
 	{
 		"viola",
 		"Viola",
 		{-5 / 16, -0.5, -5 / 16, 5 / 16, -1 / 16, 5 / 16},
-		{flower = 1, color_violet = 1, flammable = 1}
+		{color_violet = 1, flammable = 1}
 	},
 	{
 		"dandelion_white",
 		"White Dandelion",
 		{-5 / 16, -0.5, -5 / 16, 5 / 16, -2 / 16, 5 / 16},
-		{flower = 1, color_white = 1, flammable = 1}
+		{color_white = 1, flammable = 1}
 	},
 	{
 		"tulip_black",
 		"Black Tulip",
 		{-2 / 16, -0.5, -2 / 16, 2 / 16, 3 / 16, 2 / 16},
-		{flower = 1, color_black = 1, flammable = 1}
+		{color_black = 1, flammable = 1}
 	},
 }
 

--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -60,49 +60,49 @@ flowers.datas = {
 		"rose",
 		"Red Rose",
 		{-2 / 16, -0.5, -2 / 16, 2 / 16, 5 / 16, 2 / 16},
-		{color_red = 1, flammable = 1}
+		{flower = 1, color_red = 1, flammable = 1}
 	},
 	{
 		"tulip",
 		"Orange Tulip",
 		{-2 / 16, -0.5, -2 / 16, 2 / 16, 3 / 16, 2 / 16},
-		{color_orange = 1, flammable = 1}
+		{flower = 1, color_orange = 1, flammable = 1}
 	},
 	{
 		"dandelion_yellow",
 		"Yellow Dandelion",
 		{-4 / 16, -0.5, -4 / 16, 4 / 16, -2 / 16, 4 / 16},
-		{color_yellow = 1, flammable = 1}
+		{flower = 1, color_yellow = 1, flammable = 1}
 	},
 	{
 		"chrysanthemum_green",
 		"Green Chrysanthemum",
 		{-4 / 16, -0.5, -4 / 16, 4 / 16, -1 / 16, 4 / 16},
-		{color_green = 1, flammable = 1}
+		{flower = 1, color_green = 1, flammable = 1}
 	},
 	{
 		"geranium",
 		"Blue Geranium",
 		{-2 / 16, -0.5, -2 / 16, 2 / 16, 2 / 16, 2 / 16},
-		{color_blue = 1, flammable = 1}
+		{flower = 1, color_blue = 1, flammable = 1}
 	},
 	{
 		"viola",
 		"Viola",
 		{-5 / 16, -0.5, -5 / 16, 5 / 16, -1 / 16, 5 / 16},
-		{color_violet = 1, flammable = 1}
+		{flower = 1, color_violet = 1, flammable = 1}
 	},
 	{
 		"dandelion_white",
 		"White Dandelion",
 		{-5 / 16, -0.5, -5 / 16, 5 / 16, -2 / 16, 5 / 16},
-		{color_white = 1, flammable = 1}
+		{flower = 1, color_white = 1, flammable = 1}
 	},
 	{
 		"tulip_black",
 		"Black Tulip",
 		{-2 / 16, -0.5, -2 / 16, 2 / 16, 3 / 16, 2 / 16},
-		{color_black = 1, flammable = 1}
+		{flower = 1, color_black = 1, flammable = 1}
 	},
 }
 
@@ -189,7 +189,7 @@ minetest.register_node("flowers:mushroom_red", {
 	sunlight_propagates = true,
 	walkable = false,
 	buildable_to = true,
-	groups = {snappy = 3, attached_node = 1, flammable = 1},
+	groups = {mushroom = 1, snappy = 3, attached_node = 1, flammable = 1},
 	sounds = default.node_sound_leaves_defaults(),
 	on_use = minetest.item_eat(-5),
 	selection_box = {
@@ -208,7 +208,7 @@ minetest.register_node("flowers:mushroom_brown", {
 	sunlight_propagates = true,
 	walkable = false,
 	buildable_to = true,
-	groups = {food_mushroom = 1, snappy = 3, attached_node = 1, flammable = 1},
+	groups = {mushroom = 1, food_mushroom = 1, snappy = 3, attached_node = 1, flammable = 1},
 	sounds = default.node_sound_leaves_defaults(),
 	on_use = minetest.item_eat(1),
 	selection_box = {

--- a/mods/screwdriver/init.lua
+++ b/mods/screwdriver/init.lua
@@ -146,6 +146,7 @@ end
 minetest.register_tool("screwdriver:screwdriver", {
 	description = "Screwdriver (left-click rotates face, right-click rotates axis)",
 	inventory_image = "screwdriver.png",
+	groups = {tool = 1},
 	on_use = function(itemstack, user, pointed_thing)
 		screwdriver.handler(itemstack, user, pointed_thing, screwdriver.ROTATE_FACE, 200)
 		return itemstack


### PR DESCRIPTION
Ref #2323 
Ref https://github.com/minetest/minetest_game/issues/1237#issuecomment-254585091

Add groups to tools/ores/flowers (using a script when needed).

Groups added:
pickaxe (all pickaxe items)
axe (all axe items)
shovel (all shovel items)
hoe (all hoe items)
sword (all sword items)
flower (all flowers)
mushroom (only mushrooms)
ore (all ores (not coal))
stone_with_ore (all stones with ores)
ingot (all ingots)
tool (added to bucket and screwdriver only)

Do we need anymore? (leaves, cobble_variant, sandstone, drinkable)?