### PR TITLE
Reclassify some items

### DIFF
--- a/mods/binoculars/init.lua
+++ b/mods/binoculars/init.lua
@@ -53,6 +53,7 @@ minetest.register_craftitem("binoculars:binoculars", {
 	description = S("Binoculars") .. "\n" .. S("Use with 'Zoom' key"),
 	inventory_image = "binoculars_binoculars.png",
 	stack_max = 1,
+	groups = {tool = 1},
 
 	on_use = function(itemstack, user, pointed_thing)
 		binoculars.update_player_property(user)

--- a/mods/map/init.lua
+++ b/mods/map/init.lua
@@ -51,7 +51,7 @@ minetest.register_craftitem("map:mapping_kit", {
 	description = S("Mapping Kit") .. "\n" .. S("Use with 'Minimap' key"),
 	inventory_image = "map_mapping_kit.png",
 	stack_max = 1,
-	groups = {flammable = 3},
+	groups = {flammable = 3, tool = 1},
 
 	on_use = function(itemstack, user, pointed_thing)
 		map.update_hud_flags(user)


### PR DESCRIPTION
Related to #2848

Assigns groups to items to make them appear in the relevant crafting tab instead of their current tab.

This PR is 'WIP' in the case that more items/nodes want to be modified.