### PR TITLE
Allow to place rotated tree logs.

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -677,12 +677,10 @@ minetest.register_node("default:cave_ice", {
 minetest.register_node("default:tree", {
 	description = S("Apple Tree"),
 	tiles = {"default_tree_top.png", "default_tree_top.png", "default_tree.png"},
-	paramtype2 = "facedir",
+	paramtype2 = "wallmounted",
 	is_ground_content = false,
 	groups = {tree = 1, choppy = 2, oddly_breakable_by_hand = 1, flammable = 2},
 	sounds = default.node_sound_wood_defaults(),
-
-	on_place = minetest.rotate_node
 })
 
 minetest.register_node("default:wood", {
@@ -817,12 +815,10 @@ minetest.register_node("default:jungletree", {
 	description = S("Jungle Tree"),
 	tiles = {"default_jungletree_top.png", "default_jungletree_top.png",
 		"default_jungletree.png"},
-	paramtype2 = "facedir",
+	paramtype2 = "wallmounted",
 	is_ground_content = false,
 	groups = {tree = 1, choppy = 2, oddly_breakable_by_hand = 1, flammable = 2},
 	sounds = default.node_sound_wood_defaults(),
-
-	on_place = minetest.rotate_node
 })
 
 minetest.register_node("default:junglewood", {
@@ -932,12 +928,10 @@ minetest.register_node("default:pine_tree", {
 	description = S("Pine Tree"),
 	tiles = {"default_pine_tree_top.png", "default_pine_tree_top.png",
 		"default_pine_tree.png"},
-	paramtype2 = "facedir",
+	paramtype2 = "wallmounted",
 	is_ground_content = false,
 	groups = {tree = 1, choppy = 3, oddly_breakable_by_hand = 1, flammable = 3},
 	sounds = default.node_sound_wood_defaults(),
-
-	on_place = minetest.rotate_node
 })
 
 minetest.register_node("default:pine_wood", {
@@ -1011,12 +1005,10 @@ minetest.register_node("default:acacia_tree", {
 	description = S("Acacia Tree"),
 	tiles = {"default_acacia_tree_top.png", "default_acacia_tree_top.png",
 		"default_acacia_tree.png"},
-	paramtype2 = "facedir",
+	paramtype2 = "wallmounted",
 	is_ground_content = false,
 	groups = {tree = 1, choppy = 2, oddly_breakable_by_hand = 1, flammable = 2},
 	sounds = default.node_sound_wood_defaults(),
-
-	on_place = minetest.rotate_node
 })
 
 minetest.register_node("default:acacia_wood", {
@@ -1090,12 +1082,10 @@ minetest.register_node("default:aspen_tree", {
 	description = S("Aspen Tree"),
 	tiles = {"default_aspen_tree_top.png", "default_aspen_tree_top.png",
 		"default_aspen_tree.png"},
-	paramtype2 = "facedir",
+	paramtype2 = "wallmounted",
 	is_ground_content = false,
 	groups = {tree = 1, choppy = 3, oddly_breakable_by_hand = 1, flammable = 3},
 	sounds = default.node_sound_wood_defaults(),
-
-	on_place = minetest.rotate_node
 })
 
 minetest.register_node("default:aspen_wood", {


### PR DESCRIPTION
I really like to build houses by using wood and tree logs.
Unfortunately I always missing the rotation feature for tree logs.
I have added it and now I could build a house with tree logs.

I could even now create fallen trees. I checked that, and this changes do not introduce regression (you can still place logs both horizontally and vertically.

![tree-logs-house](https://user-images.githubusercontent.com/8199062/79011287-00e25380-7b64-11ea-90dd-2e0191313d44.png)

