### PR TITLE
xpanes: Fix code style

### DIFF
--- a/mods/xpanes/init.lua
+++ b/mods/xpanes/init.lua
@@ -106,12 +106,12 @@ function xpanes.register_pane(name, def)
 		wield_image = def.wield_image,
 		paramtype2 = "facedir",
 		tiles = {
-				def.textures[3],
-				def.textures[3],
-				def.textures[3],
-				def.textures[3],
-				def.textures[1],
-				def.textures[1]
+			def.textures[3],
+			def.textures[3],
+			def.textures[3],
+			def.textures[3],
+			def.textures[1],
+			def.textures[1]
 		},
 		groups = flatgroups,
 		drop = "xpanes:" .. name .. "_flat",


### PR DESCRIPTION
-1 indent on texture defs in first registered node, to match texture def which were just fixed for code style in second registered node.