### PR TITLE
Make straw stairs usable as fuel

### DIFF
--- a/mods/farming/init.lua
+++ b/mods/farming/init.lua
@@ -117,12 +117,6 @@ minetest.register_craft({
 
 minetest.register_craft({
 	type = "fuel",
-	recipe = "farming:straw",
-	burntime = 3,
-})
-
-minetest.register_craft({
-	type = "fuel",
 	recipe = "farming:wheat",
 	burntime = 1,
 })

--- a/mods/farming/nodes.lua
+++ b/mods/farming/nodes.lua
@@ -153,6 +153,13 @@ minetest.register_node("farming:straw", {
 	sounds = default.node_sound_leaves_defaults(),
 })
 
+-- Registered before the stairs so the stairs get fuel recipes.
+minetest.register_craft({
+	type = "fuel",
+	recipe = "farming:straw",
+	burntime = 3,
+})
+
 do
 	local recipe = "farming:straw"
 	local groups = {snappy = 3, flammable = 4}


### PR DESCRIPTION
The stairs should be registered after straw is registered as a fuel.