### PR TITLE
Fix duplicate background in formspec prepend.

### DIFF
--- a/mods/default/init.lua
+++ b/mods/default/init.lua
@@ -21,9 +21,9 @@ minetest.register_on_joinplayer(function(player)
 	local name = player:get_player_name()
 	local info = minetest.get_player_information(name)
 	if info.formspec_version > 1 then
-		formspec = formspec .. 'background9[5,5;1,1;gui_formbg.png;true;10]'
+		formspec = formspec .. "background9[5,5;1,1;gui_formbg.png;true;10]"
 	else
-		formspec = formspec .. 'background[5,5;1,1;gui_formbg.png;true]'
+		formspec = formspec .. "background[5,5;1,1;gui_formbg.png;true]"
 	end
 	player:set_formspec_prepend(formspec)
 end)

--- a/mods/default/init.lua
+++ b/mods/default/init.lua
@@ -14,11 +14,18 @@ default.get_translator = S
 
 -- GUI related stuff
 minetest.register_on_joinplayer(function(player)
-	player:set_formspec_prepend([[
+	local formspec = [[
 			bgcolor[#080808BB;true]
-			background[5,5;1,1;gui_formbg.png;true]
-			background9[5,5;1,1;gui_formbg.png;true;10]
-			listcolors[#00000069;#5A5A5A;#141318;#30434C;#FFF] ]])
+			listcolors[#00000069;#5A5A5A;#141318;#30434C;#FFF] ]]
+
+	local name = player:get_player_name()
+	local info = minetest.get_player_information(name)
+	if info.formspec_version > 1 then
+		formspec = formspec .. 'background9[5,5;1,1;gui_formbg.png;true;10]'
+	else
+		formspec = formspec .. 'background[5,5;1,1;gui_formbg.png;true]'
+	end
+	player:set_formspec_prepend(formspec)
 end)
 
 function default.get_hotbar_bg(x,y)


### PR DESCRIPTION
Minetest 5.1.0 seems to draw both 9-slice and regular backgrounds at the same time.

Example screenshot from the pause menu:

![Before](https://user-images.githubusercontent.com/3182651/66727153-c8560b80-ee99-11e9-9d55-90f4ea743c46.png)

This PR uses either `background[]` or `background9[]` depending on the formspec version supported by the client, not both.

![After](https://user-images.githubusercontent.com/3182651/66727183-f3405f80-ee99-11e9-9aed-6a553d786b94.png)
