### PR TITLE
Fix default mod nil check

### DIFF
--- a/mods/default/init.lua
+++ b/mods/default/init.lua
@@ -20,7 +20,7 @@ minetest.register_on_joinplayer(function(player)
 			listcolors[#00000069;#5A5A5A;#141318;#30434C;#FFF] ]]
 	local name = player:get_player_name()
 	local info = minetest.get_player_information(name)
-	if info.formspec_version > 1 then
+	if info and info.formspec_version > 1 then
 		formspec = formspec .. "background9[5,5;1,1;gui_formbg.png;true;10]"
 	else
 		formspec = formspec .. "background[5,5;1,1;gui_formbg.png;true]"


### PR DESCRIPTION
This fixes the error that occurs when info is not returned on occasion, so info.formspec_version is not available and crashes servers.
```
[Server]: static int ModApiserver::l_get_player_information(lua_state*): peer was not found
Action[Main]: Server: Shutting down
ERROR[Main]: ServerError: AsyncErr: ServerThread::run Lua: Runtime error from mod 'default' in callback on_joinplayer(): ...share/minetest/games/minetest_game/mods/default/init.lua:23:attempt to index local 'info' (a nil value)