### PR TITLE
bucket should be loaded after protection mod

### DIFF
--- a/mods/bucket/mod.conf
+++ b/mods/bucket/mod.conf
@@ -1,4 +1,4 @@
 name = bucket
 description = Minetest Game mod: bucket
 depends = default
-optional_depends = dungeon_loot
+optional_depends = dungeon_loot, areas


### PR DESCRIPTION
maybe bucket should be loaded after the protection mod e.g. areas is loaded.
otherwise protection may not work correctly?