### PR TITLE
mtg_craftguide: fix nil error

### DIFF
--- a/mods/mtg_craftguide/init.lua
+++ b/mods/mtg_craftguide/init.lua
@@ -410,7 +410,7 @@ minetest.register_on_joinplayer(function(player)
 		filter = "",
 		pagenum = 1,
 		items = init_items,
-		lang_code = info.lang_code
+		lang_code = info and info.lang_code or "en"
 	}
 end)
 


### PR DESCRIPTION
Fixes: "ERROR[Main]: ServerError: AsyncErr: ServerThread::run Lua: Runtime error from /home/xanadu/.minetest/mods/mtg_craftguide/init.lua:412: attempt to index local 'info' (a nil value)"

It seems that some 5.x clients cause a "[Server]: static int ModApiServer::l_get_player_information(lua_state*): peer was not found" issue and cause nil to be returned for the player information fields.