### PR TITLE
Attachments: Proper data cleanup in callbacks

### DIFF
--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -53,10 +53,9 @@ function boat.on_rightclick(self, clicker)
 	end
 	local name = clicker:get_player_name()
 	if self.driver and name == self.driver then
-		self.driver = nil
-		self.auto = false
+		-- Cleanup happens in boat.on_detach_child
 		clicker:set_detach()
-		player_api.player_attached[name] = false
+
 		player_api.set_animation(clicker, "stand" , 30)
 		local pos = clicker:get_pos()
 		pos = {x = pos.x, y = pos.y + 0.2, z = pos.z}
@@ -64,14 +63,6 @@ function boat.on_rightclick(self, clicker)
 			clicker:set_pos(pos)
 		end)
 	elseif not self.driver then
-		local attach = clicker:get_attach()
-		if attach and attach:get_luaentity() then
-			local luaentity = attach:get_luaentity()
-			if luaentity.driver then
-				luaentity.driver = nil
-			end
-			clicker:set_detach()
-		end
 		self.driver = name
 		clicker:set_attach(self.object, "",
 			{x = 0.5, y = 1, z = -3}, {x = 0, y = 0, z = 0})
@@ -86,6 +77,9 @@ end
 
 -- If driver leaves server while driving boat
 function boat.on_detach_child(self, child)
+	if child and child:get_player_name() == self.driver then
+		player_api.player_attached[child:get_player_name()] = false
+	end
 	self.driver = nil
 	self.auto = false
 end

--- a/mods/carts/cart_entity.lua
+++ b/mods/carts/cart_entity.lua
@@ -66,9 +66,9 @@ end
 -- 0.5.x and later: When the driver leaves
 function cart_entity:on_detach_child(child)
 	if child and child:get_player_name() == self.driver then
-		self.driver = nil
 		carts:manage_attachment(child, nil)
 	end
+	self.driver = nil
 end
 
 function cart_entity:on_punch(puncher, time_from_last_punch, tool_capabilities, direction)

--- a/mods/carts/functions.lua
+++ b/mods/carts/functions.lua
@@ -12,7 +12,7 @@ function carts:manage_attachment(player, obj)
 	end
 	local status = obj ~= nil
 	local player_name = player:get_player_name()
-	if player_api.player_attached[player_name] == status then
+	if player:get_attach() == obj then
 		return
 	end
 	player_api.player_attached[player_name] = status


### PR DESCRIPTION
Counterpart to https://github.com/minetest/minetest/pull/11181 to fix https://github.com/minetest/minetest_game/issues/2864

This avoids data being overwritten in `on_detach_child` callbacks after calling to `on_attach` from another entity/mod.

## To do

This PR is Ready for Review.

## How to test

1. Place a MTG cart
2. Place a MTG boat
3. Rightclick one and the other, switch between them and observe the eye and attachment positions
