### PR TITLE
Fix sunlight_propagates for glass stairs and slabs

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -719,7 +719,7 @@ Stairs API
 The stairs API lets you register stairs and slabs and ensures that they are registered the same way as those
 delivered with Minetest Game, to keep them compatible with other mods.
 
-`stairs.register_stair(subname, recipeitem, groups, images, description, sounds, worldaligntex)`
+`stairs.register_stair(subname, recipeitem, groups, images, description, sounds, worldaligntex, sunlight_propagates)`
 
  * Registers a stair
  * `subname`: Basically the material name (e.g. cobble) used for the stair name. Nodename pattern: "stairs:stair_subname"
@@ -729,8 +729,9 @@ delivered with Minetest Game, to keep them compatible with other mods.
  * `description`: Used for the description field in the stair's definition
  * `sounds`: See [#Default sounds]
  * `worldaligntex`: A bool to set all textures world-aligned. Default false. See [Tile definition]
+ * `sunlight_propagates`: A bool to set the sunlight_propagates field in the stair's definition. Default false.
 
-`stairs.register_slab(subname, recipeitem, groups, images, description, sounds, worldaligntex)`
+`stairs.register_slab(subname, recipeitem, groups, images, description, sounds, worldaligntex, sunlight_propagates)`
 
  * Registers a slab
  * `subname`: Basically the material name (e.g. cobble) used for the slab name. Nodename pattern: "stairs:slab_subname"
@@ -740,8 +741,9 @@ delivered with Minetest Game, to keep them compatible with other mods.
  * `description`: Used for the description field in the slab's definition
  * `sounds`: See [#Default sounds]
  * `worldaligntex`: A bool to set all textures world-aligned. Default false. See [Tile definition]
+ * `sunlight_propagates`: A bool to set the sunlight_propagates field in the slab's definition. Default false.
 
-`stairs.register_stair_inner(subname, recipeitem, groups, images, description, sounds, worldaligntex, full_description)`
+`stairs.register_stair_inner(subname, recipeitem, groups, images, description, sounds, worldaligntex, full_description, sunlight_propagates)`
 
  * Registers an inner corner stair
  * `subname`: Basically the material name (e.g. cobble) used for the stair name. Nodename pattern: "stairs:stair_inner_subname"
@@ -752,8 +754,9 @@ delivered with Minetest Game, to keep them compatible with other mods.
  * `sounds`: See [#Default sounds]
  * `worldaligntex`: A bool to set all textures world-aligned. Default false. See [Tile definition]
  * `full_description`: Overrides the description, bypassing string concatenation. This is useful for translation. (optional)
+ * `sunlight_propagates`: A bool to set the sunlight_propagates field in the stair's definition. Default false.
 
-`stairs.register_stair_outer(subname, recipeitem, groups, images, description, sounds, worldaligntex, full_description)`
+`stairs.register_stair_outer(subname, recipeitem, groups, images, description, sounds, worldaligntex, full_description, sunlight_propagates)`
 
  * Registers an outer corner stair
  * `subname`: Basically the material name (e.g. cobble) used for the stair name. Nodename pattern: "stairs:stair_outer_subname"
@@ -764,6 +767,7 @@ delivered with Minetest Game, to keep them compatible with other mods.
  * `sounds`: See [#Default sounds]
  * `worldaligntex`: A bool to set all textures world-aligned. Default false. See [Tile definition]
  * `full_description`: Overrides the description, bypassing string concatenation. This is useful for translation. (optional)
+ * `sunlight_propagates`: A bool to set the sunlight_propagates field in the stair's definition. Default false.
 
 ```
 stairs.register_stair_and_slab(subname, recipeitem, groups, images, desc_stair, desc_slab,

--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -62,7 +62,7 @@ end
 -- Node will be called stairs:stair_<subname>
 
 function stairs.register_stair(subname, recipeitem, groups, images, description,
-		sounds, worldaligntex)
+		sounds, worldaligntex, sunlight_propagates)
 	local src_def = minetest.registered_nodes[recipeitem]
 
 	-- Set backface culling and world-aligned textures
@@ -96,6 +96,7 @@ function stairs.register_stair(subname, recipeitem, groups, images, description,
 		use_texture_alpha = src_def and src_def.use_texture_alpha,
 		paramtype = "light",
 		paramtype2 = "facedir",
+		sunlight_propagates = sunlight_propagates,
 		is_ground_content = false,
 		groups = new_groups,
 		sounds = sounds,
@@ -164,7 +165,7 @@ end
 -- Node will be called stairs:slab_<subname>
 
 function stairs.register_slab(subname, recipeitem, groups, images, description,
-		sounds, worldaligntex)
+		sounds, worldaligntex, sunlight_propagates)
 	local src_def = minetest.registered_nodes[recipeitem]
 
 	-- Set world-aligned textures
@@ -194,6 +195,7 @@ function stairs.register_slab(subname, recipeitem, groups, images, description,
 		use_texture_alpha = src_def and src_def.use_texture_alpha,
 		paramtype = "light",
 		paramtype2 = "facedir",
+		sunlight_propagates = sunlight_propagates,
 		is_ground_content = false,
 		groups = new_groups,
 		sounds = sounds,
@@ -302,7 +304,7 @@ end
 -- Node will be called stairs:stair_inner_<subname>
 
 function stairs.register_stair_inner(subname, recipeitem, groups, images,
-		description, sounds, worldaligntex, full_description)
+		description, sounds, worldaligntex, full_description, sunlight_propagates)
 	local src_def = minetest.registered_nodes[recipeitem]
 
 	-- Set backface culling and world-aligned textures
@@ -341,6 +343,7 @@ function stairs.register_stair_inner(subname, recipeitem, groups, images,
 		use_texture_alpha = src_def and src_def.use_texture_alpha,
 		paramtype = "light",
 		paramtype2 = "facedir",
+		sunlight_propagates = sunlight_propagates,
 		is_ground_content = false,
 		groups = new_groups,
 		sounds = sounds,
@@ -392,7 +395,7 @@ end
 -- Node will be called stairs:stair_outer_<subname>
 
 function stairs.register_stair_outer(subname, recipeitem, groups, images,
-		description, sounds, worldaligntex, full_description)
+		description, sounds, worldaligntex, full_description, sunlight_propagates)
 	local src_def = minetest.registered_nodes[recipeitem]
 
 	-- Set backface culling and world-aligned textures
@@ -431,6 +434,7 @@ function stairs.register_stair_outer(subname, recipeitem, groups, images,
 		use_texture_alpha = src_def and src_def.use_texture_alpha,
 		paramtype = "light",
 		paramtype2 = "facedir",
+		sunlight_propagates = sunlight_propagates,
 		is_ground_content = false,
 		groups = new_groups,
 		sounds = sounds,
@@ -893,7 +897,8 @@ stairs.register_stair(
 	"default_glass.png", "stairs_glass_split.png"},
 	S("Glass Stair"),
 	default.node_sound_glass_defaults(),
-	false
+	false,
+	true
 )
 
 stairs.register_slab(
@@ -903,7 +908,8 @@ stairs.register_slab(
 	{"default_glass.png", "default_glass.png", "stairs_glass_split.png"},
 	S("Glass Slab"),
 	default.node_sound_glass_defaults(),
-	false
+	false,
+	true
 )
 
 stairs.register_stair_inner(
@@ -916,7 +922,8 @@ stairs.register_stair_inner(
 	"",
 	default.node_sound_glass_defaults(),
 	false,
-	S("Inner Glass Stair")
+	S("Inner Glass Stair"),
+	true
 )
 
 stairs.register_stair_outer(
@@ -929,7 +936,8 @@ stairs.register_stair_outer(
 	"",
 	default.node_sound_glass_defaults(),
 	false,
-	S("Outer Glass Stair")
+	S("Outer Glass Stair"),
+	true
 )
 
 stairs.register_stair(
@@ -941,7 +949,8 @@ stairs.register_stair(
 	"default_obsidian_glass.png", "stairs_obsidian_glass_split.png"},
 	S("Obsidian Glass Stair"),
 	default.node_sound_glass_defaults(),
-	false
+	false,
+	true
 )
 
 stairs.register_slab(
@@ -951,7 +960,8 @@ stairs.register_slab(
 	{"default_obsidian_glass.png", "default_obsidian_glass.png", "stairs_obsidian_glass_split.png"},
 	S("Obsidian Glass Slab"),
 	default.node_sound_glass_defaults(),
-	false
+	false,
+	true
 )
 
 stairs.register_stair_inner(
@@ -964,7 +974,8 @@ stairs.register_stair_inner(
 	"",
 	default.node_sound_glass_defaults(),
 	false,
-	S("Inner Obsidian Glass Stair")
+	S("Inner Obsidian Glass Stair"),
+	true
 )
 
 stairs.register_stair_outer(
@@ -977,7 +988,8 @@ stairs.register_stair_outer(
 	"",
 	default.node_sound_glass_defaults(),
 	false,
-	S("Outer Obsidian Glass Stair")
+	S("Outer Obsidian Glass Stair"),
+	true
 )
 
 -- Dummy calls to S() to allow translation scripts to detect the strings.


### PR DESCRIPTION
Sunlight doesn't propagate through glass and obsidian glass stairs and slabs as expected. This pull request fixes the bug by adding a new parameter (sunlight_propagates) to the stairs and slab registration functions.