### PR TITLE
Add dry_dirt to papyrus mapgen

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -2146,7 +2146,7 @@ function default.register_decorations()
 	minetest.register_decoration({
 		name = "default:papyrus",
 		deco_type = "schematic",
-		place_on = {"default:dirt"},
+		place_on = {"default:dirt", "default:dry_dirt"},
 		sidelen = 16,
 		noise_params = {
 			offset = -0.3,


### PR DESCRIPTION
Closes #2577

Fix to allow papyrus to grow on dry_dirt in the savanna biome

![test](https://user-images.githubusercontent.com/49789044/73606848-9aaae480-45a6-11ea-996f-2993bf49d23b.png)

The only problem is that the schematic of the papyrus structure contains dirt and that cannot be modified to dry_dirt unless a new schematic is specifically made for savanna biomes.