### PR TITLE
Player API: Animation-dependent collisionbox and eye_height

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -476,15 +476,48 @@ The player API can register player models and update the player's appearance.
 		animation_speed = 30,           -- Default animation speed, in FPS
 		textures = {"character.png", }, -- Default array of textures
 		visual_size = {x = 1, y = 1},   -- Used to scale the model
+		stepheight = 0.6,               -- In nodes
 		animations = {
 			-- <anim_name> = {x = <start_frame>, y = <end_frame>},
-			foo = {x = 0, y = 19},
-			bar = {x = 20, y = 39},
-			-- ...
+			-- The first 5 animations are required by the API
+			stand     = {x = 0,   y = 79},
+			lay       = {x = 162, y = 166},
+			walk      = {x = 168, y = 187},
+			mine      = {x = 189, y = 198},
+			walk_mine = {x = 200, y = 219},
+			-- The `sit` animation is only required by other Minetest Game mods
+			sit       = {x = 81,  y = 160},
+			-- More animations can be added
 		},
-		collisionbox = {-0.3, 0.0, -0.3, 0.3, 1.7, 0.3}, -- In nodes from feet position
-		stepheight = 0.6,                                -- In nodes
-		eye_height = 1.47,                               -- In nodes above feet position
+		collisionbox = {
+			-- Defined for each animation
+			-- <anim_name> = {<xmin>, <ymin>, <zmin>, <xmax>, <ymax>, <zmax>},
+			-- Min/max positions are in nodes from feet position
+			stand     = {-0.3, 0.0, -0.3, 0.3, 1.7, 0.3},
+			walk      = {-0.3, 0.0, -0.3, 0.3, 1.7, 0.3},
+			mine      = {-0.3, 0.0, -0.3, 0.3, 1.7, 0.3},
+			walk_mine = {-0.3, 0.0, -0.3, 0.3, 1.7, 0.3},
+			lay       = {-0.6, 0.0, -0.6, 0.6, 0.3, 0.6},
+			sit       = {-0.3, 0.0, -0.3, 0.3, 1.0, 0.3},
+		},
+		eye_height = {
+			-- Defined for each animation
+			-- In nodes above feet position
+			stand     = 1.47,
+			walk      = 1.47,
+			mine      = 1.47,
+			walk_mine = 1.47,
+			lay       = 0.3,
+			sit       = 0.8,
+		},
+	}
+
+Alternatively, `collisionbox` and `eye_height` can be defined as single values applied
+to all animations:
+
+	{
+		collisionbox = {-0.3, 0.0, -0.3, 0.3, 1.7, 0.3},
+		eye_height = 1.47,
 	}
 
 

--- a/mods/player_api/api.lua
+++ b/mods/player_api/api.lua
@@ -68,9 +68,10 @@ function player_api.set_textures(player, textures)
 end
 
 function player_api.set_animation(player, anim_name, speed)
-	-- Return if animation already applied to player
+	-- Return if no change of animation
 	local name = player:get_player_name()
-	if player_anim[name] == anim_name then
+	local old_anim_name = player_anim[name]
+	if anim_name == old_anim_name then
 		return
 	end
 	local model = player_model[name] and models[player_model[name]]
@@ -80,16 +81,23 @@ function player_api.set_animation(player, anim_name, speed)
 	local anim = model.animations[anim_name]
 	player_anim[name] = anim_name
 	player:set_animation(anim, speed or model.animation_speed, animation_blend)
-	-- Set animation-dependent properties
-	local eyeh
+	-- Set animation-dependent collisionbox and eye_height
+	local old_cbox = model.collisionbox[old_anim_name] or model.collisionbox
+	local new_cbox = model.collisionbox[anim_name] or model.collisionbox
+	-- Return if no change of collisionbox
+	-- Assumes eye_height does not change if collisionbox does not change
+	if table.concat(new_cbox) == table.concat(old_cbox) then
+		return
+	end
+	local new_eyeh
 	if type(model.eye_height) == "table" then
-		eyeh = model.eye_height[anim_name]
+		new_eyeh = model.eye_height[anim_name]
 	else -- number
-		eyeh = model.eye_height
+		new_eyeh = model.eye_height
 	end
 	player:set_properties({
-		collisionbox = model.collisionbox[anim_name] or model.collisionbox,
-		eye_height = eyeh,
+		collisionbox = new_cbox,
+		eye_height = new_eyeh,
 	})
 end
 

--- a/mods/player_api/init.lua
+++ b/mods/player_api/init.lua
@@ -1,13 +1,11 @@
--- player/init.lua
-
 dofile(minetest.get_modpath("player_api") .. "/api.lua")
 
 -- Default player appearance
 player_api.register_model("character.b3d", {
 	animation_speed = 30,
 	textures = {"character.png"},
+	stepheight = 0.6,
 	animations = {
-		-- Standard animations.
 		stand     = {x = 0,   y = 79},
 		lay       = {x = 162, y = 166},
 		walk      = {x = 168, y = 187},
@@ -15,9 +13,22 @@ player_api.register_model("character.b3d", {
 		walk_mine = {x = 200, y = 219},
 		sit       = {x = 81,  y = 160},
 	},
-	collisionbox = {-0.3, 0.0, -0.3, 0.3, 1.7, 0.3},
-	stepheight = 0.6,
-	eye_height = 1.47,
+	collisionbox = {
+		stand     = {-0.3, 0.0, -0.3, 0.3, 1.7, 0.3},
+		walk      = {-0.3, 0.0, -0.3, 0.3, 1.7, 0.3},
+		mine      = {-0.3, 0.0, -0.3, 0.3, 1.7, 0.3},
+		walk_mine = {-0.3, 0.0, -0.3, 0.3, 1.7, 0.3},
+		lay       = {-0.6, 0.0, -0.6, 0.6, 0.3, 0.6},
+		sit       = {-0.3, 0.0, -0.3, 0.3, 1.0, 0.3},
+	},
+	eye_height = {
+		stand     = 1.47,
+		walk      = 1.47,
+		mine      = 1.47,
+		walk_mine = 1.47,
+		lay       = 0.3,
+		sit       = 0.8,
+	},
 })
 
 -- Update appearance when the player joins


### PR DESCRIPTION
Closes #2742 
See https://github.com/minetest/minetest_game/issues/2742#issuecomment-697037345 and following comments.
For the registered MTG player model, collisionbox and eye-height will now be correctly set when 'sitting' or 'laying'.
The main benefit however is for mod-registered player models and their various and possibly more unusual animations, for example a crawling animation could now allow a player to pass through 1-node high spaces.

Player model collisionbox and eye_height can each be defined as a table of per-animation values, or left as a single universal value (which also ensures backwards compatibility).
When animation is set in `set_animation()`, the animation-dependent object properties are also set.

The `set_animation()` function returns if the requested animation is already applied to a player, so the function only executes when the animation needs to change, for example starting walking, stopping walking etc.

Now that object properties are also set in `set_animation()`, an object properties packet is sent to the client each time animation changes. I hope this is not a significant increase in network traffic, as it will be on average 1 extra packet every second (very approximately).