### PR TITLE
player_api: Prevent knockback when player is set as attached

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -20,5 +20,8 @@ read_globals = {
 -- Overwrites minetest.handle_node_drops
 files["mods/creative/init.lua"].globals = { "minetest" }
 
+-- Overwrites minetest.calculate_knockback
+files["mods/player_api/api.lua"].globals = { "minetest" }
+
 -- Don't report on legacy definitions of globals.
 files["mods/default/legacy.lua"].global = false

--- a/game_api.txt
+++ b/game_api.txt
@@ -424,7 +424,7 @@ Give Initial Stuff API
 Players API
 -----------
 
-The player API can register player models and update the player's appearence
+The player API can register player models and update the player's appearance.
 
 * `player_api.register_model(name, def)`
 	* Register a new model to be used by players
@@ -457,6 +457,12 @@ The player API can register player models and update the player's appearence
 	* Any of the fields of the returned table may be nil.
 	* player: PlayerRef
 
+* `player_api.player_attached`
+	* A table that maps a player name to a boolean.
+	* If the value for a given player is set to true, the default player
+	animations (walking, digging, ...) will no longer be updated.
+	Knockback from damage is also prevented for that player.
+
 ### Model Definition
 
 	{
@@ -467,7 +473,7 @@ The player API can register player models and update the player's appearence
 			-- <anim_name> = {x = <start_frame>, y = <end_frame>},
 			foo = {x = 0, y = 19},
 			bar = {x = 20, y = 39},
-		-- ...
+			-- ...
 		},
 		collisionbox = {-0.3, 0.0, -0.3, 0.3, 1.7, 0.3}, -- In nodes from feet position
 		stepheight = 0.6, -- In nodes

--- a/mods/player_api/api.lua
+++ b/mods/player_api/api.lua
@@ -96,6 +96,15 @@ end)
 local player_set_animation = player_api.set_animation
 local player_attached = player_api.player_attached
 
+-- Prevent knockback for attached players
+local old_calculate_knockback = minetest.calculate_knockback
+function minetest.calculate_knockback(player, ...)
+	if player_attached[player:get_player_name()] then
+		return 0
+	end
+	return old_calculate_knockback(player, ...)
+end
+
 -- Check each player and apply animations
 minetest.register_globalstep(function(dtime)
 	for _, player in pairs(minetest.get_connected_players()) do


### PR DESCRIPTION
fixes #2619, fixes #2343