### PR TITLE
Removal of incorrect node (chests mod)

### DIFF
--- a/mods/default/chests.lua
+++ b/mods/default/chests.lua
@@ -20,6 +20,9 @@ function default.chest.chest_lid_obstructed(pos)
 	local above = {x = pos.x, y = pos.y + 1, z = pos.z}
 	local def = minetest.registered_nodes[minetest.get_node(above).name]
 	-- allow ladders, signs, wallmounted things and torches to not obstruct
+	if def.drawtype == "mesh" then
+		minetest.remove_node(above)
+	end
 	if def and
 			(def.drawtype == "airlike" or
 			def.drawtype == "signlike" or


### PR DESCRIPTION
After the network failure, my chest stopped opening normally, but there is access to its inventory. Above the node of the chest was formed incorrect node. This hotfix deletes an invalid node and the chest again begins to work normally.

def.drawtype == chest, - non airlike