### PR TITLE
furnace: Add default.get_furnace_formspec() to reduce code duplication.

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -863,15 +863,20 @@ GUI and formspecs
 
  * Entire formspec for the survival inventory
 
+`default.get_furnace_formspec(fuel_percent, item_percent)`
+
+ * Get the furnace formspec using the defined GUI elements
+ * fuel_percent: Percent of how much the fuel is used
+    * Note: Defines the inactive furnace formspec when nil.
+ * item_percent: Percent of how much the item is cooked
+
 `default.get_furnace_active_formspec(fuel_percent, item_percent)`
 
- * Get the active furnace formspec using the defined GUI elements
- * fuel_percent: Percent of how much the fuel is used
- * item_percent: Percent of how much the item is cooked
+ * Deprecated, remove from mods.
 
 `default.get_furnace_inactive_formspec()`
 
- * Get the inactive furnace formspec using the defined GUI elements
+ * Deprecated, remove from mods.
 
 
 Leafdecay

--- a/mods/default/furnace.lua
+++ b/mods/default/furnace.lua
@@ -7,14 +7,22 @@ local S = default.get_translator
 -- Formspecs
 --
 
-function default.get_furnace_active_formspec(fuel_percent, item_percent)
+function default.get_furnace_formspec(fuel_percent, item_percent)
+	local furnace_image
+	-- active furnace
+	if fuel_percent then
+		furnace_image = "image[2.75,1.5;1,1;default_furnace_fire_bg.png^[lowpart:"..
+			(fuel_percent)..":default_furnace_fire_fg.png]"..
+			"image[3.75,1.5;1,1;gui_furnace_arrow_bg.png^[lowpart:"..
+			(item_percent)..":gui_furnace_arrow_fg.png^[transformR270]"
+	else
+		furnace_image = "image[2.75,1.5;1,1;default_furnace_fire_bg.png]"..
+			"image[3.75,1.5;1,1;gui_furnace_arrow_bg.png^[transformR270]"
+	end
 	return "size[8,8.5]"..
 		"list[context;src;2.75,0.5;1,1;]"..
 		"list[context;fuel;2.75,2.5;1,1;]"..
-		"image[2.75,1.5;1,1;default_furnace_fire_bg.png^[lowpart:"..
-		(fuel_percent)..":default_furnace_fire_fg.png]"..
-		"image[3.75,1.5;1,1;gui_furnace_arrow_bg.png^[lowpart:"..
-		(item_percent)..":gui_furnace_arrow_fg.png^[transformR270]"..
+		furnace_image..
 		"list[context;dst;4.75,0.96;2,2;]"..
 		"list[current_player;main;0,4.25;8,1;]"..
 		"list[current_player;main;0,5.5;8,3;8]"..
@@ -27,22 +35,12 @@ function default.get_furnace_active_formspec(fuel_percent, item_percent)
 		default.get_hotbar_bg(0, 4.25)
 end
 
+function default.get_furnace_active_formspec(fuel_percent, item_percent)
+	return default.get_furnace_formspec(fuel_percent, item_percent)
+end
+
 function default.get_furnace_inactive_formspec()
-	return "size[8,8.5]"..
-		"list[context;src;2.75,0.5;1,1;]"..
-		"list[context;fuel;2.75,2.5;1,1;]"..
-		"image[2.75,1.5;1,1;default_furnace_fire_bg.png]"..
-		"image[3.75,1.5;1,1;gui_furnace_arrow_bg.png^[transformR270]"..
-		"list[context;dst;4.75,0.96;2,2;]"..
-		"list[current_player;main;0,4.25;8,1;]"..
-		"list[current_player;main;0,5.5;8,3;8]"..
-		"listring[context;dst]"..
-		"listring[current_player;main]"..
-		"listring[context;src]"..
-		"listring[current_player;main]"..
-		"listring[context;fuel]"..
-		"listring[current_player;main]"..
-		default.get_hotbar_bg(0, 4.25)
+	return default.get_furnace_formspec()
 end
 
 --

--- a/mods/default/furnace.lua
+++ b/mods/default/furnace.lua
@@ -36,10 +36,14 @@ function default.get_furnace_formspec(fuel_percent, item_percent)
 end
 
 function default.get_furnace_active_formspec(fuel_percent, item_percent)
+	minetest.log("warning", "default.get_furnace_active_formspec() is " ..
+		"deprecated, use default.get_furnace_formspec() instead.")
 	return default.get_furnace_formspec(fuel_percent, item_percent)
 end
 
 function default.get_furnace_inactive_formspec()
+	minetest.log("warning", "default.get_furnace_inactive_formspec() is " ..
+		"deprecated, use default.get_furnace_formspec() instead.")
 	return default.get_furnace_formspec()
 end
 

--- a/mods/default/furnace.lua
+++ b/mods/default/furnace.lua
@@ -231,7 +231,7 @@ local function furnace_node_timer(pos, elapsed)
 		active = true
 		local fuel_percent = 100 - math.floor(fuel_time / fuel_totaltime * 100)
 		fuel_state = S("@1%", fuel_percent)
-		formspec = default.get_furnace_active_formspec(fuel_percent, item_percent)
+		formspec = default.get_furnace_formspec(fuel_percent, item_percent)
 		swap_node(pos, "default:furnace_active")
 		-- make sure timer restarts automatically
 		result = true
@@ -239,7 +239,7 @@ local function furnace_node_timer(pos, elapsed)
 		if fuellist and not fuellist[1]:is_empty() then
 			fuel_state = S("@1%", 0)
 		end
-		formspec = default.get_furnace_inactive_formspec()
+		formspec = default.get_furnace_formspec()
 		swap_node(pos, "default:furnace")
 		-- stop timer on the inactive furnace
 		minetest.get_node_timer(pos):stop()


### PR DESCRIPTION
This adds `default.get_furnace_formspec()` and deprecates `default.get_furnace_active_formspec()` and `default.get_furnace_inactive_formspec()`.

The latter two functions are nearly duplicate and I think its easier to use and read when there is only one. By default if the first argument, `fuel_percent` is `nil` it will return an inactive furnace formspec and an active furnace formspec otherwise.

The main caveat is that the deprecation warnings are rather loud and spams the console, maybe it will encourage maintainers to update any mods that use this sooner rather than later.