### PR TITLE
furnace: Start the timer on on_metadata_inventory_take.

### DIFF
--- a/mods/default/furnace.lua
+++ b/mods/default/furnace.lua
@@ -305,6 +305,10 @@ minetest.register_node("default:furnace", {
 		-- start timer function, it will sort out whether furnace can burn or not.
 		minetest.get_node_timer(pos):start(1.0)
 	end,
+	on_metadata_inventory_take = function(pos)
+		-- check whether the furnace is empty or not.
+		minetest.get_node_timer(pos):start(1.0)
+	end,
 	on_blast = function(pos)
 		local drops = {}
 		default.get_inventory_drops(pos, "src", drops)


### PR DESCRIPTION
This fixes a cosmetic issue that where if a player removes items from the furnace it will not revert to showing that its `"Empty"`. The furnace would only show its empty when the the items were used up by the smelting process.
