### PR TITLE
Add missing nodes to list

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -230,7 +230,7 @@ default:brick
 
 default:meselamp
 default:mese_post_light
-default:mese_post_light_acacia
+default:mese_post_light_acacia_wood
 default:mese_post_light_junglewood
 default:mese_post_light_pine_wood
 default:mese_post_light_aspen_wood

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -180,12 +180,12 @@ default:sand_with_kelp
 Corals
 ------
 
-default:coral_brown
-default:coral_orange
-default:coral_skeleton
 default:coral_green
 default:coral_pink
 default:coral_cyan
+default:coral_brown
+default:coral_orange
+default:coral_skeleton
 
 Liquids
 -------

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -183,6 +183,9 @@ Corals
 default:coral_brown
 default:coral_orange
 default:coral_skeleton
+default:coral_green
+default:coral_pink
+default:coral_cyan
 
 Liquids
 -------
@@ -214,6 +217,12 @@ default:fence_junglewood
 default:fence_pine_wood
 default:fence_aspen_wood
 
+default:fence_rail_wood
+default:fence_rail_acacia_wood
+default:fence_rail_junglewood
+default:fence_rail_pine_wood
+default:fence_rail_aspen_wood
+
 default:glass
 default:obsidian_glass
 
@@ -221,7 +230,7 @@ default:brick
 
 default:meselamp
 default:mese_post_light
-default:mese_post_light_acacia_wood
+default:mese_post_light_acacia
 default:mese_post_light_junglewood
 default:mese_post_light_pine_wood
 default:mese_post_light_aspen_wood


### PR DESCRIPTION
Closes: #2766 

Checked for `default` mod only (using a script; I never do this manually xD)

Also, a side issue;
```
default:mese_post_light
default:mese_post_light_acacia
default:mese_post_light_junglewood
default:mese_post_light_pine_wood
default:mese_post_light_aspen_wood
```

Notice the problem? Mese post acacia seems to be registered without ending in `_wood`.

Seems I made a mistake :/
https://github.com/minetest/minetest_game/pull/2599/files#diff-76ce8b84a7dab4aab70af96a5e5abe413a9d04b675ae2320ba4f725536aaebe8R2848
(EDIT: Fixed by #2800)