### PR TITLE
Add optional open/close sound gain fields to the Doors API. Balance sound levels

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -225,6 +225,8 @@ The doors mod allows modders to register custom doors and trapdoors.
 	sounds = default.node_sound_wood_defaults(), -- optional
 	sound_open = sound play for open door, -- optional
 	sound_close = sound play for close door, -- optional
+	gain_open = 0.3, -- optional, defaults to 0.3
+	gain_close = 0.3, -- optional, defaults to 0.3
 	protected = false, -- If true, only placer can open the door (locked for others)
 	on_rightclick = function(pos, node, clicker, itemstack, pointed_thing) 
 	-- optional function containing the on_rightclick callback, defaults to a doors.door_toggle-wrapper
@@ -244,6 +246,8 @@ The doors mod allows modders to register custom doors and trapdoors.
 	sounds = default.node_sound_wood_defaults(), -- optional
 	sound_open = sound play for open door, -- optional
 	sound_close = sound play for close door, -- optional
+	gain_open = 0.3, -- optional, defaults to 0.3
+	gain_close = 0.3, -- optional, defaults to 0.3
 	protected = false, -- If true, only placer can open the door (locked for others)
 	on_rightclick = function(pos, node, clicker, itemstack, pointed_thing) 
 	-- function containing the on_rightclick callback

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -168,10 +168,10 @@ function doors.door_toggle(pos, node, clicker)
 
 	if state % 2 == 0 then
 		minetest.sound_play(def.door.sounds[1],
-			{pos = pos, gain = 0.3, max_hear_distance = 10}, true)
+			{pos = pos, gain = def.door.gains[1], max_hear_distance = 10}, true)
 	else
 		minetest.sound_play(def.door.sounds[2],
-			{pos = pos, gain = 0.3, max_hear_distance = 10}, true)
+			{pos = pos, gain = def.door.gains[2], max_hear_distance = 10}, true)
 	end
 
 	minetest.swap_node(pos, {
@@ -362,12 +362,21 @@ function doors.register(name, def)
 		def.sound_close = "doors_door_close"
 	end
 
+	if not def.gain_open then
+		def.gain_open = 0.3
+	end
+
+	if not def.gain_close then
+		def.gain_close = 0.3
+	end
+
 	def.groups.not_in_creative_inventory = 1
 	def.groups.door = 1
 	def.drop = name
 	def.door = {
 		name = name,
-		sounds = { def.sound_close, def.sound_open },
+		sounds = {def.sound_close, def.sound_open},
+		gains = {def.gain_close, def.gain_open},
 	}
 	if not def.on_rightclick then
 		def.on_rightclick = function(pos, node, clicker, itemstack, pointed_thing)
@@ -458,6 +467,8 @@ doors.register("door_wood", {
 		description = S("Wooden Door"),
 		inventory_image = "doors_item_wood.png",
 		groups = {node = 1, choppy = 2, oddly_breakable_by_hand = 2, flammable = 2},
+		gain_open = 0.06,
+		gain_close = 0.13,
 		recipe = {
 			{"group:wood", "group:wood"},
 			{"group:wood", "group:wood"},
@@ -474,6 +485,8 @@ doors.register("door_steel", {
 		sounds = default.node_sound_metal_defaults(),
 		sound_open = "doors_steel_door_open",
 		sound_close = "doors_steel_door_close",
+		gain_open = 0.2,
+		gain_close = 0.2,
 		recipe = {
 			{"default:steel_ingot", "default:steel_ingot"},
 			{"default:steel_ingot", "default:steel_ingot"},
@@ -489,6 +502,8 @@ doors.register("door_glass", {
 		sounds = default.node_sound_glass_defaults(),
 		sound_open = "doors_glass_door_open",
 		sound_close = "doors_glass_door_close",
+		gain_open = 0.3,
+		gain_close = 0.25,
 		recipe = {
 			{"default:glass", "default:glass"},
 			{"default:glass", "default:glass"},
@@ -504,6 +519,8 @@ doors.register("door_obsidian_glass", {
 		sounds = default.node_sound_glass_defaults(),
 		sound_open = "doors_glass_door_open",
 		sound_close = "doors_glass_door_close",
+		gain_open = 0.3,
+		gain_close = 0.25,
 		recipe = {
 			{"default:obsidian_glass", "default:obsidian_glass"},
 			{"default:obsidian_glass", "default:obsidian_glass"},
@@ -550,12 +567,12 @@ function doors.trapdoor_toggle(pos, node, clicker)
 
 	if string.sub(node.name, -5) == "_open" then
 		minetest.sound_play(def.sound_close,
-			{pos = pos, gain = 0.3, max_hear_distance = 10}, true)
+			{pos = pos, gain = def.gain_close, max_hear_distance = 10}, true)
 		minetest.swap_node(pos, {name = string.sub(node.name, 1,
 			string.len(node.name) - 5), param1 = node.param1, param2 = node.param2})
 	else
 		minetest.sound_play(def.sound_open,
-			{pos = pos, gain = 0.3, max_hear_distance = 10}, true)
+			{pos = pos, gain = def.gain_open, max_hear_distance = 10}, true)
 		minetest.swap_node(pos, {name = node.name .. "_open",
 			param1 = node.param1, param2 = node.param2})
 	end
@@ -637,6 +654,14 @@ function doors.register_trapdoor(name, def)
 		def.sound_close = "doors_door_close"
 	end
 
+	if not def.gain_open then
+		def.gain_open = 0.3
+	end
+
+	if not def.gain_close then
+		def.gain_close = 0.3
+	end
+
 	local def_opened = table.copy(def)
 	local def_closed = table.copy(def)
 
@@ -690,6 +715,8 @@ doors.register_trapdoor("doors:trapdoor", {
 	wield_image = "doors_trapdoor.png",
 	tile_front = "doors_trapdoor.png",
 	tile_side = "doors_trapdoor_side.png",
+	gain_open = 0.06,
+	gain_close = 0.13,
 	groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 2, door = 1},
 })
 
@@ -703,6 +730,8 @@ doors.register_trapdoor("doors:trapdoor_steel", {
 	sounds = default.node_sound_metal_defaults(),
 	sound_open = "doors_steel_door_open",
 	sound_close = "doors_steel_door_close",
+	gain_open = 0.2,
+	gain_close = 0.2,
 	groups = {cracky = 1, level = 2, door = 1},
 })
 
@@ -743,7 +772,7 @@ function doors.register_fencegate(name, def)
 		on_rightclick = function(pos, node, clicker, itemstack, pointed_thing)
 			local node_def = minetest.registered_nodes[node.name]
 			minetest.swap_node(pos, {name = node_def.gate, param2 = node.param2})
-			minetest.sound_play(node_def.sound, {pos = pos, gain = 0.3,
+			minetest.sound_play(node_def.sound, {pos = pos, gain = 0.15,
 				max_hear_distance = 8}, true)
 			return itemstack
 		end,

--- a/mods/xpanes/init.lua
+++ b/mods/xpanes/init.lua
@@ -227,6 +227,8 @@ if minetest.get_modpath("doors") then
 		sounds = default.node_sound_metal_defaults(),
 		sound_open = "xpanes_steel_bar_door_open",
 		sound_close = "xpanes_steel_bar_door_close",
+		gain_open = 0.15,
+		gain_close = 0.13,
 		recipe = {
 			{"xpanes:bar_flat", "xpanes:bar_flat"},
 			{"xpanes:bar_flat", "xpanes:bar_flat"},
@@ -245,6 +247,8 @@ if minetest.get_modpath("doors") then
 		sounds = default.node_sound_metal_defaults(),
 		sound_open = "xpanes_steel_bar_door_open",
 		sound_close = "xpanes_steel_bar_door_close",
+		gain_open = 0.15,
+		gain_close = 0.13,
 	})
 
 	minetest.register_craft({


### PR DESCRIPTION
Closes #2749 

Many of the door/trapdoor/fencegate open/close sounds are far too loud when the player is close to the door.
For doors and trapdoors the sounds are also unbalanced between the different types (wood, steel, glass, steel bar) and unbalanced between open and close.

For doors and trapdoors
-
The open/close gains are hardcoded to 0.3 in the API. Therefore, setting suitable sound levels requires a lot of time and tedious effort altering the soundfile waveform amplitudes in a sound editor.

This PR adds open/close gain fields to the API. Gains fallback to the previous value of 0.3 for backwards compatibility.
This PR also defines balanced gain values for MTG doors/trapdoors

For fencegates
-
The open/close gain is hardcoded, but so are the sounds, so gain fields are not needed in the API.
This PR sets a balanced gain value for fencegates.

How to test
-
* Place: Wood/steel/glass/obsidian glass/steel bar doors, wood/steel/steel bar trapdoors, a fencegate.
* Trigger various dig/dug and footstep sounds (which are fairly well balanced) and adjust your headphones/amplification volume to an optimum level.
* Open and close the doors/trapdoors/fencegate while as close as possible, so that the sound level is maximised:
For doors, stand on the node the door is placed above and press against the closed door.
For trapdoors, dig a 2 node deep hole under the trapdoor, place ladders on hole wall, climb ladder to press against closed trapdoor.
For fencegate, press against closed fencegate from either side.
These positions are shown in the screenshots below.

![screenshot_20201030_181923](https://user-images.githubusercontent.com/3686677/97783304-b28fb300-1b8e-11eb-9080-50d20160a4b1.png)

![screenshot_20201031_152025](https://user-images.githubusercontent.com/3686677/97783307-b7546700-1b8e-11eb-8116-2c9b3feb05be.png)

![screenshot_20201030_181938](https://user-images.githubusercontent.com/3686677/97783311-ba4f5780-1b8e-11eb-832b-4614909f12a2.png)