### PR TITLE
Prevent blocking of fuel inventory by fuel replacement.

### DIFF
--- a/mods/default/furnace.lua
+++ b/mods/default/furnace.lua
@@ -177,8 +177,15 @@ local function furnace_node_timer(pos, elapsed)
 					fuel_totaltime = 0
 					src_time = 0
 				else
-					-- Take fuel from fuel list
-					inv:set_stack("fuel", 1, afterfuel.items[1])
+					-- prevent blocking of fuel inventory (for automatization mods)
+					local is_fuel = minetest.get_craft_result({method = "fuel", width = 1, items = {afterfuel.items[1]:to_string()}})
+					if is_fuel.time == 0 then
+						table.insert(fuel.replacements, afterfuel.items[1])
+						inv:set_stack("fuel", 1, "")
+					else
+						-- Take fuel from fuel list
+						inv:set_stack("fuel", 1, afterfuel.items[1])
+					end
 					-- Put replacements in dst list or drop them on the furnace.
 					local replacements = fuel.replacements
 					if replacements[1] then


### PR DESCRIPTION
There is a problem when using fuel with replacements in the furnace. It can cause a block of fuel inventory, if some automatization mod is used (Hopper for example). 

https://user-images.githubusercontent.com/17455197/130919277-639ea41a-cda0-4bf8-a6ee-10622b2defcb.mp4

https://user-images.githubusercontent.com/17455197/130919269-688505a7-8cde-404f-a83f-2b29098d62f5.mp4

Tested with biofuel mod branch [sfence_vessels_magament_6ad39ec](https://github.com/sfence/Biofuel/tree/sfence_vessels_magament_6ad39ec) and [hopper](https://content.minetest.net/packages/FaceDeer/hopper/)

