### PR TITLE
Fix and improve translation strings

### DIFF
--- a/mods/binoculars/init.lua
+++ b/mods/binoculars/init.lua
@@ -59,7 +59,7 @@ minetest.after(4.7, cyclic_update)
 -- Binoculars item
 
 minetest.register_craftitem("binoculars:binoculars", {
-	description = S("Binoculars\nUse with 'Zoom' key"),
+	description = S("Binoculars") .. "\n" .. S("Use with 'Zoom' key"),
 	inventory_image = "binoculars_binoculars.png",
 	stack_max = 1,
 

--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -154,13 +154,13 @@ function boat.on_step(self, dtime)
 			if ctrl.up and ctrl.down then
 				if not self.auto then
 					self.auto = true
-					minetest.chat_send_player(self.driver, S("[boats] Cruise on"))
+					minetest.chat_send_player(self.driver, S("Boat cruise mode on"))
 				end
 			elseif ctrl.down then
 				self.v = self.v - dtime * 1.8
 				if self.auto then
 					self.auto = false
-					minetest.chat_send_player(self.driver, S("[boats] Cruise off"))
+					minetest.chat_send_player(self.driver, S("Boat cruise mode off"))
 				end
 			elseif ctrl.up or self.auto then
 				self.v = self.v + dtime * 1.8

--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -269,7 +269,7 @@ minetest.register_on_dieplayer(function(player)
 	meta:set_string("owner", player_name)
 
 	if share_bones_time ~= 0 then
-		meta:set_string("infotext", S("@1's fresh bones.", player_name))
+		meta:set_string("infotext", S("@1's fresh bones", player_name))
 
 		if share_bones_time_early == 0 or not minetest.is_protected(pos, player_name) then
 			meta:set_int("time", 0)
@@ -279,6 +279,6 @@ minetest.register_on_dieplayer(function(player)
 
 		minetest.get_node_timer(pos):start(10)
 	else
-		meta:set_string("infotext", S("@1's bones.", player_name))
+		meta:set_string("infotext", S("@1's bones", player_name))
 	end
 end)

--- a/mods/butterflies/init.lua
+++ b/mods/butterflies/init.lua
@@ -5,9 +5,9 @@ local S = minetest.get_translator("butterflies")
 
 -- register butterflies
 local butter_list = {
-	{"white", S("White")},
-	{"red", S("Red")},
-	{"violet", S("Violet")}
+	{"white",  "White"},
+	{"red",    "Red"},
+	{"violet", "Violet"}
 }
 
 for i in ipairs (butter_list) do
@@ -15,7 +15,7 @@ for i in ipairs (butter_list) do
 	local desc = butter_list[i][2]
 
 	minetest.register_node("butterflies:butterfly_"..name, {
-		description = S("@1 Butterfly", desc),
+		description = S(desc .. " Butterfly"),
 		drawtype = "plantlike",
 		tiles = {{
 			name = "butterflies_butterfly_"..name.."_animated.png",
@@ -61,7 +61,7 @@ for i in ipairs (butter_list) do
 	})
 
 	minetest.register_node("butterflies:hidden_butterfly_"..name, {
-		description = S("Hidden @1 Butterfly", desc),
+		description = S("Hidden " .. desc .. " Butterfly"),
 		drawtype = "airlike",
 		inventory_image = "insects_butterfly_"..name..".png",
 		wield_image =  "insects_butterfly_"..name..".png",

--- a/mods/carts/cart_entity.lua
+++ b/mods/carts/cart_entity.lua
@@ -388,7 +388,7 @@ end
 minetest.register_entity("carts:cart", cart_entity)
 
 minetest.register_craftitem("carts:cart", {
-	description = S("Cart (Sneak+Click to pick up)"),
+	description = S("Cart") .. "\n" .. S("(Sneak+Click to pick up)"),
 	inventory_image = minetest.inventorycube("carts_cart_top.png", "carts_cart_side.png", "carts_cart_side.png"),
 	wield_image = "carts_cart_side.png",
 	on_place = function(itemstack, placer, pointed_thing)

--- a/mods/default/craftitems.lua
+++ b/mods/default/craftitems.lua
@@ -165,7 +165,7 @@ minetest.register_craftitem("default:book", {
 })
 
 minetest.register_craftitem("default:book_written", {
-	description = S("Book With Text"),
+	description = S("Book with Text"),
 	inventory_image = "default_book_written.png",
 	groups = {book = 1, not_in_creative_inventory = 1, flammable = 3},
 	stack_max = 1,

--- a/mods/default/furnace.lua
+++ b/mods/default/furnace.lua
@@ -226,20 +226,20 @@ local function furnace_node_timer(pos, elapsed)
 	end
 
 	local fuel_state = S("Empty")
-	local active = "inactive"
+	local active = false
 	local result = false
 
 	if fuel_totaltime ~= 0 then
-		active = "active"
+		active = true
 		local fuel_percent = math.floor(fuel_time / fuel_totaltime * 100)
-		fuel_state = fuel_percent .. "%"
+		fuel_state = S("@1%", fuel_percent)
 		formspec = default.get_furnace_active_formspec(fuel_percent, item_percent)
 		swap_node(pos, "default:furnace_active")
 		-- make sure timer restarts automatically
 		result = true
 	else
 		if not fuellist[1]:is_empty() then
-			fuel_state = "0%"
+			fuel_state = S("@1%", 0)
 		end
 		formspec = default.get_furnace_inactive_formspec()
 		swap_node(pos, "default:furnace")
@@ -247,9 +247,14 @@ local function furnace_node_timer(pos, elapsed)
 		minetest.get_node_timer(pos):stop()
 	end
 
---	local infotext = "Furnace " .. active .. "\n(Item: " .. item_state ..
---		"; Fuel: " .. fuel_state .. ")"
-	local infotext = S("Furnace @1 \n(Item: @2; Fuel: @3)", active, item_state, fuel_state)
+
+	local infotext
+	if active then
+		infotext = S("Furnace active")
+	else
+		infotext = S("Furnace inactive")
+	end
+	infotext = infotext .. "\n" .. S("(Item: @1; Fuel: @2)", item_state, fuel_state)
 
 	--
 	-- Set meta values

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -513,14 +513,14 @@ minetest.register_node("default:dirt_with_coniferous_litter", {
 })
 
 minetest.register_node("default:dry_dirt", {
-	description = "Dry Dirt",
+	description = S("Dry Dirt"),
 	tiles = {"default_dry_dirt.png"},
 	groups = {crumbly = 3, soil = 1},
 	sounds = default.node_sound_dirt_defaults(),
 })
 
 minetest.register_node("default:dry_dirt_with_dry_grass", {
-	description = "Dry Dirt with Dry Grass",
+	description = S("Dry Dirt with Dry Grass"),
 	tiles = {"default_dry_grass.png", "default_dry_dirt.png",
 		{name = "default_dry_dirt.png^default_dry_grass_side.png",
 			tileable_vertical = false}},
@@ -2556,7 +2556,7 @@ minetest.register_node("default:bookshelf", {
 
 local function register_sign(material, desc, def)
 	minetest.register_node("default:sign_wall_" .. material, {
-		description = S("@1 Sign", desc),
+		description = desc,
 		drawtype = "nodebox",
 		tiles = {"default_sign_wall_" .. material .. ".png"},
 		inventory_image = "default_sign_" .. material .. ".png",
@@ -2605,12 +2605,12 @@ local function register_sign(material, desc, def)
 	})
 end
 
-register_sign("wood", S("Wooden"), {
+register_sign("wood", S("Wooden Sign"), {
 	sounds = default.node_sound_wood_defaults(),
 	groups = {choppy = 2, attached_node = 1, flammable = 2, oddly_breakable_by_hand = 3}
 })
 
-register_sign("steel", S("Steel"), {
+register_sign("steel", S("Steel Sign"), {
 	sounds = default.node_sound_metal_defaults(),
 	groups = {cracky = 2, attached_node = 1}
 })

--- a/mods/dye/init.lua
+++ b/mods/dye/init.lua
@@ -8,21 +8,21 @@ local S = minetest.get_translator("dye")
 -- Make dye names and descriptions available globally
 
 dye.dyes = {
-	{"white",      S("White")},
-	{"grey",       S("Grey")},
-	{"dark_grey",  S("Dark Grey")},
-	{"black",      S("Black")},
-	{"violet",     S("Violet")},
-	{"blue",       S("Blue")},
-	{"cyan",       S("Cyan")},
-	{"dark_green", S("Dark Green")},
-	{"green",      S("Green")},
-	{"yellow",     S("Yellow")},
-	{"brown",      S("Brown")},
-	{"orange",     S("Orange")},
-	{"red",        S("Red")},
-	{"magenta",    S("Magenta")},
-	{"pink",       S("Pink")},
+	{"white",      "White"},
+	{"grey",       "Grey"},
+	{"dark_grey",  "Dark Grey"},
+	{"black",      "Black"},
+	{"violet",     "Violet"},
+	{"blue",       "Blue"},
+	{"cyan",       "Cyan"},
+	{"dark_green", "Dark Green"},
+	{"green",      "Green"},
+	{"yellow",     "Yellow"},
+	{"brown",      "Brown"},
+	{"orange",     "Orange"},
+	{"red",        "Red"},
+	{"magenta",    "Magenta"},
+	{"pink",       "Pink"},
 }
 
 -- Define items
@@ -35,7 +35,7 @@ for _, row in ipairs(dye.dyes) do
 
 	minetest.register_craftitem("dye:" .. name, {
 		inventory_image = "dye_" .. name .. ".png",
-		description = S("@1 Dye", description),
+		description = S(description .. " Dye"),
 		groups = groups
 	})
 

--- a/mods/farming/nodes.lua
+++ b/mods/farming/nodes.lua
@@ -86,7 +86,7 @@ minetest.register_node("farming:soil_wet", {
 })
 
 minetest.register_node("farming:dry_soil", {
-	description = "Dry Soil",
+	description = S("Dry Soil"),
 	tiles = {"default_dry_dirt.png^farming_soil.png", "default_dry_dirt.png"},
 	drop = "default:dry_dirt",
 	groups = {crumbly=3, not_in_creative_inventory=1, soil=2, grassland = 1, field = 1},
@@ -99,7 +99,7 @@ minetest.register_node("farming:dry_soil", {
 })
 
 minetest.register_node("farming:dry_soil_wet", {
-	description = "Wet Dry Soil",
+	description = S("Wet Dry Soil"),
 	tiles = {"default_dry_dirt.png^farming_soil_wet.png", "default_dry_dirt.png^farming_soil_wet_side.png"},
 	drop = "default:dry_dirt",
 	groups = {crumbly=3, not_in_creative_inventory=1, soil=3, wet = 1, grassland = 1, field = 1},

--- a/mods/map/init.lua
+++ b/mods/map/init.lua
@@ -55,7 +55,7 @@ minetest.after(5.3, cyclic_update)
 -- Mapping kit item
 
 minetest.register_craftitem("map:mapping_kit", {
-	description = S("Mapping Kit\nUse with 'Minimap' key"),
+	description = S("Mapping Kit") .. "\n" .. S("Use with 'Minimap' key"),
 	inventory_image = "map_mapping_kit.png",
 	stack_max = 1,
 	groups = {flammable = 3},

--- a/mods/screwdriver/init.lua
+++ b/mods/screwdriver/init.lua
@@ -150,7 +150,7 @@ end
 
 -- Screwdriver
 minetest.register_tool("screwdriver:screwdriver", {
-	description = S("Screwdriver (left-click rotates face, right-click rotates axis)"),
+	description = S("Screwdriver") .. "\n" .. S("(left-click rotates face, right-click rotates axis)"),
 	inventory_image = "screwdriver.png",
 	groups = {tool = 1},
 	on_use = function(itemstack, user, pointed_thing)

--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -322,7 +322,7 @@ function stairs.register_stair_inner(subname, recipeitem, groups, images,
 	new_groups.stair = 1
 	warn_if_exists("stairs:stair_inner_" .. subname)
 	minetest.register_node(":stairs:stair_inner_" .. subname, {
-		description = S("Inner @1", description),
+		description = description,
 		drawtype = "nodebox",
 		tiles = stair_images,
 		paramtype = "light",
@@ -404,7 +404,7 @@ function stairs.register_stair_outer(subname, recipeitem, groups, images,
 	new_groups.stair = 1
 	warn_if_exists("stairs:stair_outer_" .. subname)
 	minetest.register_node(":stairs:stair_outer_" .. subname, {
-		description = S("Outer @1", description),
+		description = description,
 		drawtype = "nodebox",
 		tiles = stair_images,
 		paramtype = "light",
@@ -459,13 +459,13 @@ end
 
 function stairs.register_stair_and_slab(subname, recipeitem, groups, images,
 		desc_stair, desc_slab, sounds, worldaligntex)
-	stairs.register_stair(subname, recipeitem, groups, images, desc_stair,
+	stairs.register_stair(subname, recipeitem, groups, images, S(desc_stair),
 		sounds, worldaligntex)
-	stairs.register_stair_inner(subname, recipeitem, groups, images, desc_stair,
-		sounds, worldaligntex)
-	stairs.register_stair_outer(subname, recipeitem, groups, images, desc_stair,
-		sounds, worldaligntex)
-	stairs.register_slab(subname, recipeitem, groups, images, desc_slab,
+	stairs.register_stair_inner(subname, recipeitem, groups, images,
+		S("Inner " .. desc_stair), sounds, worldaligntex)
+	stairs.register_stair_outer(subname, recipeitem, groups, images,
+		S("Outer " .. desc_stair), sounds, worldaligntex)
+	stairs.register_slab(subname, recipeitem, groups, images, S(desc_slab),
 		sounds, worldaligntex)
 end
 
@@ -477,8 +477,8 @@ stairs.register_stair_and_slab(
 	"default:wood",
 	{choppy = 2, oddly_breakable_by_hand = 2, flammable = 2},
 	{"default_wood.png"},
-	S("Wooden Stair"),
-	S("Wooden Slab"),
+	"Wooden Stair",
+	"Wooden Slab",
 	default.node_sound_wood_defaults(),
 	false
 )
@@ -488,8 +488,8 @@ stairs.register_stair_and_slab(
 	"default:junglewood",
 	{choppy = 2, oddly_breakable_by_hand = 2, flammable = 2},
 	{"default_junglewood.png"},
-	S("Jungle Wood Stair"),
-	S("Jungle Wood Slab"),
+	"Jungle Wood Stair",
+	"Jungle Wood Slab",
 	default.node_sound_wood_defaults(),
 	false
 )
@@ -499,8 +499,8 @@ stairs.register_stair_and_slab(
 	"default:pine_wood",
 	{choppy = 3, oddly_breakable_by_hand = 2, flammable = 3},
 	{"default_pine_wood.png"},
-	S("Pine Wood Stair"),
-	S("Pine Wood Slab"),
+	"Pine Wood Stair",
+	"Pine Wood Slab",
 	default.node_sound_wood_defaults(),
 	false
 )
@@ -510,8 +510,8 @@ stairs.register_stair_and_slab(
 	"default:acacia_wood",
 	{choppy = 2, oddly_breakable_by_hand = 2, flammable = 2},
 	{"default_acacia_wood.png"},
-	S("Acacia Wood Stair"),
-	S("Acacia Wood Slab"),
+	"Acacia Wood Stair",
+	"Acacia Wood Slab",
 	default.node_sound_wood_defaults(),
 	false
 )
@@ -521,8 +521,8 @@ stairs.register_stair_and_slab(
 	"default:aspen_wood",
 	{choppy = 3, oddly_breakable_by_hand = 2, flammable = 3},
 	{"default_aspen_wood.png"},
-	S("Aspen Wood Stair"),
-	S("Aspen Wood Slab"),
+	"Aspen Wood Stair",
+	"Aspen Wood Slab",
 	default.node_sound_wood_defaults(),
 	false
 )
@@ -532,8 +532,8 @@ stairs.register_stair_and_slab(
 	"default:stone",
 	{cracky = 3},
 	{"default_stone.png"},
-	S("Stone Stair"),
-	S("Stone Slab"),
+	"Stone Stair",
+	"Stone Slab",
 	default.node_sound_stone_defaults(),
 	true
 )
@@ -543,8 +543,8 @@ stairs.register_stair_and_slab(
 	"default:cobble",
 	{cracky = 3},
 	{"default_cobble.png"},
-	S("Cobblestone Stair"),
-	S("Cobblestone Slab"),
+	"Cobblestone Stair",
+	"Cobblestone Slab",
 	default.node_sound_stone_defaults(),
 	true
 )
@@ -554,8 +554,8 @@ stairs.register_stair_and_slab(
 	"default:mossycobble",
 	{cracky = 3},
 	{"default_mossycobble.png"},
-	S("Mossy Cobblestone Stair"),
-	S("Mossy Cobblestone Slab"),
+	"Mossy Cobblestone Stair",
+	"Mossy Cobblestone Slab",
 	default.node_sound_stone_defaults(),
 	true
 )
@@ -565,8 +565,8 @@ stairs.register_stair_and_slab(
 	"default:stonebrick",
 	{cracky = 2},
 	{"default_stone_brick.png"},
-	S("Stone Brick Stair"),
-	S("Stone Brick Slab"),
+	"Stone Brick Stair",
+	"Stone Brick Slab",
 	default.node_sound_stone_defaults(),
 	false
 )
@@ -576,8 +576,8 @@ stairs.register_stair_and_slab(
 	"default:stone_block",
 	{cracky = 2},
 	{"default_stone_block.png"},
-	S("Stone Block Stair"),
-	S("Stone Block Slab"),
+	"Stone Block Stair",
+	"Stone Block Slab",
 	default.node_sound_stone_defaults(),
 	true
 )
@@ -587,8 +587,8 @@ stairs.register_stair_and_slab(
 	"default:desert_stone",
 	{cracky = 3},
 	{"default_desert_stone.png"},
-	S("Desert Stone Stair"),
-	S("Desert Stone Slab"),
+	"Desert Stone Stair",
+	"Desert Stone Slab",
 	default.node_sound_stone_defaults(),
 	true
 )
@@ -598,8 +598,8 @@ stairs.register_stair_and_slab(
 	"default:desert_cobble",
 	{cracky = 3},
 	{"default_desert_cobble.png"},
-	S("Desert Cobblestone Stair"),
-	S("Desert Cobblestone Slab"),
+	"Desert Cobblestone Stair",
+	"Desert Cobblestone Slab",
 	default.node_sound_stone_defaults(),
 	true
 )
@@ -609,8 +609,8 @@ stairs.register_stair_and_slab(
 	"default:desert_stonebrick",
 	{cracky = 2},
 	{"default_desert_stone_brick.png"},
-	S("Desert Stone Brick Stair"),
-	S("Desert Stone Brick Slab"),
+	"Desert Stone Brick Stair",
+	"Desert Stone Brick Slab",
 	default.node_sound_stone_defaults(),
 	false
 )
@@ -620,8 +620,8 @@ stairs.register_stair_and_slab(
 	"default:desert_stone_block",
 	{cracky = 2},
 	{"default_desert_stone_block.png"},
-	S("Desert Stone Block Stair"),
-	S("Desert Stone Block Slab"),
+	"Desert Stone Block Stair",
+	"Desert Stone Block Slab",
 	default.node_sound_stone_defaults(),
 	true
 )
@@ -631,8 +631,8 @@ stairs.register_stair_and_slab(
 	"default:sandstone",
 	{crumbly = 1, cracky = 3},
 	{"default_sandstone.png"},
-	S("Sandstone Stair"),
-	S("Sandstone Slab"),
+	"Sandstone Stair",
+	"Sandstone Slab",
 	default.node_sound_stone_defaults(),
 	true
 )
@@ -642,8 +642,8 @@ stairs.register_stair_and_slab(
 	"default:sandstonebrick",
 	{cracky = 2},
 	{"default_sandstone_brick.png"},
-	S("Sandstone Brick Stair"),
-	S("Sandstone Brick Slab"),
+	"Sandstone Brick Stair",
+	"Sandstone Brick Slab",
 	default.node_sound_stone_defaults(),
 	false
 )
@@ -653,8 +653,8 @@ stairs.register_stair_and_slab(
 	"default:sandstone_block",
 	{cracky = 2},
 	{"default_sandstone_block.png"},
-	S("Sandstone Block Stair"),
-	S("Sandstone Block Slab"),
+	"Sandstone Block Stair",
+	"Sandstone Block Slab",
 	default.node_sound_stone_defaults(),
 	true
 )
@@ -664,8 +664,8 @@ stairs.register_stair_and_slab(
 	"default:desert_sandstone",
 	{crumbly = 1, cracky = 3},
 	{"default_desert_sandstone.png"},
-	S("Desert Sandstone Stair"),
-	S("Desert Sandstone Slab"),
+	"Desert Sandstone Stair",
+	"Desert Sandstone Slab",
 	default.node_sound_stone_defaults(),
 	true
 )
@@ -675,8 +675,8 @@ stairs.register_stair_and_slab(
 	"default:desert_sandstone_brick",
 	{cracky = 2},
 	{"default_desert_sandstone_brick.png"},
-	S("Desert Sandstone Brick Stair"),
-	S("Desert Sandstone Brick Slab"),
+	"Desert Sandstone Brick Stair",
+	"Desert Sandstone Brick Slab",
 	default.node_sound_stone_defaults(),
 	false
 )
@@ -686,8 +686,8 @@ stairs.register_stair_and_slab(
 	"default:desert_sandstone_block",
 	{cracky = 2},
 	{"default_desert_sandstone_block.png"},
-	S("Desert Sandstone Block Stair"),
-	S("Desert Sandstone Block Slab"),
+	"Desert Sandstone Block Stair",
+	"Desert Sandstone Block Slab",
 	default.node_sound_stone_defaults(),
 	true
 )
@@ -697,8 +697,8 @@ stairs.register_stair_and_slab(
 	"default:silver_sandstone",
 	{crumbly = 1, cracky = 3},
 	{"default_silver_sandstone.png"},
-	S("Silver Sandstone Stair"),
-	S("Silver Sandstone Slab"),
+	"Silver Sandstone Stair",
+	"Silver Sandstone Slab",
 	default.node_sound_stone_defaults(),
 	true
 )
@@ -708,8 +708,8 @@ stairs.register_stair_and_slab(
 	"default:silver_sandstone_brick",
 	{cracky = 2},
 	{"default_silver_sandstone_brick.png"},
-	S("Silver Sandstone Brick Stair"),
-	S("Silver Sandstone Brick Slab"),
+	"Silver Sandstone Brick Stair",
+	"Silver Sandstone Brick Slab",
 	default.node_sound_stone_defaults(),
 	false
 )
@@ -719,8 +719,8 @@ stairs.register_stair_and_slab(
 	"default:silver_sandstone_block",
 	{cracky = 2},
 	{"default_silver_sandstone_block.png"},
-	S("Silver Sandstone Block Stair"),
-	S("Silver Sandstone Block Slab"),
+	"Silver Sandstone Block Stair",
+	"Silver Sandstone Block Slab",
 	default.node_sound_stone_defaults(),
 	true
 )
@@ -730,8 +730,8 @@ stairs.register_stair_and_slab(
 	"default:obsidian",
 	{cracky = 1, level = 2},
 	{"default_obsidian.png"},
-	S("Obsidian Stair"),
-	S("Obsidian Slab"),
+	"Obsidian Stair",
+	"Obsidian Slab",
 	default.node_sound_stone_defaults(),
 	true
 )
@@ -741,8 +741,8 @@ stairs.register_stair_and_slab(
 	"default:obsidianbrick",
 	{cracky = 1, level = 2},
 	{"default_obsidian_brick.png"},
-	S("Obsidian Brick Stair"),
-	S("Obsidian Brick Slab"),
+	"Obsidian Brick Stair",
+	"Obsidian Brick Slab",
 	default.node_sound_stone_defaults(),
 	false
 )
@@ -752,8 +752,8 @@ stairs.register_stair_and_slab(
 	"default:obsidian_block",
 	{cracky = 1, level = 2},
 	{"default_obsidian_block.png"},
-	S("Obsidian Block Stair"),
-	S("Obsidian Block Slab"),
+	"Obsidian Block Stair",
+	"Obsidian Block Slab",
 	default.node_sound_stone_defaults(),
 	true
 )
@@ -763,8 +763,8 @@ stairs.register_stair_and_slab(
 	"default:brick",
 	{cracky = 3},
 	{"default_brick.png"},
-	S("Brick Stair"),
-	S("Brick Slab"),
+	"Brick Stair",
+	"Brick Slab",
 	default.node_sound_stone_defaults(),
 	false
 )
@@ -774,8 +774,8 @@ stairs.register_stair_and_slab(
 	"default:steelblock",
 	{cracky = 1, level = 2},
 	{"default_steel_block.png"},
-	S("Steel Block Stair"),
-	S("Steel Block Slab"),
+	"Steel Block Stair",
+	"Steel Block Slab",
 	default.node_sound_metal_defaults(),
 	true
 )
@@ -785,8 +785,8 @@ stairs.register_stair_and_slab(
 	"default:tinblock",
 	{cracky = 1, level = 2},
 	{"default_tin_block.png"},
-	S("Tin Block Stair"),
-	S("Tin Block Slab"),
+	"Tin Block Stair",
+	"Tin Block Slab",
 	default.node_sound_metal_defaults(),
 	true
 )
@@ -796,8 +796,8 @@ stairs.register_stair_and_slab(
 	"default:copperblock",
 	{cracky = 1, level = 2},
 	{"default_copper_block.png"},
-	S("Copper Block Stair"),
-	S("Copper Block Slab"),
+	"Copper Block Stair",
+	"Copper Block Slab",
 	default.node_sound_metal_defaults(),
 	true
 )
@@ -807,8 +807,8 @@ stairs.register_stair_and_slab(
 	"default:bronzeblock",
 	{cracky = 1, level = 2},
 	{"default_bronze_block.png"},
-	S("Bronze Block Stair"),
-	S("Bronze Block Slab"),
+	"Bronze Block Stair",
+	"Bronze Block Slab",
 	default.node_sound_metal_defaults(),
 	true
 )
@@ -818,8 +818,8 @@ stairs.register_stair_and_slab(
 	"default:goldblock",
 	{cracky = 1},
 	{"default_gold_block.png"},
-	S("Gold Block Stair"),
-	S("Gold Block Slab"),
+	"Gold Block Stair",
+	"Gold Block Slab",
 	default.node_sound_metal_defaults(),
 	true
 )
@@ -829,8 +829,8 @@ stairs.register_stair_and_slab(
 	"default:ice",
 	{cracky = 3, cools_lava = 1, slippery = 3},
 	{"default_ice.png"},
-	S("Ice Stair"),
-	S("Ice Slab"),
+	"Ice Stair",
+	"Ice Slab",
 	default.node_sound_glass_defaults(),
 	true
 )
@@ -840,8 +840,8 @@ stairs.register_stair_and_slab(
 	"default:snowblock",
 	{crumbly = 3, cools_lava = 1, snowy = 1},
 	{"default_snow.png"},
-	S("Snow Block Stair"),
-	S("Snow Block Slab"),
+	"Snow Block Stair",
+	"Snow Block Slab",
 	default.node_sound_snow_defaults(),
 	true
 )
@@ -855,7 +855,7 @@ stairs.register_stair(
 	{"stairs_glass_split.png", "default_glass.png",
 	"stairs_glass_stairside.png^[transformFX", "stairs_glass_stairside.png",
 	"default_glass.png", "stairs_glass_split.png"},
-	S("Glass Stair"),
+	"Glass Stair",
 	default.node_sound_glass_defaults(),
 	false
 )
@@ -865,7 +865,7 @@ stairs.register_slab(
 	"default:glass",
 	{cracky = 3},
 	{"default_glass.png", "default_glass.png", "stairs_glass_split.png"},
-	S("Glass Slab"),
+	"Glass Slab",
 	default.node_sound_glass_defaults(),
 	false
 )
@@ -877,7 +877,7 @@ stairs.register_stair_inner(
 	{"stairs_glass_stairside.png^[transformR270", "default_glass.png",
 	"stairs_glass_stairside.png^[transformFX", "default_glass.png",
 	"default_glass.png", "stairs_glass_stairside.png"},
-	S("Glass Stair"),
+	"Glass Stair",
 	default.node_sound_glass_defaults(),
 	false
 )
@@ -889,7 +889,7 @@ stairs.register_stair_outer(
 	{"stairs_glass_stairside.png^[transformR90", "default_glass.png",
 	"stairs_glass_outer_stairside.png", "stairs_glass_stairside.png",
 	"stairs_glass_stairside.png^[transformR90","stairs_glass_outer_stairside.png"},
-	S("Glass Stair"),
+	"Glass Stair",
 	default.node_sound_glass_defaults(),
 	false
 )
@@ -901,7 +901,7 @@ stairs.register_stair(
 	{"stairs_obsidian_glass_split.png", "default_obsidian_glass.png",
 	"stairs_obsidian_glass_stairside.png^[transformFX", "stairs_obsidian_glass_stairside.png",
 	"default_obsidian_glass.png", "stairs_obsidian_glass_split.png"},
-	S("Obsidian Glass Stair"),
+	"Obsidian Glass Stair",
 	default.node_sound_glass_defaults(),
 	false
 )
@@ -911,7 +911,7 @@ stairs.register_slab(
 	"default:obsidian_glass",
 	{cracky = 3},
 	{"default_obsidian_glass.png", "default_obsidian_glass.png", "stairs_obsidian_glass_split.png"},
-	S("Obsidian Glass Slab"),
+	"Obsidian Glass Slab",
 	default.node_sound_glass_defaults(),
 	false
 )
@@ -923,7 +923,7 @@ stairs.register_stair_inner(
 	{"stairs_obsidian_glass_stairside.png^[transformR270", "default_obsidian_glass.png",
 	"stairs_obsidian_glass_stairside.png^[transformFX", "default_obsidian_glass.png",
 	"default_obsidian_glass.png", "stairs_obsidian_glass_stairside.png"},
-	S("Obsidian Glass Stair"),
+	"Obsidian Glass Stair",
 	default.node_sound_glass_defaults(),
 	false
 )
@@ -935,7 +935,7 @@ stairs.register_stair_outer(
 	{"stairs_obsidian_glass_stairside.png^[transformR90", "default_obsidian_glass.png",
 	"stairs_obsidian_glass_outer_stairside.png", "stairs_obsidian_glass_stairside.png",
 	"stairs_obsidian_glass_stairside.png^[transformR90","stairs_obsidian_glass_outer_stairside.png"},
-	S("Obsidian Glass Stair"),
+	"Obsidian Glass Stair",
 	default.node_sound_glass_defaults(),
 	false
 )

--- a/mods/wool/init.lua
+++ b/mods/wool/init.lua
@@ -9,7 +9,7 @@ for i = 1, #dyes do
 	local name, desc = unpack(dyes[i])
 
 	minetest.register_node("wool:" .. name, {
-		description = S("@1 Wool", desc),
+		description = S(desc .. " Wool"),
 		tiles = {"wool_" .. name .. ".png"},
 		is_ground_content = false,
 		groups = {snappy = 2, choppy = 2, oddly_breakable_by_hand = 3,


### PR DESCRIPTION
Notable:
* breaks stair API compatibility on two occasions:
  * register_stair_inner, register_stair_outer no longer prepend "Inner ", "Outer " to description (unavoidable)
  * register_stair_and_slab uses the "stairs" translator on the given description (could be avoided)
* cart & screwdriver description were changed to use newline for consistency