### PR TITLE
beds: add option bed_night_skip_above_percent & enable_bed_in_the_daytime

### DIFF
--- a/mods/beds/README.txt
+++ b/mods/beds/README.txt
@@ -19,12 +19,18 @@ This mod adds a bed to Minetest which allows players to skip the night.
 To sleep, right click on the bed. If playing in singleplayer mode the night gets skipped
 immediately. If playing multiplayer you get shown how many other players are in bed too,
 if all players are sleeping the night gets skipped. The night skip can be forced if more
-than half of the players are lying in bed and use this option.
+than 50 percent of the players are lying in bed and use this option. You can change the
+percent value by setting "bed_night_skip_above_percent = <n>" in minetest.conf.
+
 
 Another feature is a controlled respawning. If you have slept in bed (not just lying in
 it) your respawn point is set to the beds location and you will respawn there after
 death.
+
 You can disable the respawn at beds by setting "enable_bed_respawn = false" in
 minetest.conf.
 You can disable the night skip feature by setting "enable_bed_night_skip = false" in
 minetest.conf or by using the /set command in-game.
+
+You can enable the bed in the daytime by setting "enable_bed_in_the_daytime = yes" in
+minetest.conf. Then the players stay in bed.


### PR DESCRIPTION
adds option `bed_night_skip_above_percent` <0> .. <99> (default: 50 - previously fixed coded value)

With this it is now possible to configure the number of players (in percent) who have to lie in bed at night in order to be able to force skip the night (option `enable_bed_night_skip`)

adds option `enable_bed_in_the_daytime` {true | false} (default: false)

When this option is enabled
- Players can also go to bed in daylight.
- If a player is still in bed between 9:00 and 18:00, the prompt 'Wake Up!' appears. However, this can be ignored;)
- after waking up (in the morning) the player remains lying down and must explicitly 'get out of bed'
This option is useful on survival servers because you can lie down during AFK and possibly not block `enable_bed_night_skip`