### PR TITLE
Check for required engine features on startup

### DIFF
--- a/mods/default/init.lua
+++ b/mods/default/init.lua
@@ -12,6 +12,20 @@ default = {}
 default.LIGHT_MAX = 14
 default.get_translator = S
 
+-- Check for engine features required by MTG
+-- This provides clear error behaviour when MTG is newer than the installed engine
+-- and avoids obscure, hard to debug runtime errors.
+-- This section should be updated before release and older checks can be dropped
+-- when newer ones are introduced.
+if not minetest.is_creative_enabled or not minetest.has_feature({
+		direct_velocity_on_players = true,
+		use_texture_alpha_string_modes = true,
+	}) then
+	error("\nThis version of Minetest Game is incompatible with your engine version "..
+		"(which is too old). You should download a version of Minetest Game that "..
+		"matches the installed engine version.\n")
+end
+
 -- GUI related stuff
 minetest.register_on_joinplayer(function(player)
 	-- Set formspec prepend


### PR DESCRIPTION
<pre>
&lt;sfan5> MTG should check minetest.features on startup, people using mtg 5.4.0 with engine 5.3.0 causes errors that don't make sense are hard to debug and generally wasted time
&lt;sfan5> this is probably the fifth time that I look at an user report and have to tell that that MTG/engine versions need to match
</pre>