### PR TITLE
Stairs: fix rotation on place

### DIFF
--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -22,32 +22,6 @@ minetest.register_alias("stairs:slab_pinewood", "stairs:slab_pine_wood")
 
 local replace = minetest.settings:get_bool("enable_stairs_replace_abm")
 
-local function rotate_and_place(itemstack, placer, pointed_thing)
-	local p0 = pointed_thing.under
-	local p1 = pointed_thing.above
-	local param2 = 0
-
-	if placer then
-		local placer_pos = placer:get_pos()
-		if placer_pos then
-			param2 = minetest.dir_to_facedir(vector.subtract(p1, placer_pos))
-		end
-
-		local finepos = minetest.pointed_thing_to_face_pos(placer, pointed_thing)
-		local fpos = finepos.y % 1
-
-		if p0.y - 1 == p1.y or (fpos > 0 and fpos < 0.5)
-				or (fpos < -0.5 and fpos > -0.999999999) then
-			param2 = param2 + 20
-			if param2 == 21 then
-				param2 = 23
-			elseif param2 == 23 then
-				param2 = 21
-			end
-		end
-	end
-	return minetest.item_place(itemstack, placer, pointed_thing, param2)
-end
 
 local function warn_if_exists(nodename)
 	if minetest.registered_nodes[nodename] then
@@ -103,10 +77,10 @@ function stairs.register_stair(subname, recipeitem, groups, images, description,
 		},
 		on_place = function(itemstack, placer, pointed_thing)
 			if pointed_thing.type ~= "node" then
-				return itemstack
+				return itemstack, nil
 			end
 
-			return rotate_and_place(itemstack, placer, pointed_thing)
+			return minetest.rotate_node(itemstack, placer, pointed_thing)
 		end,
 	})
 
@@ -194,34 +168,11 @@ function stairs.register_slab(subname, recipeitem, groups, images, description,
 			fixed = {-0.5, -0.5, -0.5, 0.5, 0, 0.5},
 		},
 		on_place = function(itemstack, placer, pointed_thing)
-			local under = minetest.get_node(pointed_thing.under)
-			local wield_item = itemstack:get_name()
-			local player_name = placer and placer:get_player_name() or ""
-
-			if under and under.name:find("^stairs:slab_") then
-				-- place slab using under node orientation
-				local dir = minetest.dir_to_facedir(vector.subtract(
-					pointed_thing.above, pointed_thing.under), true)
-
-				local p2 = under.param2
-
-				-- Placing a slab on an upside down slab should make it right-side up.
-				if p2 >= 20 and dir == 8 then
-					p2 = p2 - 20
-				-- same for the opposite case: slab below normal slab
-				elseif p2 <= 3 and dir == 4 then
-					p2 = p2 + 20
-				end
-
-				-- else attempt to place node with proper param2
-				minetest.item_place_node(ItemStack(wield_item), placer, pointed_thing, p2)
-				if not minetest.is_creative_enabled(player_name) then
-					itemstack:take_item()
-				end
-				return itemstack
-			else
-				return rotate_and_place(itemstack, placer, pointed_thing)
+			if pointed_thing.type ~= "node" then
+				return itemstack, nil
 			end
+
+			return minetest.rotate_node(itemstack, placer, pointed_thing)
 		end,
 	})
 
@@ -343,10 +294,10 @@ function stairs.register_stair_inner(subname, recipeitem, groups, images,
 		},
 		on_place = function(itemstack, placer, pointed_thing)
 			if pointed_thing.type ~= "node" then
-				return itemstack
+				return itemstack, nil
 			end
 
-			return rotate_and_place(itemstack, placer, pointed_thing)
+			return minetest.rotate_node(itemstack, placer, pointed_thing)
 		end,
 	})
 
@@ -429,10 +380,10 @@ function stairs.register_stair_outer(subname, recipeitem, groups, images,
 		},
 		on_place = function(itemstack, placer, pointed_thing)
 			if pointed_thing.type ~= "node" then
-				return itemstack
+				return itemstack, nil
 			end
 
-			return rotate_and_place(itemstack, placer, pointed_thing)
+			return minetest.rotate_node(itemstack, placer, pointed_thing)
 		end,
 	})
 


### PR DESCRIPTION
For example. slabs should placed vertically when places on a "wall".    
    
    use builtin \`rotate_node()\`:
    
    - so, use internal \`core.is_creative_enabled\`
    - fix rotation on stairs & slabs place
    - fix double \"take_item\" in creative mode
