### PR TITLE
Creative: Remove unnecessary dependency on 'default'

### DIFF
--- a/mods/creative/mod.conf
+++ b/mods/creative/mod.conf
@@ -1,3 +1,3 @@
 name = creative
 description = Minetest Game mod: creative
-depends = default, sfinv
+depends = sfinv


### PR DESCRIPTION
Closes #2404
Since https://github.com/minetest/minetest_game/commit/5b1d5819e5a9617832fba17db8da1a8d8fa690dc 'creative' no longer uses `default.get_hotbar_bg()` and so no longer depends on 'default'.
Makes using 'creative' in other games easier.
Tested by making 'default' depend on 'creative' to make sure 'creative' is loaded before 'default'.