### PR TITLE
 stairs: Add stairs.register_stair_type() to reduce duplicated code. 

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -719,16 +719,24 @@ Stairs API
 The stairs API lets you register stairs and slabs and ensures that they are registered the same way as those
 delivered with Minetest Game, to keep them compatible with other mods.
 
-`stairs.register_stair(subname, recipeitem, groups, images, description, sounds, worldaligntex)`
+`stairs.register_stair_type(subname, recipeitem, groups, images, description, sounds, worldaligntex, full_description, stairtype)`
 
  * Registers a stair
- * `subname`: Basically the material name (e.g. cobble) used for the stair name. Nodename pattern: "stairs:stair_subname"
+ * `subname`: Basically the material name (e.g. cobble) used for the stair name.
+             Nodename pattern: "stairs:stair_subname", "stairs:stair_inner_subname", stairs:stair_outer_subname
  * `recipeitem`: Item used in the craft recipe, e.g. "default:cobble", may be `nil`
  * `groups`: See [Known damage and digging time defining groups]
  * `images`: See [Tile definition]
  * `description`: Used for the description field in the stair's definition
  * `sounds`: See [#Default sounds]
  * `worldaligntex`: A bool to set all textures world-aligned. Default false. See [Tile definition]
+ * `full_description`: Overrides the description, bypassing string concatenation. This is useful for translation. (optional)
+    * Note: Only for inner and outer stairs.
+ * `stairtype`: Sets the type of stair, e.g. "inner" for inner corner stair and "outer" for outer corner stair, otherwise `nil`
+
+`stairs.register_stair(subname, recipeitem, groups, images, description, sounds, worldaligntex)`
+
+ * Deprecated, remove from mods.
 
 `stairs.register_slab(subname, recipeitem, groups, images, description, sounds, worldaligntex)`
 
@@ -743,27 +751,11 @@ delivered with Minetest Game, to keep them compatible with other mods.
 
 `stairs.register_stair_inner(subname, recipeitem, groups, images, description, sounds, worldaligntex, full_description)`
 
- * Registers an inner corner stair
- * `subname`: Basically the material name (e.g. cobble) used for the stair name. Nodename pattern: "stairs:stair_inner_subname"
- * `recipeitem`: Item used in the craft recipe, e.g. "default:cobble", may be `nil`
- * `groups`: See [Known damage and digging time defining groups]
- * `images`: See [Tile definition]
- * `description`: Used for the description field in the stair's definition with "Inner" prepended
- * `sounds`: See [#Default sounds]
- * `worldaligntex`: A bool to set all textures world-aligned. Default false. See [Tile definition]
- * `full_description`: Overrides the description, bypassing string concatenation. This is useful for translation. (optional)
+ * Deprecated, remove from mods.
 
 `stairs.register_stair_outer(subname, recipeitem, groups, images, description, sounds, worldaligntex, full_description)`
 
- * Registers an outer corner stair
- * `subname`: Basically the material name (e.g. cobble) used for the stair name. Nodename pattern: "stairs:stair_outer_subname"
- * `recipeitem`: Item used in the craft recipe, e.g. "default:cobble", may be `nil`
- * `groups`: See [Known damage and digging time defining groups]
- * `images`: See [Tile definition]
- * `description`: Used for the description field in the stair's definition with "Outer" prepended
- * `sounds`: See [#Default sounds]
- * `worldaligntex`: A bool to set all textures world-aligned. Default false. See [Tile definition]
- * `full_description`: Overrides the description, bypassing string concatenation. This is useful for translation. (optional)
+ * Deprecated, remove from mods.
 
 `stairs.register_stair_and_slab(subname, recipeitem, groups, images, desc_stair, desc_slab, sounds, worldaligntex)`
 

--- a/mods/farming/nodes.lua
+++ b/mods/farming/nodes.lua
@@ -159,12 +159,12 @@ do
 	local images = {"farming_straw.png"}
 	local sounds = default.node_sound_leaves_defaults()
 
-	stairs.register_stair("straw", recipe, groups, images, S("Straw Stair"),
+	stairs.register_stair_type("straw", recipe, groups, images, S("Straw Stair"),
 		sounds, true)
-	stairs.register_stair_inner("straw", recipe, groups, images, "",
-		sounds, true, S("Inner Straw Stair"))
-	stairs.register_stair_outer("straw", recipe, groups, images, "",
-		sounds, true, S("Outer Straw Stair"))
+	stairs.register_stair_type("straw", recipe, groups, images, "",
+		sounds, true, S("Inner Straw Stair"), "inner")
+	stairs.register_stair_type("straw", recipe, groups, images, "",
+		sounds, true, S("Outer Straw Stair"), "outer")
 	stairs.register_slab("straw", recipe, groups, images, S("Straw Slab"),
 		sounds, true)
 end

--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -368,12 +368,12 @@ end
 
 function stairs.register_stair_and_slab(subname, recipeitem, groups, images,
 		desc_stair, desc_slab, sounds, worldaligntex)
-	stairs.register_stair(subname, recipeitem, groups, images, desc_stair,
+	stairs.register_stair_type(subname, recipeitem, groups, images, desc_stair,
 		sounds, worldaligntex)
-	stairs.register_stair_inner(subname, recipeitem, groups, images, desc_stair,
-		sounds, worldaligntex)
-	stairs.register_stair_outer(subname, recipeitem, groups, images, desc_stair,
-		sounds, worldaligntex)
+	stairs.register_stair_type(subname, recipeitem, groups, images, desc_stair,
+		sounds, worldaligntex, "inner")
+	stairs.register_stair_type(subname, recipeitem, groups, images, desc_stair,
+		sounds, worldaligntex, "outer")
 	stairs.register_slab(subname, recipeitem, groups, images, desc_slab,
 		sounds, worldaligntex)
 end
@@ -381,12 +381,12 @@ end
 -- Local function so we can apply translations
 local function my_register_stair_and_slab(subname, recipeitem, groups, images,
 		desc_stair, desc_slab, sounds, worldaligntex)
-	stairs.register_stair(subname, recipeitem, groups, images, S(desc_stair),
+	stairs.register_stair_type(subname, recipeitem, groups, images, S(desc_stair),
 		sounds, worldaligntex)
-	stairs.register_stair_inner(subname, recipeitem, groups, images, "",
-		sounds, worldaligntex, S("Inner " .. desc_stair))
-	stairs.register_stair_outer(subname, recipeitem, groups, images, "",
-		sounds, worldaligntex, S("Outer " .. desc_stair))
+	stairs.register_stair_type(subname, recipeitem, groups, images, "",
+		sounds, worldaligntex, S("Inner " .. desc_stair), "inner")
+	stairs.register_stair_type(subname, recipeitem, groups, images, "",
+		sounds, worldaligntex, S("Outer " .. desc_stair), "outer")
 	stairs.register_slab(subname, recipeitem, groups, images, S(desc_slab),
 		sounds, worldaligntex)
 end
@@ -770,7 +770,7 @@ my_register_stair_and_slab(
 
 -- Glass stair nodes need to be registered individually to utilize specialized textures.
 
-stairs.register_stair(
+stairs.register_stair_type(
 	"glass",
 	"default:glass",
 	{cracky = 3},
@@ -792,7 +792,7 @@ stairs.register_slab(
 	false
 )
 
-stairs.register_stair_inner(
+stairs.register_stair_type(
 	"glass",
 	"default:glass",
 	{cracky = 3},
@@ -802,10 +802,11 @@ stairs.register_stair_inner(
 	"",
 	default.node_sound_glass_defaults(),
 	false,
-	S("Inner Glass Stair")
+	S("Inner Glass Stair"),
+	"inner"
 )
 
-stairs.register_stair_outer(
+stairs.register_stair_type(
 	"glass",
 	"default:glass",
 	{cracky = 3},
@@ -815,10 +816,11 @@ stairs.register_stair_outer(
 	"",
 	default.node_sound_glass_defaults(),
 	false,
-	S("Outer Glass Stair")
+	S("Outer Glass Stair"),
+	"outer"
 )
 
-stairs.register_stair(
+stairs.register_stair_type(
 	"obsidian_glass",
 	"default:obsidian_glass",
 	{cracky = 3},
@@ -840,7 +842,7 @@ stairs.register_slab(
 	false
 )
 
-stairs.register_stair_inner(
+stairs.register_stair_type(
 	"obsidian_glass",
 	"default:obsidian_glass",
 	{cracky = 3},
@@ -850,10 +852,11 @@ stairs.register_stair_inner(
 	"",
 	default.node_sound_glass_defaults(),
 	false,
-	S("Inner Obsidian Glass Stair")
+	S("Inner Obsidian Glass Stair"),
+	"inner"
 )
 
-stairs.register_stair_outer(
+stairs.register_stair_type(
 	"obsidian_glass",
 	"default:obsidian_glass",
 	{cracky = 3},
@@ -863,7 +866,8 @@ stairs.register_stair_outer(
 	"",
 	default.node_sound_glass_defaults(),
 	false,
-	S("Outer Obsidian Glass Stair")
+	S("Outer Obsidian Glass Stair"),
+	"outer"
 )
 
 -- Dummy calls to S() to allow translation scripts to detect the strings.

--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -202,6 +202,8 @@ end
 
 function stairs.register_stair(subname, recipeitem, groups, images, description,
 		sounds, worldaligntex)
+	minetest.log("warning", "stairs.register_stair() is " ..
+		"deprecated, use stairs.register_stair_type() instead.")
 	return stairs.register_stair_type(subname, recipeitem, groups, images,
 		description, sounds, worldaligntex, nil, nil)
 end
@@ -348,6 +350,8 @@ end
 
 function stairs.register_stair_inner(subname, recipeitem, groups, images,
 		description, sounds, worldaligntex, full_description)
+	minetest.log("warning", "stairs.register_stair_inner() is " ..
+		"deprecated, use stairs.register_stair_type() instead.")
 	return stairs.register_stair_type(subname, recipeitem, groups, images,
 		description, sounds, worldaligntex, full_description, "inner")
 end
@@ -358,6 +362,8 @@ end
 
 function stairs.register_stair_outer(subname, recipeitem, groups, images,
 		description, sounds, worldaligntex, full_description)
+	minetest.log("warning", "stairs.register_stair_outer() is " ..
+		"deprecated, use stairs.register_stair_type() instead.")
 	return stairs.register_stair_type(subname, recipeitem, groups, images,
 		description, sounds, worldaligntex, full_description, "outer")
 end


### PR DESCRIPTION
This is less than trivial cleanup, but should have no change in behavior and should be easy to update existing code whenever maintainers have time.

The problem is that `mods/stairs/init.lua` contains three large functions with largely duplicated code,  `stairs.register_stair()`, `stairs.register_stair_inner()` and `stairs.register_stair_outer()` for creating regular, inner and outer corner stairs respectively. This is very hard to read while spotting the relatively minor differences between functions.

This adds a new function, `stairs.register_stair_type()` which combines all three functions with a single new argument, `stairtype`. It can be set as `"inner"` for inner corner stairs, `"outer"` for outer corner stairs and `nil` for regular stairs.

I also updated the existing uses in `mods/stairs/init.lua`, `mods/farming/nodes.lua`, updated the docs and added deprecation warnings for the old functions.

Please let me know if there is anything I missed.