### PR TITLE
WIP: boats: rotate boat driver, during boat rotation

### DIFF
--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -159,14 +159,18 @@ function boat.on_step(self, dtime)
 			if ctrl.left then
 				if self.v < -0.001 then
 					self.object:set_yaw(self.object:get_yaw() - dtime * 0.9)
+					driver_objref:set_look_horizontal(driver_objref:get_look_horizontal() - dtime * 0.9)
 				else
 					self.object:set_yaw(self.object:get_yaw() + dtime * 0.9)
+					driver_objref:set_look_horizontal(driver_objref:get_look_horizontal() + dtime * 0.9)
 				end
 			elseif ctrl.right then
 				if self.v < -0.001 then
 					self.object:set_yaw(self.object:get_yaw() + dtime * 0.9)
+					driver_objref:set_look_horizontal(driver_objref:get_look_horizontal() + dtime * 0.9)
 				else
 					self.object:set_yaw(self.object:get_yaw() - dtime * 0.9)
+					driver_objref:set_look_horizontal(driver_objref:get_look_horizontal() - dtime * 0.9)
 				end
 			end
 		end


### PR DESCRIPTION
Currently during boat rotation, the boat driver view do not change.
With this simple patch the rotation is made also for driver.

This way is more natural for vehicles (cars, carts, boats, airplanes etc.)