### PR TITLE
Add global sounds

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -239,6 +239,32 @@ local function grow_sapling(...)
 	return default.grow_sapling(...)
 end
 
+-- Global sounds for place and dug
+function playSound(pos, actor, sound)
+    for _, player in pairs(minetest.get_connected_players()) do
+        local name = player:get_player_name()
+        if name ~= actor:get_player_name() then
+            minetest.sound_play(sound, {to_player = name, pos = pos, max_hear_distance = 8})
+        end
+    end
+end
+
+minetest.register_on_placenode(function(pos, newnode, placer)
+    local nodedef = minetest.registered_nodes[newnode.name]
+
+    if nodedef.sounds then
+        playSound(pos, placer, nodedef.sounds.place)
+    end
+end)
+
+minetest.register_on_dignode(function(pos, oldnode, digger)
+    local nodedef = minetest.registered_nodes[oldnode.name]
+
+    if nodedef.sounds then
+        playSound(pos, digger, nodedef.sounds.dug)
+    end
+end)
+
 --
 -- Stone
 --


### PR DESCRIPTION
Ref: https://github.com/minetest/minetest/issues/7996

Plays 'place' and 'dug' sounds by one client for other clients on the same server. It works globally; for all nodes in any mod (as far as I know).

- [ ] Move code to a suitable location (IMPORTANT)

- [ ] Agree on the max_hear_distance which is currently 8 blocks. I've seen 10 (used by the trapdoors)

- [ ] Check if any other sounds need to be processed globally