### PR TITLE
Player_api: Various maintenance

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -426,54 +426,56 @@ Give Initial Stuff API
 ^ Adds items to the list of items to be given
 
 
-Players API
------------
+Player API
+----------
 
 The player API can register player models and update the player's appearance.
 
 * `player_api.register_model(name, def)`
 	* Register a new model to be used by players
-	* name: model filename such as "character.x", "foo.b3d", etc.
-	* def: See [#Model definition]
-    * saved to player_api.registered_models
+	* `name`: model filename such as "character.x", "foo.b3d", etc.
+	* `def`: see [#Model definition]
+    * Saved to player_api.registered_models
 
-* `player_api.registered_player_models[name]`
-	 * Get a model's definition
-	 * see [#Model definition]
+* `player_api.registered_models[name]`
+	* Get a model's definition
+	* `name`: model filename
+	* See [#Model definition]
 
 * `player_api.set_model(player, model_name)`
 	* Change a player's model
 	* `player`: PlayerRef
 	* `model_name`: model registered with player_api.register_model()
 
-* `player_api.set_animation(player, anim_name [, speed])`
+* `player_api.set_animation(player, anim_name, speed)`
 	* Applies an animation to a player
-	* anim_name: name of the animation.
-	* speed: frames per second. If nil, default from the model is used
+	* `player`: PlayerRef
+	* `anim_name`: name of the animation
+	* `speed`: frames per second. If nil, the default from the model def is used
 
 * `player_api.set_textures(player, textures)`
 	* Sets player textures
 	* `player`: PlayerRef
-	* `textures`: array of textures, If `textures` is nil the default
-	  textures from the model def are used
+	* `textures`: array of textures. If nil, the default from the model def is used
 
 * `player_api.get_animation(player)`
-	* Returns a table containing fields `model`, `textures` and `animation`.
-	* Any of the fields of the returned table may be nil.
-	* player: PlayerRef
+	* Returns a table containing fields `model`, `textures` and `animation`
+	* Any of the fields of the returned table may be nil
+	* `player`: PlayerRef
 
 * `player_api.player_attached`
-	* A table that maps a player name to a boolean.
-	* If the value for a given player is set to true, the default player
-	animations (walking, digging, ...) will no longer be updated.
-	Knockback from damage is also prevented for that player.
+	* A table that maps a player name to a boolean
+	* If the value for a given player is set to true, the default player animations
+	  (walking, digging, ...) will no longer be updated, and knockback from damage is
+	  prevented for that player
+	* Example of usage: A mod sets a player's value to true when attached to a vehicle
 
 ### Model Definition
 
 	{
-		animation_speed = 30,            -- Default animation speed, in FPS.
-		textures = {"character.png", },  -- Default array of textures.
-		visual_size = {x = 1, y = 1},    -- Used to scale the model.
+		animation_speed = 30,           -- Default animation speed, in FPS
+		textures = {"character.png", }, -- Default array of textures
+		visual_size = {x = 1, y = 1},   -- Used to scale the model
 		animations = {
 			-- <anim_name> = {x = <start_frame>, y = <end_frame>},
 			foo = {x = 0, y = 19},
@@ -481,8 +483,8 @@ The player API can register player models and update the player's appearance.
 			-- ...
 		},
 		collisionbox = {-0.3, 0.0, -0.3, 0.3, 1.7, 0.3}, -- In nodes from feet position
-		stepheight = 0.6, -- In nodes
-		eye_height = 1.47, -- In nodes above feet position
+		stepheight = 0.6,                                -- In nodes
+		eye_height = 1.47,                               -- In nodes above feet position
 	}
 
 

--- a/mods/player_api/api.lua
+++ b/mods/player_api/api.lua
@@ -68,7 +68,7 @@ function player_api.set_textures(player, textures)
 	local model = models[player_model[name]]
 	local model_textures = model and model.textures or nil
 	player_textures[name] = textures or model_textures
-	player:set_properties({textures = textures or model_textures,})
+	player:set_properties({textures = textures or model_textures})
 end
 
 function player_api.set_animation(player, anim_name, speed)
@@ -90,6 +90,8 @@ minetest.register_on_leaveplayer(function(player)
 	player_model[name] = nil
 	player_anim[name] = nil
 	player_textures[name] = nil
+	player_sneak[name] = nil
+	player_api.player_attached[name] = nil
 end)
 
 -- Localize for better performance.

--- a/mods/player_api/init.lua
+++ b/mods/player_api/init.lua
@@ -5,7 +5,7 @@ dofile(minetest.get_modpath("player_api") .. "/api.lua")
 -- Default player appearance
 player_api.register_model("character.b3d", {
 	animation_speed = 30,
-	textures = {"character.png", },
+	textures = {"character.png"},
 	animations = {
 		-- Standard animations.
 		stand     = {x = 0,   y = 79},


### PR DESCRIPTION
 Player_api: Various maintenance

Clear 'player_sneak' and 'player_api.player_attached' table values
when player leaves.
Remove unnecessary commas and whitespace.
Fix table name in 'game_api.txt'.
Clean up documentation in 'game_api.txt'.

/////////////////////////////////

I have been working on developing and cleaning up the player_api mod for use in new games and my own games. While doing so i noticed some mess and some forgotten table clearing when a player leaves, so here is a small PR.