### PR TITLE
Escape translated text in formspecs

### DIFF
--- a/mods/beds/init.lua
+++ b/mods/beds/init.lua
@@ -2,7 +2,7 @@
 
 -- Load support for MT game translation.
 local S = minetest.get_translator("beds")
-
+local esc = minetest.formspec_escape
 
 beds = {}
 beds.player = {}
@@ -14,7 +14,7 @@ beds.get_translator = S
 beds.formspec = "size[8,11;true]" ..
 	"no_prepend[]" ..
 	"bgcolor[#080808BB;true]" ..
-	"button_exit[2,10;4,0.75;leave;" .. S("Leave Bed") .. "]"
+	"button_exit[2,10;4,0.75;leave;" .. esc(S("Leave Bed")) .. "]"
 
 local modpath = minetest.get_modpath("beds")
 


### PR DESCRIPTION
fixes #2470

> Wuzzy2
> Add `local F = minetest.formspec_escape` at the top of each offending file, then just turn `S("blabla")` into `F(S("blabla"))` whereever it's needed to keep everything nice and readable.

Most already have the `formspec_escape` code already, except for the bed formspec. I used `esc` instead of `F` to match the rest used.