### PR TITLE
mtg mods use " " instead of ' ' for item names

### DIFF
--- a/mods/bucket/init.lua
+++ b/mods/bucket/init.lua
@@ -6,10 +6,10 @@ minetest.register_alias("bucket_water", "bucket:bucket_water")
 minetest.register_alias("bucket_lava", "bucket:bucket_lava")
 
 minetest.register_craft({
-	output = 'bucket:bucket_empty 1',
+	output = "bucket:bucket_empty 1",
 	recipe = {
-		{'default:steel_ingot', '', 'default:steel_ingot'},
-		{'', 'default:steel_ingot', ''},
+		{"default:steel_ingot", "", "default:steel_ingot"},
+		{"", "default:steel_ingot", ""},
 	}
 })
 

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -701,19 +701,19 @@ doors.register_trapdoor("doors:trapdoor_steel", {
 })
 
 minetest.register_craft({
-	output = 'doors:trapdoor 2',
+	output = "doors:trapdoor 2",
 	recipe = {
-		{'group:wood', 'group:wood', 'group:wood'},
-		{'group:wood', 'group:wood', 'group:wood'},
-		{'', '', ''},
+		{"group:wood", "group:wood", "group:wood"},
+		{"group:wood", "group:wood", "group:wood"},
+		{"", "", ""},
 	}
 })
 
 minetest.register_craft({
-	output = 'doors:trapdoor_steel',
+	output = "doors:trapdoor_steel",
 	recipe = {
-		{'default:steel_ingot', 'default:steel_ingot'},
-		{'default:steel_ingot', 'default:steel_ingot'},
+		{"default:steel_ingot", "default:steel_ingot"},
+		{"default:steel_ingot", "default:steel_ingot"},
 	}
 })
 

