### PR TITLE
fix collision between water types with waving water on

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -2272,6 +2272,7 @@ minetest.register_node("default:water_flowing", {
 minetest.register_node("default:river_water_source", {
 	description = S("River Water Source"),
 	drawtype = "liquid",
+	waving = 3,
 	tiles = {
 		{
 			name = "default_river_water_source_animated.png",
@@ -2321,6 +2322,7 @@ minetest.register_node("default:river_water_source", {
 minetest.register_node("default:river_water_flowing", {
 	description = S("Flowing River Water"),
 	drawtype = "flowingliquid",
+	waving = 3,
 	tiles = {"default_river_water.png"},
 	special_tiles = {
 		{


### PR DESCRIPTION
Currently, with Waving Water = true in minetest settings, you get this ugly 'feature' caused because river water does not have 'waving = 3'.
![screenshot_20200124_181048](https://user-images.githubusercontent.com/44441970/75576375-71526c80-5a1d-11ea-94e5-ecb78297e456.png)
Trivial and should be merged to prevent this weird artifacting.