### PR TITLE
Fixed Moss-growth-function. Prevents server for crash.

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -560,8 +560,10 @@ minetest.register_abm({
 	catch_up = false,
 	action = function(pos, node)
 		node.name = moss_correspondences[node.name]
-		minetest.set_node(pos, node)
-	end
+		if node.name then
+			minetest.set_node(pos, node)
+		end
+    end
 })
 
 

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -563,7 +563,7 @@ minetest.register_abm({
 		if node.name then
 			minetest.set_node(pos, node)
 		end
-    end
+	end
 })
 
 


### PR DESCRIPTION
If a mod overwrites the stairs-nodes, this function will crash the server, because the function try to set a nil instead a valid node, because for example, moreblocks:stairs_cobble aren't in the corresponding array and gives nil back.
