### PR TITLE
add default as optional dep for creative

### DIFF
--- a/mods/creative/mod.conf
+++ b/mods/creative/mod.conf
@@ -1,3 +1,4 @@
 name = creative
 description = Minetest Game mod: creative
 depends = sfinv
+optional_depends = default


### PR DESCRIPTION
When default was removed as a dep in creative, it removed creative mode abilities.
Here I simply added default as an optional dep.
Not sure if this is the overall solution but it at least fixes this problem momentarily.