--- a/mods/dye/init.lua
+++ b/mods/dye/init.lua
@@ -94,7 +94,7 @@ local dye_recipes = {
 for _, mix in pairs(dye_recipes) do
 	minetest.register_craft({
 		type = "shapeless",
-		output = 'dye:' .. mix[3] .. ' 2',
-		recipe = {'dye:' .. mix[1], 'dye:' .. mix[2]},
+		output = "dye:" .. mix[3] .. " 2",
+		recipe = {"dye:" .. mix[1], "dye:" .. mix[2]},
 	})
 end

--- a/mods/farming/nodes.lua
+++ b/mods/farming/nodes.lua
@@ -217,8 +217,8 @@ for i = 1, 5 do
 	minetest.override_item("default:grass_"..i, {drop = {
 		max_items = 1,
 		items = {
-			{items = {'farming:seed_wheat'},rarity = 5},
-			{items = {'default:grass_1'}},
+			{items = {"farming:seed_wheat"},rarity = 5},
+			{items = {"default:grass_1"}},
 		}
 	}})
 end
@@ -226,7 +226,7 @@ end
 minetest.override_item("default:junglegrass", {drop = {
 	max_items = 1,
 	items = {
-		{items = {'farming:seed_cotton'},rarity = 8},
-		{items = {'default:junglegrass'}},
+		{items = {"farming:seed_cotton"},rarity = 8},
+		{items = {"default:junglegrass"}},
 	}
 }})

--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -109,7 +109,7 @@ function stairs.register_stair(subname, recipeitem, groups, images, description,
 	if recipeitem then
 		-- Recipe matches appearence in inventory
 		minetest.register_craft({
-			output = 'stairs:stair_' .. subname .. ' 8',
+			output = "stairs:stair_" .. subname .. " 8",
 			recipe = {
 				{"", "", recipeitem},
 				{"", recipeitem, recipeitem},
@@ -119,10 +119,10 @@ function stairs.register_stair(subname, recipeitem, groups, images, description,
 
 		-- Use stairs to craft full blocks again (1:1)
 		minetest.register_craft({
-			output = recipeitem .. ' 3',
+			output = recipeitem .. " 3",
 			recipe = {
-				{'stairs:stair_' .. subname, 'stairs:stair_' .. subname},
-				{'stairs:stair_' .. subname, 'stairs:stair_' .. subname},
+				{"stairs:stair_" .. subname, "stairs:stair_" .. subname},
+				{"stairs:stair_" .. subname, "stairs:stair_" .. subname},
 			},
 		})
 
@@ -135,7 +135,7 @@ function stairs.register_stair(subname, recipeitem, groups, images, description,
 		if baseburntime > 0 then
 			minetest.register_craft({
 				type = "fuel",
-				recipe = 'stairs:stair_' .. subname,
+				recipe = "stairs:stair_" .. subname,
 				burntime = math.floor(baseburntime * 0.75),
 			})
 		end
@@ -224,7 +224,7 @@ function stairs.register_slab(subname, recipeitem, groups, images, description,
 
 	if recipeitem then
 		minetest.register_craft({
-			output = 'stairs:slab_' .. subname .. ' 6',
+			output = "stairs:slab_" .. subname .. " 6",
 			recipe = {
 				{recipeitem, recipeitem, recipeitem},
 			},
@@ -234,8 +234,8 @@ function stairs.register_slab(subname, recipeitem, groups, images, description,
 		minetest.register_craft({
 			output = recipeitem,
 			recipe = {
-				{'stairs:slab_' .. subname},
-				{'stairs:slab_' .. subname},
+				{"stairs:slab_" .. subname},
+				{"stairs:slab_" .. subname},
 			},
 		})
 
@@ -248,7 +248,7 @@ function stairs.register_slab(subname, recipeitem, groups, images, description,
 		if baseburntime > 0 then
 			minetest.register_craft({
 				type = "fuel",
-				recipe = 'stairs:slab_' .. subname,
+				recipe = "stairs:slab_" .. subname,
 				burntime = math.floor(baseburntime * 0.5),
 			})
 		end
@@ -335,7 +335,7 @@ function stairs.register_stair_inner(subname, recipeitem, groups, images,
 
 	if recipeitem then
 		minetest.register_craft({
-			output = 'stairs:stair_inner_' .. subname .. ' 7',
+			output = "stairs:stair_inner_" .. subname .. " 7",
 			recipe = {
 				{"", recipeitem, ""},
 				{recipeitem, "", recipeitem},
@@ -352,7 +352,7 @@ function stairs.register_stair_inner(subname, recipeitem, groups, images,
 		if baseburntime > 0 then
 			minetest.register_craft({
 				type = "fuel",
-				recipe = 'stairs:stair_inner_' .. subname,
+				recipe = "stairs:stair_inner_" .. subname,
 				burntime = math.floor(baseburntime * 0.875),
 			})
 		end
@@ -415,7 +415,7 @@ function stairs.register_stair_outer(subname, recipeitem, groups, images,
 
 	if recipeitem then
 		minetest.register_craft({
-			output = 'stairs:stair_outer_' .. subname .. ' 6',
+			output = "stairs:stair_outer_" .. subname .. " 6",
 			recipe = {
 				{"", recipeitem, ""},
 				{recipeitem, recipeitem, recipeitem},
@@ -431,7 +431,7 @@ function stairs.register_stair_outer(subname, recipeitem, groups, images,
 		if baseburntime > 0 then
 			minetest.register_craft({
 				type = "fuel",
-				recipe = 'stairs:stair_outer_' .. subname,
+				recipe = "stairs:stair_outer_" .. subname,
 				burntime = math.floor(baseburntime * 0.625),
 			})
 		end

--- a/mods/walls/init.lua
+++ b/mods/walls/init.lua
@@ -31,7 +31,7 @@ walls.register = function(wall_name, wall_desc, wall_texture_table, wall_mat, wa
 	minetest.register_craft({
 		output = wall_name .. " 6",
 		recipe = {
-			{ '', '', '' },
+			{ "", "", "" },
 			{ wall_mat, wall_mat, wall_mat},
 			{ wall_mat, wall_mat, wall_mat},
 		}


### PR DESCRIPTION
Continuation of #2430 
This concludes, covering all the other mods within MTG