### PR TITLE
Marram grass: Fix noise flags to make 2D noise 'eased'

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -2348,13 +2348,13 @@ function default.register_decorations()
 		place_on = {"default:sand"},
 		sidelen = 4,
 		noise_params = {
-			offset = -0.4,
-			scale = 3.0,
+			offset = -0.7,
+			scale = 4.0,
 			spread = {x = 16, y = 16, z = 16},
 			seed = 513337,
 			octaves = 1,
-			persist = 0.5,
-			flags = "absvalue"
+			persist = 0.0,
+			flags = "absvalue, eased"
 		},
 		biomes = {"coniferous_forest_dunes", "grassland_dunes"},
 		y_max = 6,


### PR DESCRIPTION
 Marram grass: Fix noise flags to make 2D noise 'eased'

Increase noise resolution from 4 to 2 nodes for a higher quality
distribution.
Retune noise parameters to compensate for using eased noise.
///////////////////////////////////////////////

![screenshot_20190921_015323](https://user-images.githubusercontent.com/3686677/65365608-b8d50100-dc12-11e9-9bbf-f651493aee1f.png)

^ PR

When the noise flag 'absvalue' is used, 'eased' must be specified also, otherwise 2D noise becomes 'uneased' and non-smooth.
This wasn't noticeable due to the low resolution of marram grass placement, but eased 2D noise will create higher quality patterns.
Note that 2D noise is eased by default.

Apart from using a higher quality, higher resolutrion noise, the distribution of marram grass is similar to before, so treating as trivial.