### PR TITLE
Verify object is player before checking privs

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -573,7 +573,7 @@ minetest.register_abm({
 --
 
 function default.can_interact_with_node(player, pos)
-	if player then
+	if player and player:is_player() then
 		if minetest.check_player_privs(player, "protection_bypass") then
 			return true
 		end


### PR DESCRIPTION
This prevents a crash when a NULL digger is passed by the engine to minetest.node_dig.

To reproduce the crash, execute

```lua
minetest.dig_node(vector.new(x, y, z))
```

where x, y, z are the coords of a locked chest.