### PR TITLE
Adjust shadow intensity based on cloud density.

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -72,6 +72,6 @@ default:torch 99,default:cobble 99
 # Helps rivers create more sound, especially on level sections.
 #river_source_sounds = false
 
-# Enable cloud variation by the 'weather' mod.
+# Enable cloud and shadow intensity variation by the 'weather' mod.
 # Non-functional in V6 or Singlenode mapgens.
 #enable_weather = true

--- a/mods/weather/init.lua
+++ b/mods/weather/init.lua
@@ -1,11 +1,18 @@
 -- Disable by mapgen or setting
 
 local mg_name = minetest.get_mapgen_setting("mg_name")
-if mg_name == "v6" or mg_name == "singlenode" or
-		minetest.settings:get_bool("enable_weather") == false then
+if minetest.settings:get_bool("enable_weather") == false then
 	return
 end
 
+if mg_name == "v6" or mg_name == "singlenode" then
+	-- set a default shadow intensity for mgv6 and singlenode
+	minetest.register_on_joinplayer(function(player)
+		player:set_lighting({ shadows = { intensity = 0.33 } })
+	end)
+
+	return
+end
 
 -- Parameters
 
@@ -96,15 +103,18 @@ local function update_clouds()
 		-- density_max = 0.8 at humid = 50.
 		-- density_max = 1.35 at humid = 100.
 		local density_max = 0.8 + ((humid - 50) / 50) * 0.55
+		local density = rangelim(density_max, 0.2, 1.0) * n_density
 		player:set_clouds({
 			-- Range limit density_max to always have occasional
 			-- small scattered clouds at extreme low humidity.
-			density = rangelim(density_max, 0.2, 1.0) * n_density,
+			density = density,
 			thickness = math.max(math.floor(
 				rangelim(32 * humid / 100, 8, 32) * n_thickness
 				), 2),
 			speed = {x = n_speedx * 4, z = n_speedz * 4},
 		})
+		-- now adjust the shadow intensity
+		player:set_lighting({ shadows = { intensity = 0.7 * (1 - density) } })
 	end
 end
 

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -72,6 +72,6 @@ engine_spawn (Use engine spawn search) bool false
 #    Helps rivers create more sound, especially on level sections.
 river_source_sounds (River source node sounds) bool false
 
-#    Enable cloud variation by the 'weather' mod.
+#    Enable cloud and shadow intensity variation by the 'weather' mod.
 #    Non-functional in V6 or Singlenode mapgens.
 enable_weather (Enable weather) bool true


### PR DESCRIPTION
Now that https://github.com/minetest/minetest/pull/11944 is merged, we can use that in minetest_game to set the shadow intensity automatically based on the cloud density.

Shadow intensity becomes as much a game emergence feature as clouds.