### PR TITLE
Add initial 'weather' mod to vary cloud density, thickness, velocity

### DIFF
--- a/mods/weather/README.txt
+++ b/mods/weather/README.txt
@@ -1,0 +1,4 @@
+Minetest Game mod: weather
+==========================
+See license.txt for license information.
+Source code by paramat (MIT).

--- a/mods/weather/init.lua
+++ b/mods/weather/init.lua
@@ -1,0 +1,112 @@
+-- Disable by mapgen or setting
+
+local mg_name = minetest.get_mapgen_setting("mg_name")
+if mg_name == "v6" or mg_name == "singlenode" or
+		minetest.settings:get_bool("enable_weather") == false then
+	return
+end
+
+
+-- Parameters
+
+local TSCALE = 600 -- Time scale of noise variation in seconds
+local CYCLE = 8 -- Time period of cyclic clouds update in seconds
+
+local np_density = {
+	offset = 0.5,
+	scale = 0.5,
+	spread = {x = TSCALE, y = TSCALE, z = TSCALE},
+	seed = 813,
+	octaves = 1,
+	persist = 0,
+	lacunarity = 2,
+}
+
+local np_thickness = {
+	offset = 0.5,
+	scale = 0.5,
+	spread = {x = TSCALE, y = TSCALE, z = TSCALE},
+	seed = 96,
+	octaves = 1,
+	persist = 0,
+	lacunarity = 2,
+}
+
+local np_speedx = {
+	offset = 0,
+	scale = 1,
+	spread = {x = TSCALE, y = TSCALE, z = TSCALE},
+	seed = 911923,
+	octaves = 1,
+	persist = 0,
+	lacunarity = 2,
+}
+
+local np_speedz = {
+	offset = 0,
+	scale = 1,
+	spread = {x = TSCALE, y = TSCALE, z = TSCALE},
+	seed = 5728,
+	octaves = 1,
+	persist = 0,
+	lacunarity = 2,
+}
+
+-- End parameters
+
+
+-- Initialise noise objects to nil
+
+local nobj_density = nil
+local nobj_thickness = nil
+local nobj_speedx = nil
+local nobj_speedz = nil
+
+
+-- Update clouds function
+
+local os_time_0 = os.time()
+local t_offset = math.random(0, 300000)
+
+local function update_clouds()
+	-- Time in seconds.
+	-- Add random time offset to avoid identical behaviour each server session.
+	local time = os.difftime(os.time(), os_time_0) - t_offset
+
+	nobj_density = nobj_density or minetest.get_perlin(np_density)
+	nobj_thickness = nobj_thickness or minetest.get_perlin(np_thickness)
+	nobj_speedx = nobj_speedx or minetest.get_perlin(np_speedx)
+	nobj_speedz = nobj_speedz or minetest.get_perlin(np_speedz)
+
+	local n_density = nobj_density:get2d({x = time, y = 0})
+	local n_thickness = nobj_thickness:get2d({x = time, y = 0})
+	local n_speedx = nobj_speedx:get2d({x = time, y = 0})
+	local n_speedz = nobj_speedz:get2d({x = time, y = 0})
+
+	for _, player in ipairs(minetest.get_connected_players()) do
+		local humid = minetest.get_humidity(player:get_pos())
+		player:set_clouds({
+			density = math.min(math.max(humid / 100, 0.25), 1.0) * n_density,
+			thickness = math.max(math.floor(
+				math.min(math.max(32 * humid / 100, 8), 32) * n_thickness
+				), 1),
+			speed = {x = n_speedx * 4, z = n_speedz * 4},
+		})
+	end
+end
+
+
+local function cyclic_update()
+	update_clouds()
+	minetest.after(CYCLE, cyclic_update)
+end
+
+
+minetest.after(0, cyclic_update)
+
+
+-- Update on player join to instantly alter clouds from the default
+
+minetest.register_on_joinplayer(function(player)
+	update_clouds()
+end)

--- a/mods/weather/init.lua
+++ b/mods/weather/init.lua
@@ -65,6 +65,10 @@ local nobj_speedz = nil
 
 -- Update clouds function
 
+local function rangelim(value, lower, upper)
+	return math.min(math.max(value, lower), upper)
+end
+
 local os_time_0 = os.time()
 local t_offset = math.random(0, 300000)
 
