### PR TITLE
Add patches of bare 'dry dirt' to savanna

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -1838,6 +1838,30 @@ end
 
 
 function default.register_decorations()
+	-- Savanna bare dirt patches.
+	-- Must come before all savanna decorations that are placed on dry grass.
+	-- Noise is similar to long dry grass noise, but scale inverted, to appear
+	-- where long dry grass is least dense and shortest.
+
+	minetest.register_decoration({
+		deco_type = "simple",
+		place_on = {"default:dry_dirt_with_dry_grass"},
+		sidelen = 4,
+		noise_params = {
+			offset = -1.5,
+			scale = -1.5,
+			spread = {x = 200, y = 200, z = 200},
+			seed = 329,
+			octaves = 4,
+			persist = 1.0
+		},
+		biomes = {"savanna"},
+		y_max = 31000,
+		y_min = 1,
+		decoration = "default:dry_dirt",
+		place_offset_y = -1,
+		flags = "force_placement",
+	})
 
 	-- Apple tree and log
 


### PR DESCRIPTION
Tune noise to appear where long dry grass is least dense and shortest.
////////////////////////////

![screenshot_20190727_211556](https://user-images.githubusercontent.com/3686677/61999199-ceff8e80-b0b3-11e9-80b0-e7205d54bee8.png)

![patchy8IND](https://user-images.githubusercontent.com/3686677/62097059-990e0600-b27d-11e9-9be0-634c67bbd070.png)

^ 2000x2000, with no long dry grass to clearly show bare patches