### PR TITLE
Remove stack_max and function default.add_group

### DIFF
--- a/mods/bucket/init.lua
+++ b/mods/bucket/init.lua
@@ -113,7 +113,6 @@ end
 minetest.register_craftitem("bucket:bucket_empty", {
 	description = "Empty Bucket",
 	inventory_image = "bucket.png",
-	stack_max = 99,
 	groups = {tool = 1},
 	liquids_pointable = true,
 	on_use = function(itemstack, user, pointed_thing)

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -608,3 +608,59 @@ function default.can_interact_with_node(player, pos)
 
 	return false
 end
+
+
+-- 
+-- Simple clones a given table to a new one
+--
+
+function default.table_clone(c_table)
+  local table_clone = {}
+  for key,value in pairs(c_table) do
+    table_clone[key] = value
+    
+  end
+  
+  return table_clone
+  
+end -- function table_clone
+
+
+--
+-- Add groups to already registered nodes, items or tools.
+--
+    
+function default.add_group(node, entry)
+    
+    local newgroup = {}
+    
+    if(type(node) ~= "string") then return end -- Not a real node, do nothing
+    
+    -- Check the item and get the group
+    if(minetest.registered_nodes[node] ~= nil) then
+        newgroup = default.table_clone(minetest.registered_nodes[node].groups)
+    
+    elseif(minetest.registered_items[node] ~= nil) then
+        newgroup = default.table_clone(minetest.registered_items[node].groups)
+        
+    elseif(minetest.registered_craftitems[node] ~= nil) then
+        newgroup = default.table_clone(minetest.registered_craftitems[node].groups)
+    
+    elseif(minetest.registered_tools[node] ~= nil) then
+        newgroup = default.table_clone(minetest.registered_tools[node].groups)
+        
+    end -- if(minetest.registered_nodes
+    
+    -- add the new groups to the item
+    local key, value
+    for key,value in pairs(entry) do
+        newgroup[key] = value
+        
+    end
+        
+    minetest.override_item(node, {
+                                  groups = newgroup
+                                 })
+
+end -- function add_group()
+

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -610,7 +610,7 @@ function default.can_interact_with_node(player, pos)
 end
 
 
--- 
+--
 -- Simple clones a given table to a new one
 --
 
@@ -618,46 +618,45 @@ function default.table_clone(c_table)
   local table_clone = {}
   for key,value in pairs(c_table) do
     table_clone[key] = value
-    
+
   end
-  
+
   return table_clone
-  
+
 end -- function table_clone
 
 
 --
 -- Add groups to already registered nodes, items or tools.
 --
-    
+
 function default.add_group(node, entry)
-    
+
     local newgroup = {}
-    
+
     if(type(node) ~= "string") then return end -- Not a real node, do nothing
-    
+
     -- Check the item and get the group
     if(minetest.registered_nodes[node] ~= nil) then
         newgroup = default.table_clone(minetest.registered_nodes[node].groups)
-    
+
     elseif(minetest.registered_items[node] ~= nil) then
         newgroup = default.table_clone(minetest.registered_items[node].groups)
-        
+
     elseif(minetest.registered_craftitems[node] ~= nil) then
         newgroup = default.table_clone(minetest.registered_craftitems[node].groups)
-    
+
     elseif(minetest.registered_tools[node] ~= nil) then
         newgroup = default.table_clone(minetest.registered_tools[node].groups)
-        
+
     end -- if(minetest.registered_nodes
-    
+
     -- add the new groups to the item
-    local key, value
     for key,value in pairs(entry) do
         newgroup[key] = value
-        
+
     end
-        
+
     minetest.override_item(node, {
                                   groups = newgroup
                                  })


### PR DESCRIPTION
Hello,

**First commit:**
i've removed the unneeded stack_max from bucket_empty, because 99 is default.

**Second commit:**
I added two functions in default game for better support to other mods.

_default.table_clone()_ adds lua to the ability to copy a simple table in lua
example: 
local table_a = {1, 2, 3}
local table_b = default.table(table_a)

_default.add_group()_ don't override only the groups like minetest.override(), 
it adds the new groups to the existing groups.
example: default.add_group("default:stone", {hard = 1})
after them, default:stone has his original groups  + the group hard.

This should give a better support between the mods and recipes to prevent recipe-collisions, without to change the foreign mod.

Greetings, Clyde.