### PR TITLE
Use itemstack name in door on_place

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -264,6 +264,7 @@ function doors.register(name, def)
 				return itemstack
 			end
 
+			local doorname = itemstack:get_name()
 			local node = minetest.get_node(pointed_thing.under)
 			local pdef = minetest.registered_nodes[node.name]
 			if pdef and pdef.on_rightclick and
@@ -315,10 +316,10 @@ function doors.register(name, def)
 			local state = 0
 			if minetest.get_item_group(minetest.get_node(aside).name, "door") == 1 then
 				state = state + 2
-				minetest.set_node(pos, {name = name .. "_b", param2 = dir})
+				minetest.set_node(pos, {name = doorname .. "_b", param2 = dir})
 				minetest.set_node(above, {name = "doors:hidden", param2 = (dir + 3) % 4})
 			else
-				minetest.set_node(pos, {name = name .. "_a", param2 = dir})
+				minetest.set_node(pos, {name = doorname .. "_a", param2 = dir})
 				minetest.set_node(above, {name = "doors:hidden", param2 = dir})
 			end
 


### PR DESCRIPTION
This will allow me to have a single door item that places different door nodes depending on the player or pointed_thing

Example semi-pseudocode usage in a CaptureTheFlag context:
```lua
local old_on_place = minetest.registered_craftitems["ctf_teams:door_steel"].on_place
minetest.override_item("ctf_teams:door_steel", {
	on_place = function(itemstack, placer, pointed_thing)
		if placer_in_team then
			local newitemstack = ItemStack("ctf_teams:door_steel_"..placer_team)
			newitemstack:set_count(itemstack:get_count())

			itemstack:set_count(old_on_place(newitemstack, placer, pointed_thing):get_count())

			return itemstack
		end

		return old_on_place(itemstack, placer, pointed_thing)
	end
})
```

(I can already change what the door nodes drop pretty easily)