### PR TITLE
Update nodes papyrus can grow on, include default:dry_dirt

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -210,7 +210,12 @@ end
 function default.grow_papyrus(pos, node)
 	pos.y = pos.y - 1
 	local name = minetest.get_node(pos).name
-	if name ~= "default:dirt_with_grass" and name ~= "default:dirt" then
+	if name ~= "default:dirt" and
+			name ~= "default:dirt_with_grass" and
+			name ~= "default:dirt_with_dry_grass" and
+			name ~= "default:dirt_with_rainforest_litter" and
+			name ~= "default:dry_dirt" and
+			name ~= "default:dry_dirt_with_dry_grass" then
 		return
 	end
 	if not minetest.find_node_near(pos, 3, {"group:water"}) then
@@ -247,7 +252,17 @@ minetest.register_abm({
 minetest.register_abm({
 	label = "Grow papyrus",
 	nodenames = {"default:papyrus"},
-	neighbors = {"default:dirt", "default:dirt_with_grass"},
+	-- Grows on the dirt and surface dirt nodes of the biomes papyrus appears in,
+	-- including the old savanna nodes.
+	-- 'default:dirt_with_grass' is here only because it was allowed before.
+	neighbors = {
+		"default:dirt",
+		"default:dirt_with_grass",
+		"default:dirt_with_dry_grass",
+		"default:dirt_with_rainforest_litter",
+		"default:dry_dirt",
+		"default:dry_dirt_with_dry_grass",
+	},
 	interval = 14,
 	chance = 71,
 	action = function(...)


### PR DESCRIPTION
![screenshot_20200616_194403](https://user-images.githubusercontent.com/3686677/84814766-db614280-b009-11ea-9a2b-718cad5734e5.png)

^ Tested to not grow on 'dirt with coniferous litter' or 'dirt with snow'

Fixes #2703 

Papyrus should grow on the dirt and surface dirt nodes of the biomes papyrus appears in (savanna and rainforest), including the old savanna nodes.
"default:dirt_with_grass" is only allowed because it was allowed before.