### PR TITLE
Use Minetest 5.3 'minetest.is_creative_enabled' API

### DIFF
--- a/mods/beds/api.lua
+++ b/mods/beds/api.lua
@@ -95,8 +95,7 @@ function beds.register_bed(name, def)
 			minetest.set_node(pos, {name = name .. "_bottom", param2 = dir})
 			minetest.set_node(botpos, {name = name .. "_top", param2 = dir})
 
-			if not (creative and creative.is_enabled_for
-					and creative.is_enabled_for(player_name)) then
+			if not minetest.is_creative_enabled(player_name) then
 				itemstack:take_item()
 			end
 			return itemstack

--- a/mods/binoculars/init.lua
+++ b/mods/binoculars/init.lua
@@ -8,25 +8,16 @@ binoculars = {}
 local S = minetest.get_translator("binoculars")
 
 
--- Detect creative mod
-local creative_mod = minetest.get_modpath("creative")
--- Cache creative mode setting as fallback if creative mod not present
-local creative_mode_cache = minetest.settings:get_bool("creative_mode")
-
-
 -- Update player property
 -- Global to allow overriding
 
 function binoculars.update_player_property(player)
-	local creative_enabled =
-		(creative_mod and creative.is_enabled_for(player:get_player_name())) or
-		creative_mode_cache
 	local new_zoom_fov = 0
 
 	if player:get_inventory():contains_item(
 			"main", "binoculars:binoculars") then
 		new_zoom_fov = 10
-	elseif creative_enabled then
+	elseif minetest.is_creative_enabled(player:get_player_name()) then
 		new_zoom_fov = 15
 	end
 

--- a/mods/binoculars/mod.conf
+++ b/mods/binoculars/mod.conf
@@ -1,4 +1,3 @@
 name = binoculars
 description = Minetest Game mod: binoculars
 depends = default
-optional_depends = creative

--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -119,8 +119,7 @@ function boat.on_punch(self, puncher)
 	if not self.driver then
 		self.removed = true
 		local inv = puncher:get_inventory()
-		if not (creative and creative.is_enabled_for
-				and creative.is_enabled_for(name))
+		if not minetest.is_creative_enabled(name)
 				or not inv:contains_item("main", "boats:boat") then
 			local leftover = inv:add_item("main", "boats:boat")
 			-- if no room in inventory add a replacement boat to the world
