### PR TITLE
Dungeon loot: Warn on unknown registered loot items

### DIFF
--- a/mods/dungeon_loot/mapgen.lua
+++ b/mods/dungeon_loot/mapgen.lua
@@ -89,20 +89,20 @@ local function populate_chest(pos, rand, dungeontype)
 				amount = rand:next(loot.count[1], loot.count[2])
 			end
 
-			if itemdef then
-				if itemdef.tool_capabilities then
-					for n = 1, amount do
-						local wear = rand:next(0.20 * 65535, 0.75 * 65535) -- 20% to 75% wear
-						table.insert(items, ItemStack({name = loot.name, wear = wear}))
-					end
-				elseif itemdef.stack_max == 1 then
-					-- not stackable, add separately
-					for n = 1, amount do
-						table.insert(items, loot.name)
-					end
-				else
-					table.insert(items, ItemStack({name = loot.name, count = amount}))
+			if not itemdef then
+				minetest.log("warning", "Registered loot item " .. loot.name .. " does not exist")
+			elseif itemdef.tool_capabilities then
+				for n = 1, amount do
+					local wear = rand:next(0.20 * 65535, 0.75 * 65535) -- 20% to 75% wear
+					table.insert(items, ItemStack({name = loot.name, wear = wear}))
 				end
+			elseif itemdef.stack_max == 1 then
+				-- not stackable, add separately
+				for n = 1, amount do
+					table.insert(items, loot.name)
+				end
+			else
+				table.insert(items, ItemStack({name = loot.name, count = amount}))
 			end
 		end
 	end


### PR DESCRIPTION
Now that loot registration was sorted into the mods that provide those items (8d9aa077522135ef31af32579ffab7cf5ce7fd52), there is no reason an unknown item should find its way into the dungeon loot table. So print a warning if that happens.