### PR TITLE
TNT centre node adheres to protection

### DIFF
--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -402,7 +402,7 @@ function tnt.boom(pos, def)
 	def.damage_radius = def.damage_radius or def.radius * 2
 	local meta = minetest.get_meta(pos)
 	local owner = meta:get_string("owner")
-	if not def.explode_center then
+	if not def.explode_center and def.ignore_protection ~= true then
 		minetest.set_node(pos, {name = "tnt:boom"})
 	end
 	local sound = def.sound or "tnt_explode"


### PR DESCRIPTION
Make sure tnt.boom() doesnt replace centre node when ignore_protection is false.

Fixes: https://github.com/minetest/minetest_game/issues/2663