### PR TITLE
Beds: Fix physical override bug

### DIFF
--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -75,7 +75,7 @@ local function lay_down(player, pos, bed_pos, state, skip)
 		player:set_eye_offset({x = 0, y = 0, z = 0}, {x = 0, y = 0, z = 0})
 		player:set_look_horizontal(math.random(1, 180) / 100)
 		player_api.player_attached[name] = false
-		player:set_physics_override(1, 1, 1)
+		player:set_physics_override({jump = 1, speed = 1, gravity = 1})
 		hud_flags.wielditem = true
 		player_api.set_animation(player, "stand" , 30)
 
@@ -112,7 +112,7 @@ local function lay_down(player, pos, bed_pos, state, skip)
 			y = bed_pos.y + 0.07,
 			z = bed_pos.z + dir.z / 2
 		}
-		player:set_physics_override(0, 0, 0)
+		player:set_physics_override({jump = 0, speed = 0, gravity = 0})
 		player:set_pos(p)
 		player_api.player_attached[name] = true
 		hud_flags.wielditem = false


### PR DESCRIPTION
This uses the group setting for player override to stop game crashing when using beds.