### PR TITLE
Add enable_locking setting

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -64,3 +64,6 @@ default:torch 99,default:cobble 99
 # starting biome, is used.
 # Default value is false.
 #engine_spawn = false
+
+# Wheather locked chests and doors are enabled
+#enable_locking = true

--- a/mods/default/chests.lua
+++ b/mods/default/chests.lua
@@ -81,6 +81,10 @@ function default.chest.register_chest(name, d)
 	def.legacy_facedir_simple = true
 	def.is_ground_content = false
 
+	if minetest.settings:get_bool("enable_locking") == false and def.protected then
+		return --  Locking is disabled quit registration
+	end
+
 	if def.protected then
 		def.on_construct = function(pos)
 			local meta = minetest.get_meta(pos)

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -511,7 +511,9 @@ function doors.register_door(name, def)
 		def.protected = true
 	end
 	def.only_placer_can_open = nil
-
+	if minetest.settings:get_bool("enable_locking") == false and def.protected then
+		return --  Locking is disabled quit registration
+	end
 	local i = name:find(":")
 	local modname = name:sub(1, i - 1)
 	if not def.tiles then

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -64,3 +64,6 @@ enable_stairs_replace_abm (Replace old stairs) bool false
 #    If enabled, use the engine's spawn search which does not check for a
 #    suitable starting biome.
 engine_spawn (Use engine spawn search) bool false
+
+#    Enable locked chests/doors
+enable_locking (Enable locked chests/doors) bool true


### PR DESCRIPTION
Rebase of #269
Should the enable_locking = false also disable the skeleton key because it is useless then?