### PR TITLE
Make dry grass spread on default:dirt again

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -501,7 +501,7 @@ end
 
 
 --
--- Convert dirt to something that fits the environment
+-- Convert default:dirt to something that fits the environment
 --
 
 minetest.register_abm({
@@ -510,6 +510,7 @@ minetest.register_abm({
 	neighbors = {
 		"air",
 		"group:grass",
+		"group:dry_grass",
 		"default:snow",
 	},
 	interval = 6,
@@ -538,6 +539,8 @@ minetest.register_abm({
 			minetest.set_node(pos, {name = "default:dirt_with_snow"})
 		elseif minetest.get_item_group(name, "grass") ~= 0 then
 			minetest.set_node(pos, {name = "default:dirt_with_grass"})
+		elseif minetest.get_item_group(name, "dry_grass") ~= 0 then
+			minetest.set_node(pos, {name = "default:dirt_with_dry_grass"})
 		end
 	end
 })

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -463,7 +463,7 @@ minetest.register_node("default:dirt_with_dry_grass", {
 		"default_dirt.png",
 		{name = "default_dirt.png^default_dry_grass_side.png",
 			tileable_vertical = false}},
-	groups = {crumbly = 3, soil = 1},
+	groups = {crumbly = 3, soil = 1, spreading_dirt_type = 1},
 	drop = "default:dirt",
 	sounds = default.node_sound_dirt_defaults({
 		footstep = {name = "default_grass_footstep", gain = 0.4},


### PR DESCRIPTION
Possibly attends to #2684 

Commit https://github.com/minetest/minetest_game/commit/c32b8adaa36353f9b21d896e93cce732e26cf0a0# possibly went too far in removing dry grass spreading behaviour in old savanna areas. This PR intends to restore dry grass spreading behaviour in the old savanna areas that use default:dirt and default:dirt_with_dry_grass.

Intentions:
* A default:dry_grass plant placed on default:dirt should eventually turn the default:dirt into default:dirt_with_dry_grass.
* default:dirt_with_dry_grass placed next to default:dirt should eventually turn the default:dirt into default:dirt_with_dry_grass.

Not yet tested. @Montandalar please test this. I will test when i have time.