### PR TITLE
Fix simple bed height, make player lay down just above it, not inside it

### DIFF
--- a/mods/beds/beds.lua
+++ b/mods/beds/beds.lua
@@ -79,10 +79,10 @@ beds.register_bed("beds:bed", {
 		}
 	},
 	nodebox = {
-		bottom = {-0.5, -0.5, -0.5, 0.5, 0.06, 0.5},
-		top = {-0.5, -0.5, -0.5, 0.5, 0.06, 0.5},
+		bottom = {-0.5, -0.5, -0.5, 0.5, 0.0625, 0.5},
+		top = {-0.5, -0.5, -0.5, 0.5, 0.0625, 0.5},
 	},
-	selectionbox = {-0.5, -0.5, -0.5, 0.5, 0.06, 1.5},
+	selectionbox = {-0.5, -0.5, -0.5, 0.5, 0.0625, 1.5},
 	recipe = {
 		{"wool:white", "wool:white", "wool:white"},
 		{"group:wood", "group:wood", "group:wood"}

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -90,7 +90,13 @@ local function lay_down(player, pos, bed_pos, state, skip)
 		local yaw, param2 = get_look_yaw(bed_pos)
 		player:set_look_horizontal(yaw)
 		local dir = minetest.facedir_to_dir(param2)
-		local p = {x = bed_pos.x + dir.x / 2, y = bed_pos.y, z = bed_pos.z + dir.z / 2}
+		-- p.y is just above the nodebox height of the 'Simple Bed' (the highest bed),
+		-- to avoid sinking down through the bed.
+		local p = {
+			x = bed_pos.x + dir.x / 2,
+			y = bed_pos.y + 0.07,
+			z = bed_pos.z + dir.z / 2
+		}
 		player:set_physics_override(0, 0, 0)
 		player:set_pos(p)
 		default.player_attached[name] = true


### PR DESCRIPTION
Closes #2581

Previously, collision changes recently made in the engine caused the player to sink down through the simple bed, because the player is placed inside it, not just above it.

When laying down, place player just above the simple bed (the highest bed).
Also, make the simple bed nodebox height exactly 9 pixels (the texture height).

Tested.