### PR TITLE
Introduce option to make lava renewable, off by default

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -37,6 +37,9 @@
 # Whether lavacooling should be enabled.
 #enable_lavacooling = true
 
+# Whether lava sources are renewable or not.
+#renewable_lava = false
+
 # Whether the stuff in initial_stuff should be given to new players.
 #give_initial_stuff = false
 #initial_stuff = default:pick_steel,default:axe_steel,default:shovel_steel,

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -2406,7 +2406,7 @@ minetest.register_node("default:lava_source", {
 	liquid_alternative_flowing = "default:lava_flowing",
 	liquid_alternative_source = "default:lava_source",
 	liquid_viscosity = 7,
-	liquid_renewable = false,
+	liquid_renewable = minetest.settings:get_bool("renewable_lava") or false,
 	damage_per_second = 4 * 2,
 	post_effect_color = {a = 191, r = 255, g = 64, b = 0},
 	groups = {lava = 3, liquid = 2, igniter = 1},


### PR DESCRIPTION
Considering MTG is being frozen feature-wise, I think it's important to clean up the remaining usability kinks.

Lava not being renewable is an important design decision that was taken 7 years ago
(introducing a significant, but justified change), and yet the question about making it renewable again
re-emerges periodically (the last hit I could find is from February this year, in the forum).

Making lava renewable again is something that users can do with a two-line mod, but I see having to go
through the (as limited as it might be) hassle of introducing a mod just to toggle this feature as a usability issue.

My proposal to fix this is to introduce a configuration option (that defaults to false, keeping the current behavior)
that can be toggled to make lava renewable again.
This eliminates the need to go through the mod system for something so trivial,
and is consistent with the spirit of making potentially destructive feature available,
albeit disabled by default.
