### PR TITLE
Transform brick top texture to align bricks correctly

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -2816,7 +2816,10 @@ minetest.register_node("default:brick", {
 	description = S("Brick Block"),
 	paramtype2 = "facedir",
 	place_param2 = 0,
-	tiles = {"default_brick.png"},
+	tiles = {
+		"default_brick.png^[transformFX",
+		"default_brick.png",
+	},
 	is_ground_content = false,
 	groups = {cracky = 3},
 	sounds = default.node_sound_stone_defaults(),


### PR DESCRIPTION
Fixes aligning of bricks by flipping the top texture of the brick node on the X axis.

OLD <---> NEW
![test2](https://user-images.githubusercontent.com/49789044/75323234-64dae200-586c-11ea-90e5-cd377230e68b.png)
@paramat 