### PR TITLE
Allow overriding default.after_place_leaves and default.grow_sapling easily

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -230,6 +230,11 @@ local function after_place_leaves(...)
 	return default.after_place_leaves(...)
 end
 
+-- Required wrapper to allow customization of default.grow_sapling
+local function grow_sapling(...)
+	return default.grow_sapling(...)
+end
+
 --
 -- Stone
 --
@@ -676,7 +681,7 @@ minetest.register_node("default:sapling", {
 	paramtype = "light",
 	sunlight_propagates = true,
 	walkable = false,
-	on_timer = default.grow_sapling,
+	on_timer = grow_sapling,
 	selection_box = {
 		type = "fixed",
 		fixed = {-4 / 16, -0.5, -4 / 16, 4 / 16, 7 / 16, 4 / 16}
@@ -837,7 +842,7 @@ minetest.register_node("default:junglesapling", {
 	paramtype = "light",
 	sunlight_propagates = true,
 	walkable = false,
-	on_timer = default.grow_sapling,
+	on_timer = grow_sapling,
 	selection_box = {
 		type = "fixed",
 		fixed = {-4 / 16, -0.5, -4 / 16, 4 / 16, 7 / 16, 4 / 16}
@@ -873,7 +878,7 @@ minetest.register_node("default:emergent_jungle_sapling", {
 	paramtype = "light",
 	sunlight_propagates = true,
 	walkable = false,
-	on_timer = default.grow_sapling,
+	on_timer = grow_sapling,
 	selection_box = {
 		type = "fixed",
 		fixed = {-4 / 16, -0.5, -4 / 16, 4 / 16, 7 / 16, 4 / 16}
@@ -951,7 +956,7 @@ minetest.register_node("default:pine_sapling", {
 	paramtype = "light",
 	sunlight_propagates = true,
 	walkable = false,
-	on_timer = default.grow_sapling,
+	on_timer = grow_sapling,
 	selection_box = {
 		type = "fixed",
 		fixed = {-4 / 16, -0.5, -4 / 16, 4 / 16, 7 / 16, 4 / 16}
@@ -1031,7 +1036,7 @@ minetest.register_node("default:acacia_sapling", {
 	paramtype = "light",
 	sunlight_propagates = true,
 	walkable = false,
-	on_timer = default.grow_sapling,
+	on_timer = grow_sapling,
 	selection_box = {
 		type = "fixed",
 		fixed = {-4 / 16, -0.5, -4 / 16, 4 / 16, 7 / 16, 4 / 16}
@@ -1109,7 +1114,7 @@ minetest.register_node("default:aspen_sapling", {
 	paramtype = "light",
 	sunlight_propagates = true,
 	walkable = false,
-	on_timer = default.grow_sapling,
+	on_timer = grow_sapling,
 	selection_box = {
 		type = "fixed",
 		fixed = {-3 / 16, -0.5, -3 / 16, 3 / 16, 0.5, 3 / 16}
@@ -1668,9 +1673,7 @@ minetest.register_node("default:bush_sapling", {
 	paramtype = "light",
 	sunlight_propagates = true,
 	walkable = false,
-	on_timer = function(...)
-		return default.grow_sapling(...)
-	end,
+	on_timer = grow_sapling,
 	selection_box = {
 		type = "fixed",
 		fixed = {-4 / 16, -0.5, -4 / 16, 4 / 16, 2 / 16, 4 / 16}
@@ -1737,7 +1740,7 @@ minetest.register_node("default:blueberry_bush_leaves", {
 		end
 	end,
 
-	after_place_node = default.after_place_leaves,
+	after_place_node = after_place_leaves,
 })
 
 minetest.register_node("default:blueberry_bush_sapling", {
@@ -1749,7 +1752,7 @@ minetest.register_node("default:blueberry_bush_sapling", {
 	paramtype = "light",
 	sunlight_propagates = true,
 	walkable = false,
-	on_timer = default.grow_sapling,
+	on_timer = grow_sapling,
 	selection_box = {
 		type = "fixed",
 		fixed = {-4 / 16, -0.5, -4 / 16, 4 / 16, 2 / 16, 4 / 16}
@@ -1820,7 +1823,7 @@ minetest.register_node("default:acacia_bush_sapling", {
 	paramtype = "light",
 	sunlight_propagates = true,
 	walkable = false,
-	on_timer = default.grow_sapling,
+	on_timer = grow_sapling,
 	selection_box = {
 		type = "fixed",
 		fixed = {-3 / 16, -0.5, -3 / 16, 3 / 16, 2 / 16, 3 / 16}
@@ -1879,7 +1882,7 @@ minetest.register_node("default:pine_bush_needles", {
 	},
 	sounds = default.node_sound_leaves_defaults(),
 
-	after_place_node = default.after_place_leaves,
+	after_place_node = after_place_leaves,
 })
 
 minetest.register_node("default:pine_bush_sapling", {
@@ -1891,7 +1894,7 @@ minetest.register_node("default:pine_bush_sapling", {
 	paramtype = "light",
 	sunlight_propagates = true,
 	walkable = false,
-	on_timer = default.grow_sapling,
+	on_timer = grow_sapling,
 	selection_box = {
 		type = "fixed",
 		fixed = {-4 / 16, -0.5, -4 / 16, 4 / 16, 2 / 16, 4 / 16}

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -225,6 +225,10 @@ default:cloud
 
 --]]
 
+local function after_place_leaves(...)
+	default.after_place_leaves(...)
+end
+
 --
 -- Stone
 --
@@ -724,7 +728,7 @@ minetest.register_node("default:leaves", {
 	},
 	sounds = default.node_sound_leaves_defaults(),
 
-	after_place_node = default.after_place_leaves,
+	after_place_node = after_place_leaves,
 })
 
 minetest.register_node("default:apple", {
@@ -820,7 +824,7 @@ minetest.register_node("default:jungleleaves", {
 	},
 	sounds = default.node_sound_leaves_defaults(),
 
-	after_place_node = default.after_place_leaves,
+	after_place_node = after_place_leaves,
 })
 
 minetest.register_node("default:junglesapling", {
@@ -934,7 +938,7 @@ minetest.register_node("default:pine_needles",{
 	},
 	sounds = default.node_sound_leaves_defaults(),
 
-	after_place_node = default.after_place_leaves,
+	after_place_node = after_place_leaves,
 })
 
 minetest.register_node("default:pine_sapling", {
@@ -1014,7 +1018,7 @@ minetest.register_node("default:acacia_leaves", {
 	},
 	sounds = default.node_sound_leaves_defaults(),
 
-	after_place_node = default.after_place_leaves,
+	after_place_node = after_place_leaves,
 })
 
 minetest.register_node("default:acacia_sapling", {
@@ -1092,7 +1096,7 @@ minetest.register_node("default:aspen_leaves", {
 	},
 	sounds = default.node_sound_leaves_defaults(),
 
-	after_place_node = default.after_place_leaves,
+	after_place_node = after_place_leaves,
 })
 
 minetest.register_node("default:aspen_sapling", {
@@ -1651,7 +1655,7 @@ minetest.register_node("default:bush_leaves", {
 	},
 	sounds = default.node_sound_leaves_defaults(),
 
-	after_place_node = default.after_place_leaves,
+	after_place_node = after_place_leaves,
 })
 
 minetest.register_node("default:bush_sapling", {
@@ -1801,7 +1805,7 @@ minetest.register_node("default:acacia_bush_leaves", {
 	},
 	sounds = default.node_sound_leaves_defaults(),
 
-	after_place_node = default.after_place_leaves,
+	after_place_node = after_place_leaves,
 })
 
 minetest.register_node("default:acacia_bush_sapling", {

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1668,6 +1668,9 @@ minetest.register_node("default:bush_sapling", {
 	paramtype = "light",
 	sunlight_propagates = true,
 	walkable = false,
+	on_timer = function(...)
+		return default.grow_sapling(...)
+	end,
 	selection_box = {
 		type = "fixed",
 		fixed = {-4 / 16, -0.5, -4 / 16, 4 / 16, 2 / 16, 4 / 16}

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -225,8 +225,9 @@ default:cloud
 
 --]]
 
+-- Required wrapper to allow customization of default.after_place_leaves
 local function after_place_leaves(...)
-	default.after_place_leaves(...)
+	return default.after_place_leaves(...)
 end
 
 --
@@ -1667,7 +1668,6 @@ minetest.register_node("default:bush_sapling", {
 	paramtype = "light",
 	sunlight_propagates = true,
 	walkable = false,
-	on_timer = default.grow_sapling,
 	selection_box = {
 		type = "fixed",
 		fixed = {-4 / 16, -0.5, -4 / 16, 4 / 16, 2 / 16, 4 / 16}


### PR DESCRIPTION
Fix from p_gimeno to allow custom leafdecay, since overrriding `default.after_place_leaves` does not affect the leaves definition (changed reference).