### PR TITLE
Fix respawn not working at all when suitable position was not found

### DIFF
--- a/mods/spawn/init.lua
+++ b/mods/spawn/init.lua
@@ -135,6 +135,7 @@ local function on_spawn(player)
 	if success then
 		player:set_pos(spawn_pos)
 	end
+	return success
 end
 
 minetest.register_on_newplayer(function(player)
@@ -153,7 +154,5 @@ minetest.register_on_respawnplayer(function(player)
 		return
 	end
 
-	on_spawn(player)
-
-	return true
+	return on_spawn(player)
 end)


### PR DESCRIPTION
If you install a mod that replaced biomes with custom ones, the spawning code does not find a suitable location and you are respawned at the exact location you die