### PR TITLE
chests: Do not hardcode "default:".

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -136,12 +136,12 @@ The chests API allows the creation of chests, which have their own inventories f
  * A table indexed by player name to keep track of who opened what chest.
  * Key: The name of the player.
  * Value: A table containing information about the chest the player is looking at.
-   e.g `{ pos = {1, 1, 1}, sound = null, swap = "chest" }`
+   e.g `{ pos = {1, 1, 1}, sound = null, swap = "default:chest" }`
 
 `default.chest.register_chest(name, def)`
 
  * Registers new chest
- * `name` Name for chest
+ * `name` Name for chest e.g "default:chest"
  * `def`  See [#Chest Definition]
 
 ### Chest Definition

--- a/mods/default/chests.lua
+++ b/mods/default/chests.lua
@@ -44,7 +44,7 @@ function default.chest.chest_lid_close(pn)
 	end
 
 	local node = minetest.get_node(pos)
-	minetest.after(0.2, minetest.swap_node, pos, { name = "default:" .. swap,
+	minetest.after(0.2, minetest.swap_node, pos, { name = swap,
 			param2 = node.param2 })
 	minetest.sound_play(sound, {gain = 0.3, pos = pos,
 		max_hear_distance = 10}, true)
@@ -132,7 +132,7 @@ function default.chest.register_chest(name, d)
 					pos = pos, max_hear_distance = 10}, true)
 			if not default.chest.chest_lid_obstructed(pos) then
 				minetest.swap_node(pos,
-						{ name = "default:" .. name .. "_open",
+						{ name = name .. "_open",
 						param2 = node.param2 })
 			end
 			minetest.after(0.2, minetest.show_formspec,
@@ -203,7 +203,7 @@ function default.chest.register_chest(name, d)
 					max_hear_distance = 10}, true)
 			if not default.chest.chest_lid_obstructed(pos) then
 				minetest.swap_node(pos, {
-						name = "default:" .. name .. "_open",
+						name = name .. "_open",
 						param2 = node.param2 })
 			end
 			minetest.after(0.2, minetest.show_formspec,
@@ -215,7 +215,7 @@ function default.chest.register_chest(name, d)
 		def.on_blast = function(pos)
 			local drops = {}
 			default.get_inventory_drops(pos, "main", drops)
-			drops[#drops+1] = "default:" .. name
+			drops[#drops+1] = name
 			minetest.remove_node(pos)
 			return drops
 		end
@@ -248,7 +248,7 @@ function default.chest.register_chest(name, d)
 			def_opened.tiles[i].backface_culling = true
 		end
 	end
-	def_opened.drop = "default:" .. name
+	def_opened.drop = name
 	def_opened.groups.not_in_creative_inventory = 1
 	def_opened.selection_box = {
 		type = "fixed",
@@ -265,29 +265,32 @@ function default.chest.register_chest(name, d)
 	def_closed.tiles[5] = def.tiles[3] -- drawtype to make them match the mesh
 	def_closed.tiles[3] = def.tiles[3].."^[transformFX"
 
-	minetest.register_node("default:" .. name, def_closed)
-	minetest.register_node("default:" .. name .. "_open", def_opened)
+	minetest.register_node(name, def_closed)
+	minetest.register_node(name .. "_open", def_opened)
 
 	-- convert old chests to this new variant
-	minetest.register_lbm({
-		label = "update chests to opening chests",
-		name = "default:upgrade_" .. name .. "_v2",
-		nodenames = {"default:" .. name},
-		action = function(pos, node)
-			local meta = minetest.get_meta(pos)
-			meta:set_string("formspec", nil)
-			local inv = meta:get_inventory()
-			local list = inv:get_list("default:chest")
-			if list then
-				inv:set_size("main", 8*4)
-				inv:set_list("main", list)
-				inv:set_list("default:chest", nil)
+	if name == "default:chest" or name == "default:chest_locked" then
+		local itemname = string.match(name, ":(.*)")
+		minetest.register_lbm({
+			label = "update chests to opening chests",
+			name = "default:upgrade_" .. itemname .. "_v2",
+			nodenames = {name},
+			action = function(pos, node)
+				local meta = minetest.get_meta(pos)
+				meta:set_string("formspec", nil)
+				local inv = meta:get_inventory()
+				local list = inv:get_list("default:chest")
+				if list then
+					inv:set_size("main", 8*4)
+					inv:set_list("main", list)
+					inv:set_list("default:chest", nil)
+				end
 			end
-		end
-	})
+		})
+	end
 end
 
-default.chest.register_chest("chest", {
+default.chest.register_chest("default:chest", {
 	description = S("Chest"),
 	tiles = {
 		"default_chest_top.png",
@@ -303,7 +306,7 @@ default.chest.register_chest("chest", {
 	groups = {choppy = 2, oddly_breakable_by_hand = 2},
 })
 
-default.chest.register_chest("chest_locked", {
+default.chest.register_chest("default:chest_locked", {
 	description = S("Locked Chest"),
 	tiles = {
 		"default_chest_top.png",


### PR DESCRIPTION
Fixes #1936.

This allows mods other than `default` to use `default.chest.register_chest()` to create their own chests.

The problem is that the function hard-codes `default:chest` ~~and `default:chest_locked`~~ leaving other mods unable to create new chests (e.g. `foo:new_chest`) while using the same function as opposed to reinventing the wheel and creating their own.

This changes the `default.chest.register_chest()` to require the mod name in addition to the item name (e.g. `default:chests` instead of `chests`), ~~but if this is not provided it will print a warning message and default to using `default:`.~~

~~This also requires locked chests to provide the `unlocked` definition and unlocked chests to provide the `locked` definition which contains the full name of the corresponding unlocked and locked chests. The `unlocked` definition is not need for unlocked chests and the `locked` definition is not needed for `locked` chests which is determined by if the `protected` definition is set as `true`. By default if these are not provided when needed it will default to `mod:name_locked` for locked chests and `mod:name` for unlocked chests. The caveat being that it depends on the locked chest name being appended with `_locked` when these definitions are missing.~~

Also here is a `testschests` mod that serves as a working test case.

__mod.conf__
```
name = testchests
description = Minetest Game mod: testchests
depends = default
```
__init.lua__
```
default.chest.register_chest("testchests:new_chest", {
	description = "Test Chest",
	tiles = {
		"default_chest_top.png",
		"default_chest_top.png",
		"default_chest_side.png",
		"default_chest_side.png",
		"default_chest_front.png",
		"default_chest_inside.png"
	},
	sounds = default.node_sound_wood_defaults(),
	sound_open = "default_chest_open",
	sound_close = "default_chest_close",
	groups = {choppy = 2, oddly_breakable_by_hand = 2},
})

default.chest.register_chest("testchests:new_chest_protected", {
	description = "Test Locked Chest",
	tiles = {
		"default_chest_top.png",
		"default_chest_top.png",
		"default_chest_side.png",
		"default_chest_side.png",
		"default_chest_lock.png",
		"default_chest_inside.png"
	},
	sounds = default.node_sound_wood_defaults(),
	sound_open = "default_chest_open",
	sound_close = "default_chest_close",
	groups = {choppy = 2, oddly_breakable_by_hand = 2},
	protected = true,
})

minetest.register_craft({
	output = "testchests:new_chest",
	recipe = {
		{"", "group:wood", "group:wood"},
		{"group:wood", "", "group:wood"},
		{"group:wood", "group:wood", "group:wood"},
	}
})

minetest.register_craft({
	output = "testchests:new_chest_protected",
	recipe = {
		{"", "group:wood", "group:wood"},
		{"group:wood", "default:steel_ingot", "group:wood"},
		{"group:wood", "group:wood", "group:wood"},
	}
})

minetest.register_craft( {
	type = "shapeless",
	output = "testchests:new_chest_protected",
	recipe = {"testchests:new_chest", "default:steel_ingot", "default:steel_ingot"},
})
```