### PR TITLE
Add missing 'weather' mod documentation to minetest.conf.example

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -71,3 +71,7 @@ default:torch 99,default:cobble 99
 # Whether river water source nodes create flowing sounds.
 # Helps rivers create more sound, especially on level sections.
 #river_source_sounds = false
+
+# Enable cloud variation by the 'weather' mod.
+# Non-functional in V6 or Singlenode mapgens.
+#enable_weather = true

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -72,6 +72,6 @@ engine_spawn (Use engine spawn search) bool false
 #    Helps rivers create more sound, especially on level sections.
 river_source_sounds (River source node sounds) bool false
 
-#    Enable cloud variation.
+#    Enable cloud variation by the 'weather' mod.
 #    Non-functional in V6 or Singlenode mapgens.
 enable_weather (Enable weather) bool true


### PR DESCRIPTION
I forgot this when the 'weather' mod was added, probably due to being used to how the engine auto-generates minetest.conf.example.