### PR TITLE
Override local_animation settings for certain animations

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -462,6 +462,12 @@ The player API can register player models and update the player's appearance.
 	* `player`: PlayerRef
 	* `textures`: array of textures. If nil, the default from the model def is used
 
+* `player_api.set_textures(player, index, texture)`
+	* Sets one of the player textures
+	* `player`: PlayerRef
+	* `index`: Index into array of all textures
+	* `texture`: the texture string
+
 * `player_api.get_animation(player)`
 	* Returns a table containing fields `model`, `textures` and `animation`
 	* Any of the fields of the returned table may be nil
@@ -480,7 +486,14 @@ The player API can register player models and update the player's appearance.
 		animation_speed = 30,           -- Default animation speed, in keyframes per second
 		textures = {"character.png"},   -- Default array of textures
 		animations = {
-			-- [anim_name] = {x = <start_frame>, y = <end_frame>, collisionbox = model collisionbox, eye_height = model eye height},
+			-- [anim_name] = {
+			--   x = <start_frame>,
+			--   y = <end_frame>,
+			--   collisionbox = <model collisionbox>, -- (optional)
+			--   eye_height = <model eye height>,     -- (optional)
+			--   -- suspend client side animations while this one is active (optional)
+			--   override_local = <true/false>
+			-- },
 			stand = ..., lay = ..., walk = ..., mine = ..., walk_mine = ..., -- required animations
 			sit = ... -- used by boats and other MTG mods
 		},

--- a/mods/player_api/init.lua
+++ b/mods/player_api/init.lua
@@ -7,11 +7,13 @@ player_api.register_model("character.b3d", {
 	animations = {
 		-- Standard animations.
 		stand     = {x = 0,   y = 79},
-		lay       = {x = 162, y = 166, collisionbox = {-0.6, 0.0, -0.6, 0.6, 0.3, 0.6}, eye_height = 0.3},
+		lay       = {x = 162, y = 166, eye_height = 0.3, override_local = true,
+			collisionbox = {-0.6, 0.0, -0.6, 0.6, 0.3, 0.6}},
 		walk      = {x = 168, y = 187},
 		mine      = {x = 189, y = 198},
 		walk_mine = {x = 200, y = 219},
-		sit       = {x = 81,  y = 160, collisionbox = {-0.3, 0.0, -0.3, 0.3, 1.0, 0.3}, eye_height = 0.8}
+		sit       = {x = 81,  y = 160, eye_height = 0.8, override_local = true,
+			collisionbox = {-0.3, 0.0, -0.3, 0.3, 1.0, 0.3}}
 	},
 	collisionbox = {-0.3, 0.0, -0.3, 0.3, 1.7, 0.3},
 	stepheight = 0.6,


### PR DESCRIPTION
This makes the lay/sit animation work on the local client (in third-person).