### PR TITLE
player_api: Fix crash for players without model

### DIFF
--- a/mods/player_api/api.lua
+++ b/mods/player_api/api.lua
@@ -182,7 +182,7 @@ minetest.register_globalstep(function()
 	for _, player in pairs(minetest.get_connected_players()) do
 		local name = player:get_player_name()
 		local player_data = players[name]
-		local model = models[player_data.model]
+		local model = player_data and models[player_data.model]
 		if model and not player_attached[name] then
 			local controls = player:get_player_control()
 			local animation_speed_mod = model.animation_speed or 30


### PR DESCRIPTION
Indexing the `nil` value `player_api` pretty much instantly (next globalstep) triggered a crash if a player did not have data. This wasn't the case before my redo so I now restore compat.