### PR TITLE
Make default:snow collisionbox half of nodebox height

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -621,7 +621,7 @@ minetest.register_node("default:snow", {
 	collision_box = {
 		type = "fixed",
 		fixed = {
-			{-0.5, -0.5, -0.5, 0.5, -7 / 16, 0.5},
+			{-0.5, -0.5, -0.5, 0.5, -6 / 16, 0.5},
 		},
 	},
 	groups = {crumbly = 3, falling_node = 1, snowy = 1},


### PR DESCRIPTION
![screenshot_20200412_191523](https://user-images.githubusercontent.com/3686677/79076918-59952600-7cf5-11ea-87e3-77171c519883.png)

^ PR

Modification of #2133
Previously, players (and all objects) sank into default:snow by 3/4 the nodebox thickness.
But i noticed that the collisionbox was so thin that when walking onto and off default:snow there was almost no noticeable vertical motion, making it feel like the snow was not there at all. This has always felt wrong.

This PR makes objects sink into default:snow by 1/2 the nodebox thickness.
There is now significant and very noticeable vertical motion when walking onto and off default:snow.

Note that players still do not contact low-hanging pine needle nodes above them, so this does not cause any obstruction when walking through the taiga biome.