### PR TITLE
Remove leaf decay/sneak key gotcha'

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -414,7 +414,7 @@ end
 -- Prevent decay of placed leaves
 
 default.after_place_leaves = function(pos, placer, itemstack, pointed_thing)
-	if placer and placer:is_player() and not placer:get_player_control().sneak then
+	if placer and placer:is_player() then
 		local node = minetest.get_node(pos)
 		node.param2 = 1
 		minetest.set_node(pos, node)


### PR DESCRIPTION
When a player places leaves, those leaves aren't subject to leaf decay, because the player deliberately placed them there, and thus clearly wants them to stay. However, if the player happens to be holding the "sneak" key - for example, if they're up on top of something high and trying not to fall off - the "param2" value of the leaf node doesn't get set, meaning that the leaves aren't marked as being player-placed, and are not immune to leaf decay. There is absolutely *no* indication of this in-game. My leaves kept disappearing on me, with no apparent cause, leading me to believe some sort of bug was at work here, and not a deliberately-coded feature.

My proposal is that this annoying quirk be removed. If a player places leaves, they probably want them there, and if they don't, they can remove them when they're done with them. This pull request does just that.

An alternative, if you want to keep this behaviour, would be to inform the player of this counter-intuitive functionality in some way. For example, the screwdriver includes usage information in its "description" field, so when  a player looks at what the screwdriver is, they see the usage information. Similarly, while carts don't have full usage information in their "description" field, they do have instructions for the most difficult thing to figure out: picking them up and putting them back into the players' inventory. Similarly, leaf nodes could contain information about this in their descriptions as well.