### PR TITLE
Add missing not_in_creative_inventory group where appropriate

### DIFF
--- a/mods/beds/api.lua
+++ b/mods/beds/api.lua
@@ -155,7 +155,8 @@ function beds.register_bed(name, def)
 		paramtype2 = "facedir",
 		is_ground_content = false,
 		pointable = false,
-		groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 3, bed = 2},
+		groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 3, bed = 2,
+				not_in_creative_inventory = 1},
 		sounds = def.sounds or default.node_sound_wood_defaults(),
 		drop = name .. "_bottom",
 		node_box = {

--- a/mods/default/tools.lua
+++ b/mods/default/tools.lua
@@ -4,6 +4,7 @@
 local S = default.get_translator
 
 -- The hand
+-- Override the hand item registered in the engine in builtin/game/register.lua
 minetest.override_item("", {
 	wield_scale = {x=1,y=1,z=2.5},
 	tool_capabilities = {

--- a/mods/default/tools.lua
+++ b/mods/default/tools.lua
@@ -4,9 +4,7 @@
 local S = default.get_translator
 
 -- The hand
-minetest.register_item(":", {
-	type = "none",
-	wield_image = "wieldhand.png",
+minetest.override_item("", {
 	wield_scale = {x=1,y=1,z=2.5},
 	tool_capabilities = {
 		full_punch_interval = 0.9,

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -434,7 +434,7 @@ minetest.register_node("tnt:boom", {
 	light_source = default.LIGHT_MAX,
 	walkable = false,
 	drop = "",
-	groups = {dig_immediate = 3},
+	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
 	-- unaffected by explosions
 	on_blast = function() end,
 })
@@ -531,7 +531,8 @@ minetest.register_node("tnt:gunpowder_burning", {
 	groups = {
 		dig_immediate = 2,
 		attached_node = 1,
-		connect_to_raillike = minetest.raillike_group("gunpowder")
+		connect_to_raillike = minetest.raillike_group("gunpowder"),
+		not_in_creative_inventory = 1
 	},
 	sounds = default.node_sound_leaves_defaults(),
 	on_timer = function(pos, elapsed)
@@ -678,7 +679,7 @@ function tnt.register_tnt(def)
 		light_source = 5,
 		drop = "",
 		sounds = default.node_sound_wood_defaults(),
-		groups = {falling_node = 1},
+		groups = {falling_node = 1, not_in_creative_inventory = 1},
 		on_timer = function(pos, elapsed)
 			tnt.boom(pos, def)
 		end,


### PR DESCRIPTION
Items found with:
```lua
minetest.after(0, function()
	print("--- searched items:")
	for name, def in pairs(minetest.registered_items) do
		if (def.description == "" or type(def.description) ~= "string" or
				def.description == name) and
				(def.groups or {}).not_in_creative_inventory ~= 1 then
			print(name)
		end
	end
	print("---")
end)
```

Also, the hand is overridden instead of registered again, to use the builtin registration, which includes the group:
https://github.com/minetest/minetest/blob/f3ae45b2b245dd0aeb4a7d9b76afaf078871104c/builtin/game/register.lua#L391-L396

Related / fixes: #2754 