### PR TITLE
furnace: Fix "output full" infotext

### DIFF
--- a/mods/default/furnace.lua
+++ b/mods/default/furnace.lua
@@ -107,6 +107,7 @@ local function furnace_node_timer(pos, elapsed)
 
 	local inv = meta:get_inventory()
 	local srclist, fuellist
+	local dst_full = false
 
 	local cookable, cooked
 	local fuel
@@ -146,6 +147,8 @@ local function furnace_node_timer(pos, elapsed)
 						inv:set_stack("src", 1, aftercooked.items[1])
 						src_time = src_time - cooked.time
 						update = true
+					else
+						dst_full = true
 					end
 				else
 					-- Item could not be cooked: probably missing fuel
@@ -195,7 +198,7 @@ local function furnace_node_timer(pos, elapsed)
 	local item_percent = 0
 	if cookable then
 		item_percent = math.floor(src_time / cooked.time * 100)
-		if item_percent > 100 then
+		if dst_full then
 			item_state = "100% (output full)"
 		else
 			item_state = item_percent .. "%"


### PR DESCRIPTION
This was broken since bd0c627a207b70975dd020dbaa33e0e3a58037bc.
To test, fill the furnace output list by cooking 4 different things, then cook something else.