### PR TITLE
Carts: switching the drivers's yaw to the cart's

### DIFF
--- a/mods/carts/cart_entity.lua
+++ b/mods/carts/cart_entity.lua
@@ -351,7 +351,13 @@ local function rail_on_step(self, dtime)
 		yaw = 1
 	end
 	self.object:set_yaw(yaw * math.pi)
-
+	if self.driver then
+		player = minetest.get_player_by_name(self.driver)
+		if player then
+			player:set_look_horizontal(yaw * math.pi)
+		end
+	end
+	
 	local anim = {x=0, y=0}
 	if dir.y == -1 then
 		anim = {x=1, y=1}


### PR DESCRIPTION
This is a proposal to make the player's look direction follow the direction of the cart when the cart turns. That makes roller coasters circuits much more enjoyable and easier to follow.