### PR TITLE
screwdriver: Allow protection bypass

### DIFF
--- a/mods/screwdriver/init.lua
+++ b/mods/screwdriver/init.lua
@@ -93,7 +93,8 @@ screwdriver.handler = function(itemstack, user, pointed_thing, mode, uses)
 	local pos = pointed_thing.under
 	local player_name = user and user:get_player_name() or ""
 
-	if minetest.is_protected(pos, player_name) then
+	if minetest.is_protected(pos, player_name) and
+			not minetest.check_player_privs(player_name, { protection_bypass = true }) then
 		minetest.record_protection_violation(pos, player_name)
 		return
 	end


### PR DESCRIPTION
Allow players with the `protection_bypass` privilege to rotate protected nodes