### PR TITLE
Fix incorrectly negated comparisons

### DIFF
--- a/mods/carts/cart_entity.lua
+++ b/mods/carts/cart_entity.lua
@@ -398,7 +398,7 @@ minetest.register_craftitem("carts:cart", {
 				pointed_thing) or itemstack
 		end
 
-		if not pointed_thing.type == "node" then
+		if pointed_thing.type ~= "node" then
 			return
 		end
 		if carts:is_rail(pointed_thing.under) then

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -260,7 +260,7 @@ function doors.register(name, def)
 		on_place = function(itemstack, placer, pointed_thing)
 			local pos
 
-			if not pointed_thing.type == "node" then
+			if pointed_thing.type ~= "node" then
 				return itemstack
 			end
 


### PR DESCRIPTION
Comparing `(not pointed_thing.type)` - a boolean - against a string will always yield `false`. The intention is clear; this PR fixes the bug. Fixes https://github.com/minetest/minetest_game/issues/2939.
