### PR TITLE
Cart inventory image was rendering the side twice

### DIFF
--- a/mods/carts/cart_entity.lua
+++ b/mods/carts/cart_entity.lua
@@ -389,7 +389,7 @@ minetest.register_entity("carts:cart", cart_entity)
 
 minetest.register_craftitem("carts:cart", {
 	description = S("Cart") .. "\n" .. S("(Sneak+Click to pick up)"),
-	inventory_image = minetest.inventorycube("carts_cart_top.png", "carts_cart_side.png", "carts_cart_side.png"),
+	inventory_image = minetest.inventorycube("carts_cart_top.png", "carts_cart_front.png", "carts_cart_side.png"),
 	wield_image = "carts_cart_side.png",
 	on_place = function(itemstack, placer, pointed_thing)
 		local under = pointed_thing.under


### PR DESCRIPTION
Before the cart in the inventory was showing the side picture (`carts_cart_side.png`) on both the lateral faces. Now one of them shows `carts_cart_front.png`