### PR TITLE
Papyrus: Add to the rainforest swamp biome

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -1944,11 +1944,35 @@ function default.register_decorations()
 	minetest.register_decoration({
 		name = "default:jungle_tree",
 		deco_type = "schematic",
-		place_on = {"default:dirt_with_rainforest_litter", "default:dirt"},
+		place_on = {"default:dirt_with_rainforest_litter"},
 		sidelen = 80,
 		fill_ratio = 0.1,
-		biomes = {"rainforest", "rainforest_swamp"},
+		biomes = {"rainforest"},
 		y_max = 31000,
+		y_min = 1,
+		schematic = minetest.get_modpath("default") .. "/schematics/jungle_tree.mts",
+		flags = "place_center_x, place_center_z",
+		rotation = "random",
+	})
+
+	-- Swamp jungle trees
+
+	minetest.register_decoration({
+		name = "default:jungle_tree(swamp)",
+		deco_type = "schematic",
+		place_on = {"default:dirt"},
+		sidelen = 16,
+		-- Noise tuned to place swamp trees where papyrus is absent
+		noise_params = {
+			offset = 0.0,
+			scale = -0.1,
+			spread = {x = 200, y = 200, z = 200},
+			seed = 354,
+			octaves = 1,
+			persist = 0.5
+		},
+		biomes = {"rainforest_swamp"},
+		y_max = 0,
 		y_min = -1,
 		schematic = minetest.get_modpath("default") .. "/schematics/jungle_tree.mts",
 		flags = "place_center_x, place_center_z",
@@ -1962,7 +1986,7 @@ function default.register_decorations()
 		place_offset_y = 1,
 		sidelen = 80,
 		fill_ratio = 0.005,
-		biomes = {"rainforest", "rainforest_swamp"},
+		biomes = {"rainforest"},
 		y_max = 31000,
 		y_min = 1,
 		schematic = minetest.get_modpath("default") .. "/schematics/jungle_log.mts",
@@ -2185,7 +2209,7 @@ function default.register_decorations()
 			octaves = 3,
 			persist = 0.7
 		},
-		biomes = {"savanna_shore"},
+		biomes = {"savanna_shore", "rainforest_swamp"},
 		y_max = 0,
 		y_min = 0,
 		schematic = minetest.get_modpath("default") .. "/schematics/papyrus.mts",


### PR DESCRIPTION
Previously, papyrus was limited to the savanna biome.
Rainforest is a suitable habitat for papyrus.
Makes papyrus a little less difficult to find.
Move swamp jungletrees into a separate registration, to allow
applying distribution by perlin noise to keep these away from
papyrus areas.

Fix error: Remove non-functional 'rainforest swamp' from the
biome list for the jungle log decoration. It is not placed in
swamps due to the 'y max/min' and 'place on' parameters.
/////////////////////////////////////

![screenshot_20191107_232132](https://user-images.githubusercontent.com/3686677/68439072-2d153500-01be-11ea-8076-9819c42a2e84.png)

^ Separated swamp (lower left) and papyrus (upper right) areas

A post on the forum mentioning the difficulty of finding papyrus made me research and discover that rainforest is a suitable habitat for it.
Also adds some welcome variation to the rainforest shore instead of being 100% jungletree swamp.