### PR TITLE
Add missing infotext to nodes

### DIFF
--- a/mods/default/furnace.lua
+++ b/mods/default/furnace.lua
@@ -292,6 +292,7 @@ minetest.register_node("default:furnace", {
 	on_construct = function(pos)
 		local meta = minetest.get_meta(pos)
 		meta:set_string("formspec", default.get_furnace_inactive_formspec())
+		meta:set_string("infotext", 'Furnace inactive\n(Item: Empty; Fuel: Empty)')
 		local inv = meta:get_inventory()
 		inv:set_size('src', 1)
 		inv:set_size('fuel', 1)

--- a/mods/default/furnace.lua
+++ b/mods/default/furnace.lua
@@ -200,7 +200,7 @@ local function furnace_node_timer(pos, elapsed)
 	if fuel and fuel_totaltime > fuel.time then
 		fuel_totaltime = fuel.time
 	end
-	if srclist[1]:is_empty() then
+	if srclist and srclist[1]:is_empty() then
 		src_time = 0
 	end
 
@@ -218,10 +218,10 @@ local function furnace_node_timer(pos, elapsed)
 			item_state = S("@1%", item_percent)
 		end
 	else
-		if srclist[1]:is_empty() then
-			item_state = S("Empty")
-		else
+		if srclist and not srclist[1]:is_empty() then
 			item_state = S("Not cookable")
+		else
+			item_state = S("Empty")
 		end
 	end
 
@@ -238,7 +238,7 @@ local function furnace_node_timer(pos, elapsed)
 		-- make sure timer restarts automatically
 		result = true
 	else
-		if not fuellist[1]:is_empty() then
+		if fuellist and not fuellist[1]:is_empty() then
 			fuel_state = S("@1%", 0)
 		end
 		formspec = default.get_furnace_inactive_formspec()
@@ -291,12 +291,11 @@ minetest.register_node("default:furnace", {
 
 	on_construct = function(pos)
 		local meta = minetest.get_meta(pos)
-		meta:set_string("formspec", default.get_furnace_inactive_formspec())
-		meta:set_string("infotext", 'Furnace inactive\n(Item: Empty; Fuel: Empty)')
 		local inv = meta:get_inventory()
 		inv:set_size('src', 1)
 		inv:set_size('fuel', 1)
 		inv:set_size('dst', 4)
+		furnace_node_timer(pos, 0)
 	end,
 
 	on_metadata_inventory_move = function(pos)

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -2600,7 +2600,12 @@ local function register_sign(material, desc, def)
 				text .. "\" to sign at " .. minetest.pos_to_string(pos))
 			local meta = minetest.get_meta(pos)
 			meta:set_string("text", text)
-			meta:set_string("infotext", '"' .. text .. '"')
+
+			if string.len(text) > 0 then
+				meta:set_string("infotext", '"' .. text .. '"')
+			else
+				meta:set_string("infotext", '')
+			end
 		end,
 	})
 end

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -2601,7 +2601,7 @@ local function register_sign(material, desc, def)
 			local meta = minetest.get_meta(pos)
 			meta:set_string("text", text)
 
-			if string.len(text) > 0 then
+			if #text > 0 then
 				meta:set_string("infotext", '"' .. text .. '"')
 			else
 				meta:set_string("infotext", '')

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -333,7 +333,7 @@ function doors.register(name, def)
 
 			if def.protected then
 				meta:set_string("owner", pn)
-				meta:set_string("infotext", S("Steel Door\nOwned by @1", pn))
+				meta:set_string("infotext", S("Steel Door") .. "\n" .. S("Owned by @1", pn))
 			end
 
 			if not (creative and creative.is_enabled_for and creative.is_enabled_for(pn)) then
@@ -586,7 +586,7 @@ function doors.register_trapdoor(name, def)
 			local pn = placer:get_player_name()
 			local meta = minetest.get_meta(pos)
 			meta:set_string("owner", pn)
-			meta:set_string("infotext", S("Steel Trapdoor\nOwned by @1", pn))
+			meta:set_string("infotext", S("Steel Trapdoor") .. "\n" .. S("Owned by @1", pn))
 
 			return (creative and creative.is_enabled_for and creative.is_enabled_for(pn))
 		end

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -333,7 +333,7 @@ function doors.register(name, def)
 
 			if def.protected then
 				meta:set_string("owner", pn)
-				meta:set_string("infotext", S("Owned by @1", pn))
+				meta:set_string("infotext", S("Steel Door\nOwned by @1", pn))
 			end
 
 			if not (creative and creative.is_enabled_for and creative.is_enabled_for(pn)) then
@@ -586,7 +586,7 @@ function doors.register_trapdoor(name, def)
 			local pn = placer:get_player_name()
 			local meta = minetest.get_meta(pos)
 			meta:set_string("owner", pn)
-			meta:set_string("infotext", S("Owned by @1", pn))
+			meta:set_string("infotext", S("Steel Trapdoor\nOwned by @1", pn))
 
 			return (creative and creative.is_enabled_for and creative.is_enabled_for(pn))
 		end

--- a/mods/vessels/init.lua
+++ b/mods/vessels/init.lua
@@ -16,11 +16,15 @@ local vessels_shelf_formspec =
 	"listring[current_player;main]" ..
 	default.get_hotbar_bg(0, 2.85)
 
-local function get_vessels_shelf_formspec(inv)
+local function update_vessels_shelf(pos)
+	local meta = minetest.get_meta(pos)
+	local inv = meta:get_inventory()
+	local invlist = inv:get_list("vessels")
+
 	local formspec = vessels_shelf_formspec
-	local invlist = inv and inv:get_list("vessels")
 	-- Inventory slots overlay
 	local vx, vy = 0, 0.3
+	local n_items = 0
 	for i = 1, 16 do
 		if i == 9 then
 			vx = 0
@@ -29,10 +33,20 @@ local function get_vessels_shelf_formspec(inv)
 		if not invlist or invlist[i]:is_empty() then
 			formspec = formspec ..
 				"image[" .. vx .. "," .. vy .. ";1,1;vessels_shelf_slot.png]"
+		else
+			local stack = invlist[i]
+			if not stack:is_empty() then
+				n_items = n_items + stack:get_count()
+			end
 		end
 		vx = vx + 1
 	end
-	return formspec
+	meta:set_string("formspec", formspec)
+	if n_items == 0 then
+		meta:set_string("infotext", S("Empty Vessel Shelf"))
+	else
+		meta:set_string("infotext", S("Vessel Shelf (@1 items)", n_items))
+	end
 end
 
 minetest.register_node("vessels:shelf", {
@@ -46,7 +60,7 @@ minetest.register_node("vessels:shelf", {
 
 	on_construct = function(pos)
 		local meta = minetest.get_meta(pos)
-		meta:set_string("formspec", get_vessels_shelf_formspec(nil))
+		update_vessels_shelf(pos)
 		local inv = meta:get_inventory()
 		inv:set_size("vessels", 8 * 2)
 	end,
@@ -63,20 +77,17 @@ minetest.register_node("vessels:shelf", {
 	on_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)
 		minetest.log("action", player:get_player_name() ..
 			   " moves stuff in vessels shelf at ".. minetest.pos_to_string(pos))
-		local meta = minetest.get_meta(pos)
-		meta:set_string("formspec", get_vessels_shelf_formspec(meta:get_inventory()))
+		update_vessels_shelf(pos)
 	end,
 	on_metadata_inventory_put = function(pos, listname, index, stack, player)
 		minetest.log("action", player:get_player_name() ..
 			   " moves stuff to vessels shelf at ".. minetest.pos_to_string(pos))
-		local meta = minetest.get_meta(pos)
-		meta:set_string("formspec", get_vessels_shelf_formspec(meta:get_inventory()))
+		update_vessels_shelf(pos)
 	end,
 	on_metadata_inventory_take = function(pos, listname, index, stack, player)
 		minetest.log("action", player:get_player_name() ..
 			   " takes stuff from vessels shelf at ".. minetest.pos_to_string(pos))
-		local meta = minetest.get_meta(pos)
-		meta:set_string("formspec", get_vessels_shelf_formspec(meta:get_inventory()))
+		update_vessels_shelf(pos)
 	end,
 	on_blast = function(pos)
 		local drops = {}


### PR DESCRIPTION
Ref: #2469 

Video showing the new changes:
https://my.pcloud.com/publink/show?code=XZtYHpkZ3UIwRBzs6nSKon9zbekjVQvXCxvX

- [x] Sign, Locked Sign: Shows no infotext when there is no text in the sign

```diff
-    meta:set_string("infotext", '"' .. text .. '"')

+    if string.len(text) > 0 then
+        meta:set_string("infotext", '"' .. text .. '"')
+    else
+        meta:set_string("infotext", '')
+    end
```


- [x] Steel Door, Steel Trapdoor: Shows what it is and the owner

```diff
-    meta:set_string("infotext", S("Owned by @1", pn))
+    meta:set_string("infotext", S("Steel Door\nOwned by @1", pn))

-    meta:set_string("infotext", S("Owned by @1", pn))
+    meta:set_string("infotext", S("Steel Trapdoor\nOwned by @1", pn))
```

- [x] Furnace: Shows infotext on placement:

```diff
on_construct = function(pos)
local meta = minetest.get_meta(pos)
     meta:set_string("formspec", default.get_furnace_inactive_formspec())
+    meta:set_string("infotext", 'Furnace inactive\n(Item: Empty; Fuel: Empty)')
     local inv = meta:get_inventory()
     inv:set_size('src', 1)
     inv:set_size('fuel', 1)
     inv:set_size('dst', 4)
end,
```


- [x] Vessels shelf: Similar to the bookshelf; shows the amount of items and "Empty Vessel Shelf" when no items inside.