### PR TITLE
sethome: Do not write empty homes file

### DIFF
--- a/mods/sethome/init.lua
+++ b/mods/sethome/init.lua
@@ -32,6 +32,9 @@ sethome.set = function(name, pos)
 	player:set_attribute("sethome:home", minetest.pos_to_string(pos))
 
 	-- remove `name` from the old storage file
+	if not homepos[name] then
+		return true
+	end
 	local data = {}
 	local output = io.open(homes_file, "w")
 	if output then


### PR DESCRIPTION
The migration code added in 1c78fd346db7cd5bab4569d07ee2cb74e8e88047 removes a player home from the legacy file when a new one is set.
This also meant that the file was created when you never had any legacy homes at all, this PR stops it from doing that.