### PR TITLE
Fix cause of doors/coral crash

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -2031,7 +2031,7 @@ local function coral_on_place(itemstack, placer, pointed_thing)
 	local def_under = minetest.registered_nodes[node_under.name]
 
 	if def_under and def_under.on_rightclick and not placer:get_player_control().sneak then
-		return def_under.on_rightclick(pos_under, node_under.name,
+		return def_under.on_rightclick(pos_under, node_under,
 				placer, itemstack, pointed_thing) or itemstack
 	end
 


### PR DESCRIPTION
Fixes a tiny error in the default mod which causes a crash when a door is right-clicked with coral:

```
minetest_1           | 2019-11-13 18:24:53: ERROR[Main]: ServerError: AsyncErr: ServerThread::run Lua: Runtime error from mod 'default' in callback item_OnPlace(): ...l/share/minetest/games/minetest_game/mods/doors/init.lua:141: attempt to index local 'def' (a nil value)
minetest_1           | 2019-11-13 18:24:53: ERROR[Main]: stack traceback:
minetest_1           | 2019-11-13 18:24:53: ERROR[Main]: 	...l/share/minetest/games/minetest_game/mods/doors/init.lua:141: in function 'door_toggle'
minetest_1           | 2019-11-13 18:24:53: ERROR[Main]: 	...l/share/minetest/games/minetest_game/mods/doors/init.lua:382: in function 'on_rightclick'
minetest_1           | 2019-11-13 18:24:53: ERROR[Main]: 	...hare/minetest/games/minetest_game/mods/default/nodes.lua:2034: in function <...hare/minetest/games/minetest_game/mods/default/nodes.lua:2022>
```

Original issue: https://github.com/pandorabox-io/pandorabox.io/issues/358