### PR TITLE
Clarify descriptions of dry grass, dry dirt

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -458,7 +458,7 @@ minetest.register_node("default:dirt_with_grass_footsteps", {
 })
 
 minetest.register_node("default:dirt_with_dry_grass", {
-	description = S("Dirt with Dry Grass"),
+	description = S("Dirt with Savanna Grass"),
 	tiles = {"default_dry_grass.png",
 		"default_dirt.png",
 		{name = "default_dirt.png^default_dry_grass_side.png",
@@ -513,14 +513,14 @@ minetest.register_node("default:dirt_with_coniferous_litter", {
 })
 
 minetest.register_node("default:dry_dirt", {
-	description = S("Dry Dirt"),
+	description = S("Savanna Dirt"),
 	tiles = {"default_dry_dirt.png"},
 	groups = {crumbly = 3, soil = 1},
 	sounds = default.node_sound_dirt_defaults(),
 })
 
 minetest.register_node("default:dry_dirt_with_dry_grass", {
-	description = S("Dry Dirt with Dry Grass"),
+	description = S("Savanna Dirt with Savanna Grass"),
 	tiles = {"default_dry_grass.png", "default_dry_dirt.png",
 		{name = "default_dry_dirt.png^default_dry_grass_side.png",
 			tileable_vertical = false}},
@@ -1497,7 +1497,7 @@ end
 
 
 minetest.register_node("default:dry_grass_1", {
-	description = S("Dry Grass"),
+	description = S("Savanna Grass"),
 	drawtype = "plantlike",
 	waving = 1,
 	tiles = {"default_dry_grass_1.png"},
@@ -1526,7 +1526,7 @@ minetest.register_node("default:dry_grass_1", {
 
 for i = 2, 5 do
 	minetest.register_node("default:dry_grass_" .. i, {
-		description = S("Dry Grass"),
+		description = S("Savanna Grass"),
 		drawtype = "plantlike",
 		waving = 1,
 		tiles = {"default_dry_grass_" .. i .. ".png"},

--- a/mods/farming/nodes.lua
+++ b/mods/farming/nodes.lua
@@ -86,7 +86,7 @@ minetest.register_node("farming:soil_wet", {
 })
 
 minetest.register_node("farming:dry_soil", {
-	description = S("Dry Soil"),
+	description = S("Savanna Soil"),
 	tiles = {"default_dry_dirt.png^farming_soil.png", "default_dry_dirt.png"},
 	drop = "default:dry_dirt",
 	groups = {crumbly=3, not_in_creative_inventory=1, soil=2, grassland = 1, field = 1},
@@ -99,7 +99,7 @@ minetest.register_node("farming:dry_soil", {
 })
 
 minetest.register_node("farming:dry_soil_wet", {
-	description = S("Wet Dry Soil"),
+	description = S("Wet Savanna Soil"),
 	tiles = {"default_dry_dirt.png^farming_soil_wet.png", "default_dry_dirt.png^farming_soil_wet_side.png"},
 	drop = "default:dry_dirt",
 	groups = {crumbly=3, not_in_creative_inventory=1, soil=3, wet = 1, grassland = 1, field = 1},


### PR DESCRIPTION
Perhaps for 5.2.0 to reduce confusion?

There is problematic confusion about default:dry_dirt, misunderstanding it as being 'dry default:dirt', when it is actually a different dirt type.
This also created a bizarre looking node description in farming: 'Wet Dry Soil'.
When default:dry_dirt was added we simply made the descriptions copy the nodenames, which now seems to probably be a mistake.
For completeness, symmetry and consistency i have also changed the description of default:dry_grass, this may help avoid it being considered 'dry default:grass'.

Now the farming nodes refer to the biome just like 'Desert Sand Soil' and 'Wet Desert Sand Soil' do.

If desired i could also change the description of default:dry_shrub to 'Desert Shrub', but have not as it seemed controversial.