### PR TITLE
Balance open/close sound levels of doors, trapdoors, fencegates

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -168,10 +168,10 @@ function doors.door_toggle(pos, node, clicker)
 
 	if state % 2 == 0 then
 		minetest.sound_play(def.door.sounds[1],
-			{pos = pos, gain = 0.3, max_hear_distance = 10}, true)
+			{pos = pos, gain = 0.2, max_hear_distance = 10}, true)
 	else
 		minetest.sound_play(def.door.sounds[2],
-			{pos = pos, gain = 0.3, max_hear_distance = 10}, true)
+			{pos = pos, gain = 0.2, max_hear_distance = 10}, true)
 	end
 
 	minetest.swap_node(pos, {
@@ -550,12 +550,12 @@ function doors.trapdoor_toggle(pos, node, clicker)
 
 	if string.sub(node.name, -5) == "_open" then
 		minetest.sound_play(def.sound_close,
-			{pos = pos, gain = 0.3, max_hear_distance = 10}, true)
+			{pos = pos, gain = 0.2, max_hear_distance = 10}, true)
 		minetest.swap_node(pos, {name = string.sub(node.name, 1,
 			string.len(node.name) - 5), param1 = node.param1, param2 = node.param2})
 	else
 		minetest.sound_play(def.sound_open,
-			{pos = pos, gain = 0.3, max_hear_distance = 10}, true)
+			{pos = pos, gain = 0.2, max_hear_distance = 10}, true)
 		minetest.swap_node(pos, {name = node.name .. "_open",
 			param1 = node.param1, param2 = node.param2})
 	end
@@ -743,7 +743,7 @@ function doors.register_fencegate(name, def)
 		on_rightclick = function(pos, node, clicker, itemstack, pointed_thing)
 			local node_def = minetest.registered_nodes[node.name]
 			minetest.swap_node(pos, {name = node_def.gate, param2 = node.param2})
-			minetest.sound_play(node_def.sound, {pos = pos, gain = 0.3,
+			minetest.sound_play(node_def.sound, {pos = pos, gain = 0.2,
 				max_hear_distance = 8}, true)
 			return itemstack
 		end,


### PR DESCRIPTION
Closes #2749

Door, trapdoor and fencegate sound levels were too high and out of balance with other sounds.
They did not take into account how the sound becomes much louder when you are close, these being positional sounds.
Pressure plates are often used to actuate doors, the plates are usually placed adjacent to a door so the player is very close to the door when it opens.

In this PR the sound levels have been adjusted to be balanced and not excessively loud when the player is as close to the door/trapdoor/fencegate as possible.

Because the gain values affect all registered doors/trapdoors, and because each door/trapdoor type sound file (wooden, steel, glass, steel bar) has slightly different sound levels, i have had to compromise a little. Wooden doors/trapdoors and steel bar doors/trapdoors are still a little loud, glass door is still a little quiet, but for all types the average is balanced.

Because door, trapdoor and fencegate sounds are usually balanced against each other in mods, i have made the same change of 0.3 to 0.2 for all of these.

The changes try to take into account not only MTG but all mods that register doors.

How to test
-
* Place: Wood/steel/glass/steel bar doors, wood/steel/steel bar trapdoors, a fencegate.
* Trigger various dig/dug and footstep sounds (which are fairly well balanced) and adjust your headphones/amplification volume to an optimum level.
* Open and close the doors/trapdoors/fencegate while as close as possible, so that the sound level is maximised:
For doors, stand on the node the door is placed above and press against the door.
For trapdoors, dig a 1 node deep hole next to a trapdoor and press against it.
For fencegate, press against it from either side.
These positions are shown in the screenshots below.

![screenshot_20201030_181923](https://user-images.githubusercontent.com/3686677/97745871-6cc8e100-1ae1-11eb-89ba-c091cf741983.png)

![screenshot_20201030_181906](https://user-images.githubusercontent.com/3686677/97745886-70f4fe80-1ae1-11eb-9c1a-8b910362fb03.png)

![screenshot_20201030_181938](https://user-images.githubusercontent.com/3686677/97745906-74888580-1ae1-11eb-9a5b-aee85c235397.png)