### PR TITLE
intersects_protection(): Fix compatibility code.

### DIFF
--- a/mods/default/legacy.lua
+++ b/mods/default/legacy.lua
@@ -45,5 +45,5 @@ default.register_chest = default.chest.register_chest
 function default.intersects_protection(minp, maxp, player_name, interval)
 	minetest.log("warning", "default.intersects_protection() is " ..
 		"deprecated, use minetest.is_area_protected() instead.")
-	minetest.is_area_protected(minp, maxp, player_name, interval)
+	return minetest.is_area_protected(minp, maxp, player_name, interval)
 end


### PR DESCRIPTION
Add a missing `return`.