### PR TITLE
Add support for dynamic shadows

### DIFF
--- a/mods/weather/init.lua
+++ b/mods/weather/init.lua
@@ -110,7 +110,7 @@ local function update_clouds()
 				), 2),
 			speed = {x = n_speedx * 4, z = n_speedz * 4},
 		})
-		if weather.shadows_enabled then
+		if weather.shadows_enabled and player.set_lighting ~= nil then
 			player:set_lighting({shadows = { intensity = 0.5 - density / 2.0} })
 		end
 	end

--- a/mods/weather/init.lua
+++ b/mods/weather/init.lua
@@ -6,6 +6,10 @@ if mg_name == "v6" or mg_name == "singlenode" or
 	return
 end
 
+-- Public behavior flags
+weather = {
+	shadows_enabled = true,
+}
 
 -- Parameters
 
@@ -106,7 +110,9 @@ local function update_clouds()
 				), 2),
 			speed = {x = n_speedx * 4, z = n_speedz * 4},
 		})
-		player:set_lighting({shadows = { intensity = 0.5 - density / 2.0} })
+		if weather.shadows_enabled then
+			player:set_lighting({shadows = { intensity = 0.5 - density / 2.0} })
+		end
 	end
 end
 

--- a/mods/weather/init.lua
+++ b/mods/weather/init.lua
@@ -96,15 +96,17 @@ local function update_clouds()
 		-- density_max = 0.8 at humid = 50.
 		-- density_max = 1.35 at humid = 100.
 		local density_max = 0.8 + ((humid - 50) / 50) * 0.55
+		local density = rangelim(density_max, 0.2, 1.0) * n_density
 		player:set_clouds({
 			-- Range limit density_max to always have occasional
 			-- small scattered clouds at extreme low humidity.
-			density = rangelim(density_max, 0.2, 1.0) * n_density,
+			density = density,
 			thickness = math.max(math.floor(
 				rangelim(32 * humid / 100, 8, 32) * n_thickness
 				), 2),
 			speed = {x = n_speedx * 4, z = n_speedz * 4},
 		})
+		player:set_lighting({shadows = { intensity = 0.5 - density / 2.0} })
 	end
 end
 


### PR DESCRIPTION
This PR adds control of shadow intensity and links it to cloud density. It uses `set_lighting` API that is introduced in minetest/minetest#11944.

Behavior is controlled by `weather.shadows_enabled` flag, so that downstream games can disable default behavior if it does not apply.

PR is also compatible with Minetest engine versions without `set_lighting` API.

## Testing

1. Switch to minetest/minetest#11944
2. Enable dynamic shadows in the client
3. Start MTG with any world
4. Observe the shadows
5. Shadow intensity is lowest in biomes with high humidity (and high loud density), e.g. mountains/snow, and shadows have the highest intensity in dry biomes with few clouds, e.g. desert.
