### PR TITLE
mtg_craftguide: Fix incorrect item tooltips

### DIFF
--- a/mods/mtg_craftguide/init.lua
+++ b/mods/mtg_craftguide/init.lua
@@ -242,11 +242,13 @@ local function recipe_fs(fs, data)
 	for i, item in pairs(recipe.items) do
 		local x, y = coords(i - 1, width)
 
+		local elem_name = item
 		local groups = extract_groups(item)
 		if groups then
 			item = groups_to_item(groups)
+			elem_name = esc(item.."."..table.concat(groups, "+"))
 		end
-		item_button_fs(fs, base_x + x, base_y + y, item, item, groups)
+		item_button_fs(fs, base_x + x, base_y + y, item, elem_name, groups)
 	end
 
 	if shapeless or recipe.method == "cooking" then
@@ -378,7 +380,7 @@ local function on_receive_fields(player, fields)
 		local item
 		for field in pairs(fields) do
 			if field:find(":") then
-				item = field
+				item = field:match("[%w_:]+")
 				break
 			end
 		end


### PR DESCRIPTION
This happened when the same item was visible twice and one of them was a
group item. Fix it by ensuring that buttons that should have different
tooltips don't have the same element name.

Bug reported in #2836.