@@ -268,8 +267,7 @@ minetest.register_craftitem("boats:boat", {
 				boat:set_yaw(placer:get_look_horizontal())
 			end
 			local player_name = placer and placer:get_player_name() or ""
-			if not (creative and creative.is_enabled_for and
-					creative.is_enabled_for(player_name)) then
+			if not minetest.is_creative_enabled(player_name) then
 				itemstack:take_item()
 			end
 		end

--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -191,7 +191,6 @@ local function is_all_empty(player_inv)
 end
 
 minetest.register_on_dieplayer(function(player)
-
 	local bones_mode = minetest.settings:get("bones_mode") or "bones"
 	if bones_mode ~= "bones" and bones_mode ~= "drop" and bones_mode ~= "keep" then
 		bones_mode = "bones"
@@ -203,8 +202,7 @@ minetest.register_on_dieplayer(function(player)
 	local pos_string = minetest.pos_to_string(pos)
 
 	-- return if keep inventory set or in creative mode
-	if bones_mode == "keep" or (creative and creative.is_enabled_for
-			and creative.is_enabled_for(player:get_player_name())) then
+	if bones_mode == "keep" or minetest.is_creative_enabled(player_name) then
 		minetest.log("action", player_name .. " dies at " .. pos_string ..
 			". No bones placed")
 		if bones_position_message then

--- a/mods/carts/cart_entity.lua
+++ b/mods/carts/cart_entity.lua
@@ -108,8 +108,7 @@ function cart_entity:on_punch(puncher, time_from_last_punch, tool_capabilities, 
 		end
 		-- Pick up cart
 		local inv = puncher:get_inventory()
-		if not (creative and creative.is_enabled_for
-				and creative.is_enabled_for(puncher:get_player_name()))
+		if not minetest.is_creative_enabled(puncher:get_player_name())
 				or not inv:contains_item("main", "carts:cart") then
 			local leftover = inv:add_item("main", "carts:cart")
 			-- If no room in inventory add a replacement cart to the world
@@ -416,8 +415,7 @@ minetest.register_craftitem("carts:cart", {
 		minetest.sound_play({name = "default_place_node_metal", gain = 0.5},
 			{pos = pointed_thing.above}, true)
 
-		if not (creative and creative.is_enabled_for
-				and creative.is_enabled_for(placer:get_player_name())) then
+		if not minetest.is_creative_enabled(placer:get_player_name()) then
 			itemstack:take_item()
 		end
 		return itemstack

--- a/mods/creative/init.lua
+++ b/mods/creative/init.lua
@@ -79,7 +79,7 @@ end
 -- Unlimited node placement
 minetest.register_on_placenode(function(pos, newnode, placer, oldnode, itemstack)
 	if placer and placer:is_player() then
-		return creative.is_enabled_for(placer:get_player_name())
+		return minetest.is_creative_enabled(placer:get_player_name())
 	end
 end)
 
@@ -87,7 +87,7 @@ end)
 local old_handle_node_drops = minetest.handle_node_drops
 function minetest.handle_node_drops(pos, drops, digger)
 	if not digger or not digger:is_player() or
-		not creative.is_enabled_for(digger:get_player_name()) then
+		not minetest.is_creative_enabled(digger:get_player_name()) then
 		return old_handle_node_drops(pos, drops, digger)
 	end
 	local inv = digger:get_inventory()

--- a/mods/creative/inventory.lua
+++ b/mods/creative/inventory.lua
@@ -33,7 +33,7 @@ function creative.init_creative_inventory(player)
 	minetest.create_detached_inventory("creative_" .. player_name, {
 		allow_move = function(inv, from_list, from_index, to_list, to_index, count, player2)
 			local name = player2 and player2:get_player_name() or ""
-			if not creative.is_enabled_for(name) or
+			if not minetest.is_creative_enabled(name) or
 					to_list == "main" then
 				return 0
 			end
@@ -44,7 +44,7 @@ function creative.init_creative_inventory(player)
 		end,
 		allow_take = function(inv, listname, index, stack, player2)
 			local name = player2 and player2:get_player_name() or ""
-			if not creative.is_enabled_for(name) then
+			if not minetest.is_creative_enabled(name) then
 				return 0
 			end
 			return -1
@@ -143,7 +143,7 @@ function creative.register_tab(name, title, items)
 	sfinv.register_page("creative:" .. name, {
 		title = title,
 		is_in_nav = function(self, player, context)
-			return creative.is_enabled_for(player:get_player_name())
+			return minetest.is_creative_enabled(player:get_player_name())
 		end,
 		get = function(self, player, context)
 			local player_name = player:get_player_name()
@@ -248,7 +248,7 @@ creative.register_tab("craftitems", S("Items"), registered_craftitems)
 
 local old_homepage_name = sfinv.get_homepage_name
 function sfinv.get_homepage_name(player)
-	if creative.is_enabled_for(player:get_player_name()) then
+	if minetest.is_creative_enabled(player:get_player_name()) then
 		return "creative:all"
 	else
 		return old_homepage_name(player)

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1998,8 +1998,7 @@ minetest.register_node("default:sand_with_kelp", {
 					not minetest.is_protected(pos_top, player_name) then
 				minetest.set_node(pos, {name = "default:sand_with_kelp",
 					param2 = height * 16})
-				if not (creative and creative.is_enabled_for
-						and creative.is_enabled_for(player_name)) then
+				if not minetest.is_creative_enabled(player_name) then
 					itemstack:take_item()
 				end
 			else
@@ -2054,7 +2053,7 @@ local function coral_on_place(itemstack, placer, pointed_thing)
 
 	node_under.name = itemstack:get_name()
 	minetest.set_node(pos_under, node_under)
-	if not (creative and creative.is_enabled_for(player_name)) then
+	if not minetest.is_creative_enabled(player_name) then
 		itemstack:take_item()
 	end
 

--- a/mods/default/trees.lua
+++ b/mods/default/trees.lua
@@ -575,8 +575,7 @@ function default.sapling_on_place(itemstack, placer, pointed_thing,
 	minetest.log("action", player_name .. " places node "
 			.. sapling_name .. " at " .. minetest.pos_to_string(pos))
 
-	local take_item = not (creative and creative.is_enabled_for
-		and creative.is_enabled_for(player_name))
+	local take_item = not minetest.is_creative_enabled(player_name)
 	local newnode = {name = sapling_name}
 	local ndef = minetest.registered_nodes[sapling_name]
 	minetest.set_node(pos, newnode)

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -330,7 +330,7 @@ function doors.register(name, def)
 				meta:set_string("infotext", def.description .. "\n" .. S("Owned by @1", pn))
 			end
 
-			if not (creative and creative.is_enabled_for and creative.is_enabled_for(pn)) then
+			if not minetest.is_creative_enabled(pn) then
 				itemstack:take_item()
 			end
 
@@ -590,7 +590,7 @@ function doors.register_trapdoor(name, def)
 			meta:set_string("owner", pn)
 			meta:set_string("infotext", def.description .. "\n" .. S("Owned by @1", pn))
 
-			return (creative and creative.is_enabled_for and creative.is_enabled_for(pn))
+			return minetest.is_creative_enabled(pn)
 		end
 
 		def.on_blast = function() end

--- a/mods/farming/api.lua
+++ b/mods/farming/api.lua
@@ -45,12 +45,14 @@ farming.hoe_on_use = function(itemstack, user, pointed_thing, uses)
 		return
 	end
 
-	if minetest.is_protected(pt.under, user:get_player_name()) then
-		minetest.record_protection_violation(pt.under, user:get_player_name())
+	local player_name = user and user:get_player_name() or ""
+
+	if minetest.is_protected(pt.under, player_name) then
+		minetest.record_protection_violation(pt.under, player_name)
 		return
 	end
-	if minetest.is_protected(pt.above, user:get_player_name()) then
-		minetest.record_protection_violation(pt.above, user:get_player_name())
+	if minetest.is_protected(pt.above, player_name) then
+		minetest.record_protection_violation(pt.above, player_name)
 		return
 	end
 
@@ -61,8 +63,7 @@ farming.hoe_on_use = function(itemstack, user, pointed_thing, uses)
 		gain = 0.5,
 	}, true)
 
-	if not (creative and creative.is_enabled_for
-			and creative.is_enabled_for(user:get_player_name())) then
+	if not minetest.is_creative_enabled(player_name) then
 		-- wear tool
 		local wdef = itemstack:get_definition()
 		itemstack:add_wear(65535/(uses-1))
@@ -181,8 +182,7 @@ farming.place_seed = function(itemstack, placer, pointed_thing, plantname)
 		minetest.pos_to_string(pt.above))
 	minetest.add_node(pt.above, {name = plantname, param2 = 1})
 	tick(pt.above)
-	if not (creative and creative.is_enabled_for
-			and creative.is_enabled_for(player_name)) then
+	if not minetest.is_creative_enabled(player_name) then
 		itemstack:take_item()
 	end
 	return itemstack

--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -111,8 +111,7 @@ minetest.register_tool("fire:flint_and_steel", {
 				minetest.set_node(pointed_thing.above, {name = "fire:basic_flame"})
 			end
 		end
-		if not (creative and creative.is_enabled_for
-				and creative.is_enabled_for(player_name)) then
+		if not minetest.is_creative_enabled(player_name) then
 			-- Wear tool
 			local wdef = itemstack:get_definition()
 			itemstack:add_wear(1000)

--- a/mods/fireflies/init.lua
+++ b/mods/fireflies/init.lua
@@ -106,7 +106,7 @@ minetest.register_tool("fireflies:bug_net", {
 				minetest.add_item(pointed_thing.under, node_name.." 1")
 			end
 		end
-		if not (creative and creative.is_enabled_for(player:get_player_name())) then
+		if not minetest.is_creative_enabled(player_name) then
 			itemstack:add_wear(256)
 			return itemstack
 		end

--- a/mods/fireflies/init.lua
+++ b/mods/fireflies/init.lua
@@ -92,8 +92,9 @@ minetest.register_tool("fireflies:bug_net", {
 	description = S("Bug Net"),
 	inventory_image = "fireflies_bugnet.png",
 	on_use = function(itemstack, player, pointed_thing)
+		local player_name = player and player:get_player_name() or ""
 		if not pointed_thing or pointed_thing.type ~= "node" or
-				minetest.is_protected(pointed_thing.under, player:get_player_name()) then
+				minetest.is_protected(pointed_thing.under, player_name) then
 			return
 		end
 		local node_name = minetest.get_node(pointed_thing.under).name

--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -312,8 +312,7 @@ local waterlily_def = {
 				minetest.set_node(pos, {name = "flowers:waterlily" ..
 					(def.waving == 3 and "_waving" or ""),
 					param2 = math.random(0, 3)})
-				if not (creative and creative.is_enabled_for
-						and creative.is_enabled_for(player_name)) then
+				if not minetest.is_creative_enabled(player_name) then
 					itemstack:take_item()
 				end
 			else

--- a/mods/map/init.lua
+++ b/mods/map/init.lua
@@ -9,18 +9,11 @@ map = {}
 local S = minetest.get_translator("map")
 
 
--- Cache creative mode setting
-
-local creative_mode_cache = minetest.settings:get_bool("creative_mode")
-
-
 -- Update HUD flags
 -- Global to allow overriding
 
 function map.update_hud_flags(player)
-	local creative_enabled =
-		(creative and creative.is_enabled_for(player:get_player_name())) or
-		creative_mode_cache
+	local creative_enabled = minetest.is_creative_enabled(player:get_player_name())
 
 	local minimap_enabled = creative_enabled or
 		player:get_inventory():contains_item("main", "map:mapping_kit")

--- a/mods/map/mod.conf
+++ b/mods/map/mod.conf
@@ -1,4 +1,3 @@
 name = map
 description = Minetest Game mod: map
 depends = default, dye
-optional_depends = creative

--- a/mods/screwdriver/init.lua
+++ b/mods/screwdriver/init.lua
@@ -140,8 +140,7 @@ screwdriver.handler = function(itemstack, user, pointed_thing, mode, uses)
 		minetest.check_for_falling(pos)
 	end
 
-	if not (creative and creative.is_enabled_for and
-			creative.is_enabled_for(player_name)) then
+	if not minetest.is_creative_enabled(player_name) then
 		itemstack:add_wear(65535 / ((uses or 200) - 1))
 	end
 

--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -197,8 +197,6 @@ function stairs.register_slab(subname, recipeitem, groups, images, description,
 			local under = minetest.get_node(pointed_thing.under)
 			local wield_item = itemstack:get_name()
 			local player_name = placer and placer:get_player_name() or ""
-			local creative_enabled = (creative and creative.is_enabled_for
-					and creative.is_enabled_for(player_name))
 
 			if under and under.name:find("^stairs:slab_") then
 				-- place slab using under node orientation
@@ -217,7 +215,7 @@ function stairs.register_slab(subname, recipeitem, groups, images, description,
 
 				-- else attempt to place node with proper param2
 				minetest.item_place_node(ItemStack(wield_item), placer, pointed_thing, p2)
-				if not creative_enabled then
+				if not minetest.is_creative_enabled(player_name) then
 					itemstack:take_item()
 				end
 				return itemstack


### PR DESCRIPTION
Why are mods still dependent on the standard `creative` mod, which also adds inventory that is not used by almost any Minetest server?
The new `minetest.is_creative_enabled` API was added about half a year ago.
It should be used to reduce unnecessary mod dependency.