### PR TITLE
Improve player model credits, add contributors to license

### DIFF
--- a/mods/player_api/README.txt
+++ b/mods/player_api/README.txt
@@ -13,13 +13,11 @@ Various Minetest developers and contributors (LGPLv2.1+)
 
 Authors of media (textures, models and sounds)
 ----------------------------------------------
-stujones11 (CC BY-SA 3.0):
+Original model by MirceaKitsune (CC BY-SA 3.0).
+Various alterations and fixes by kilbith, sofar, xunto, Rogier-5, TeTpaAka, Desour,
+stujones11, An0n3m0us (CC BY-SA 3.0):
   character.b3d
-  character.blend -- Both derived from a model by MirceaKitsune (CC BY-SA 3.0)
-
-An0n3m0us (CC BY-SA 3.0):
-  character.b3d
-  character.blend -- Player animation improvement
+  character.blend
 
 Jordach (CC BY-SA 3.0):
   character.png

--- a/mods/player_api/license.txt
+++ b/mods/player_api/license.txt
@@ -2,8 +2,8 @@ License of source code
 ----------------------
 
 GNU Lesser General Public License, version 2.1
-Copyright (C) 2011-2018 celeron55, Perttu Ahola <celeron55@gmail.com>
-Copyright (C) 2011-2018 Various Minetest developers and contributors
+Copyright (C) 2011 celeron55, Perttu Ahola <celeron55@gmail.com>
+Copyright (C) 2011 Various Minetest developers and contributors
 
 This program is free software; you can redistribute it and/or modify it under the terms
 of the GNU Lesser General Public License as published by the Free Software Foundation;
@@ -19,8 +19,15 @@ Licenses of media (textures, models and sounds)
 -----------------------------------------------
 
 Attribution-ShareAlike 3.0 Unported (CC BY-SA 3.0)
-Copyright (C) 2011-2018 celeron55, Perttu Ahola <celeron55@gmail.com>
-Copyright (C) 2012-2018 Jordach
+Copyright (C) 2011 celeron55, Perttu Ahola <celeron55@gmail.com>
+Copyright (C) 2012 MirceaKitsune
+Copyright (C) 2012 Jordach
+Copyright (C) 2015 kilbith
+Copyright (C) 2016 sofar
+Copyright (C) 2016 xunto
+Copyright (C) 2016 Rogier-5
+Copyright (C) 2017 TeTpaAka
+Copyright (C) 2017 Desour
 Copyright (C) 2018 stujones11
 Copyright (C) 2019 An0n3m0us
 


### PR DESCRIPTION
Closes #2621 

I searched through all player model history and credited all contributors who have worked on the player model.
All contributors are added to license.txt.
MirceaKitsune was missing from license.txt (!) so is added.
Copyright dates like 2011-2018 have had the 'end year' removed, as this is a pain to update every year, updating is often forgotten causing a misleading end year, and the end year can be assumed to be the current year if missing.

Fairly trivial PR so will merge in a few days to give others a chance to check this.