### PR TITLE
Use group for mushroom spread ABM

### DIFF
--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -248,7 +248,7 @@ end
 
 minetest.register_abm({
 	label = "Mushroom spread",
-	nodenames = {"flowers:mushroom_brown", "flowers:mushroom_red"},
+	nodenames = {"group:mushroom"},
 	interval = 11,
 	chance = 150,
 	action = function(...)


### PR DESCRIPTION
Have mushroom spread abm use group:mushroom to spread, not only default red and brown but all defined shrooms.