### PR TITLE
Spawn: Avoid spawning outside small worlds 

### DIFF
--- a/mods/spawn/init.lua
+++ b/mods/spawn/init.lua
@@ -56,6 +56,15 @@ local success = false
 local spawn_pos = {}
 
 
+-- Get world 'mapgen_limit' and 'chunksize' to calculate 'spawn_limit'.
+-- This accounts for how mapchunks are not generated if they or their shell exceed
+-- 'mapgen_limit'.
+
+local mapgen_limit = tonumber(minetest.get_mapgen_setting("mapgen_limit"))
+local chunksize = tonumber(minetest.get_mapgen_setting("chunksize"))
+local spawn_limit = math.max(mapgen_limit - (chunksize + 1) * 16, 0)
+
+
 --Functions
 -----------
 
@@ -100,6 +109,10 @@ local function search()
 		end
 
 		pos = next_pos()
+		-- Check for position being outside world edge
+		if math.abs(pos.x) > spawn_limit or math.abs(pos.z) > spawn_limit then
+			return false
+		end
 	end
 
 	return false


### PR DESCRIPTION
 Spawn: Avoid spawning outside small worlds

Previously, the value of 'mapgen_limit' was not used to limit the
spawn position.
If a friendly-biome spawn point is not found within a small world,
spawn point falls back to the engine spawn point, which has a larger
chance of success.
//////////////////////////////

Closes #2451 