### PR TITLE
Update can_interact_with_node function

### DIFF
--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -677,7 +677,7 @@ function default.can_interact_with_node(player, pos)
 	end
 
 	-- Interaction with owned node
-	if prot = "" and (owner == "" or owner == player_name) then
+	if prot == "" and (owner == "" or owner == player_name) then
 		return true
 	end
 

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -666,10 +666,18 @@ function default.can_interact_with_node(player, pos)
 		return false
 	end
 
+	local player_name = player:get_player_name()
 	local meta = minetest.get_meta(pos)
-	local owner = meta:get_string("owner")
+	local owner = meta:get_string("owner") or ""
+	local prot = meta:get_string("protector") or ""
 
-	if not owner or owner == "" or owner == player:get_player_name() then
+	-- Interaction with protected node
+	if prot ~= "" and owner == "" and not minetest.is_protected(pos, player_name) then
+		return true
+	end
+
+	-- Interaction with owned node
+	if prot = "" and (owner == "" or owner == player_name) then
 		return true
 	end
 


### PR DESCRIPTION
This change has the can_interact_with_node function check for both owner and protector, this way nodes like doors and chests could be protected and opened by many defined players within the protection mod instead of using keys (which still work too :)