@@ -86,9 +90,9 @@ local function update_clouds()
 	for _, player in ipairs(minetest.get_connected_players()) do
 		local humid = minetest.get_humidity(player:get_pos())
 		player:set_clouds({
-			density = math.min(math.max(humid / 100, 0.25), 1.0) * n_density,
+			density = rangelim(humid / 100, 0.25, 1.0) * n_density,
 			thickness = math.max(math.floor(
-				math.min(math.max(32 * humid / 100, 8), 32) * n_thickness
+				rangelim(32 * humid / 100, 8, 32) * n_thickness
 				), 1),
 			speed = {x = n_speedx * 4, z = n_speedz * 4},
 		})

--- a/mods/weather/license.txt
+++ b/mods/weather/license.txt
@@ -1,0 +1,24 @@
+License of source code
+----------------------
+
+The MIT License (MIT)
+Copyright (C) 2019 paramat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+For more details:
+https://opensource.org/licenses/MIT

--- a/mods/weather/mod.conf
+++ b/mods/weather/mod.conf
@@ -1,0 +1,2 @@
+name = weather
+description = Minetest Game mod: weather

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -71,3 +71,7 @@ engine_spawn (Use engine spawn search) bool false
 #    Whether river water source nodes create flowing sounds.
 #    Helps rivers create more sound, especially on level sections.
 river_source_sounds (River source node sounds) bool false
+
+#    Enable cloud variation.
+#    Non-functional in V6 or Singlenode mapgens.
+enable_weather (Enable weather) bool true


### PR DESCRIPTION
![screenshot_20191001_171356](https://user-images.githubusercontent.com/3686677/65981298-b4111800-e470-11e9-9829-e3c754ee3d2d.png)

![screenshot_20191001_172037](https://user-images.githubusercontent.com/3686677/65981309-b83d3580-e470-11e9-8763-b5f238ae2cb2.png)

Firstly, don't get too excited by the mod name.
This mod is like 'env_sounds', it is intended to be simple at first, to have more features added later as engine features improve. This is why it is called 'weather' even though it only varies cloud density, thickness and velocity.

The reason i haven't included dark clouds, rain. snow etc. yet is because those are currently problematic/intensive/network-intensive. Work on improving weather implementation is going on elsewhere (Hidden Worlds game, snowdrift mod). Considering the problems it is too early to add a complete weather system to MTG, the MTEngine may need improving first.
Clouds are very often in view, so although this is simple it makes a very significant difference to the experience.
Using my experience with the snowdrift mod (and Hidden Worlds) i will be happy to develop this mod and add weather features in future.

* This mod uses player location humidity and 4 noises to vary: density, thickness, x velocity, z velocity.
* By default, every 8sec all players have their sky updated.
* The default time scale for changes is 600sec / 10min, half of a default MT day. This keeps changes gradual but allows significant change during daylight.
* Every server session start a random time offset is added to randomise the behaviour of the noises. Without this, each server session in a world would go through identical noise variations.
* Also works with 3D clouds disabled.

Variations
------------
Density (proportion of cloud covering sky):

The initial value varies from 0.25 at humidity 0 to 1.0 at humidity 100, and is limited to those values for more extreme humidities.
Then this value is multiplied by the noise value (0.0 to 1.0).
The result is that density varies between 0.0 and 0.25 at humidity 0 (desert), and varies between 0.0 and 1.0 at humidity 100 (rainforest).
The intention being that clear sky is possible in both biomes, but cloud cover is always low in desert, but can become overcast in rainforest.

Thickness (in nodes):

The initial value varies from 8 (fairly thin clouds) at humidity 0 to 32 (twice classic thickness) at humidity 100, and is limited to those values for more extreme humidities.
Then this value is multiplied by the noise value (0.0 to 1.0).
At this stage, the value varies between 0 and 8 at humidity 0 (desert), and varies between 0 and 32 at humidity 100 (rainforest).
The value is then rounded down to an integer to make clouds a certain number of nodes thick, in the same way that their unit width is 64 nodes.
Finally a minimum of 1 node thick is enforced, so that only density variaton can make clouds disappear, not thickness variation.
The intention being that thin clouds are possible in both biomes, but clouds are always fairly thin in desert, but can become very fat in rainforest.

Velocity (in nodes per second):

Each component is varied by noise between 0 and 4 (twice classic velocity).

How to test
--------------
* In the init.lua, set TSCALE = 3 and CYCLE = 3, to cause rapidly changing noise values.
* Edit line 78 to `local humid = 0` or `local humid = 100` to see behaviour at the extremes of humidity, indoependent of what biome the player is in.