### PR TITLE
Avoid error when 'get_player_information' returns 'nil'

### DIFF
--- a/mods/default/init.lua
+++ b/mods/default/init.lua
@@ -20,7 +20,7 @@ minetest.register_on_joinplayer(function(player)
 			listcolors[#00000069;#5A5A5A;#141318;#30434C;#FFF] ]]
 	local name = player:get_player_name()
 	local info = minetest.get_player_information(name)
-	if info.formspec_version > 1 then
+	if info and info.formspec_version > 1 then
 		formspec = formspec .. "background9[5,5;1,1;gui_formbg.png;true;10]"
 	else
 		formspec = formspec .. "background[5,5;1,1;gui_formbg.png;true]"


### PR DESCRIPTION
MTG robustness fix for issue https://github.com/minetest/minetest/issues/9352 , as that may take some time to fix in the engine.