### PR TITLE
Don't replace protected liquids with bones.

### DIFF
--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -141,8 +141,18 @@ local function may_replace(pos, player)
 		return false
 	end
 
-	-- allow replacing air and liquids
-	if node_name == "air" or node_definition.liquidtype ~= "none" then
+	-- allow replacing air
+	if node_name == "air" then
+		return true
+	end
+
+	-- don't replace nodes inside protections
+	if minetest.is_protected(pos, player:get_player_name()) then
+		return false
+	end
+
+	-- allow replacing liquids
+	if node_definition.liquidtype ~= "none" then
 		return true
 	end
 
@@ -154,8 +164,7 @@ local function may_replace(pos, player)
 
 	-- default to each nodes buildable_to; if a placed block would replace it, why shouldn't bones?
 	-- flowers being squished by bones are more realistical than a squished stone, too
-	-- exception are of course any protected buildable_to
-	return node_definition.buildable_to and not minetest.is_protected(pos, player:get_player_name())
+	return node_definition.buildable_to
 end
 
 local drop = function(pos, itemstack)


### PR DESCRIPTION
Griefers like to repeatedly die in protected water and lava. This destroys lava nodes or causes liquid to flow over the protection.