### PR TITLE
default:ladder: Fix placing ladder on each other

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -2651,6 +2651,7 @@ minetest.register_node("default:ladder_wood", {
 	walkable = false,
 	climbable = true,
 	is_ground_content = false,
+	buildable_to = true,
 	selection_box = {
 		type = "wallmounted",
 		--wall_top = = <default>
@@ -2674,6 +2675,7 @@ minetest.register_node("default:ladder_steel", {
 	walkable = false,
 	climbable = true,
 	is_ground_content = false,
+	buildable_to = true,
 	selection_box = {
 		type = "wallmounted",
 		--wall_top = = <default>


### PR DESCRIPTION
When the ladder is placed, it is ofter happened unnatural duplicate ladder (see attached screenshot
![Wrong-ladder-placement](https://user-images.githubusercontent.com/8199062/159364292-f4e40857-b534-45b6-814c-2eaeee510b55.png)

by enabling `buildable_to` it is no longer possible to break ladder in that way.