### PR TITLE
Creative: Override the hand instead of re-registering

### DIFF
--- a/mods/creative/init.lua
+++ b/mods/creative/init.lua
@@ -40,10 +40,8 @@ if creative_mode_cache then
 	local digtime = 42
 	local caps = {times = {digtime, digtime, digtime}, uses = 0, maxlevel = 256}
 
-	minetest.register_item(":", {
-		type = "none",
-		wield_image = "wieldhand.png",
-		wield_scale = {x = 1, y = 1, z = 2.5},
+	-- Override the hand tool
+	minetest.override_item("", {
 		range = 10,
 		tool_capabilities = {
 			full_punch_interval = 0.5,

--- a/mods/creative/mod.conf
+++ b/mods/creative/mod.conf
@@ -1,4 +1,3 @@
 name = creative
 description = Minetest Game mod: creative
-depends = sfinv
-optional_depends = default
+depends = default, sfinv


### PR DESCRIPTION
Allows the initial hand registration to alter the 'wield_scale' without
needing to also alter it in creative mod.
Also make default mod a dependency again, as the initial hand
registration is required.
///////////////////////////////////

Closes #2455 

Makes creative mod easier to use in new games unmodified, in the case that the initial hand registration uses a different 'wield_scale'.