### PR TITLE
TNT node drop particles: Only pick string tiles as fallback

### DIFF
--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -243,9 +243,9 @@ local function add_effects(pos, radius, drops)
 			local def = minetest.registered_nodes[name]
 			if def then
 				node = { name = name }
-			end
-			if def and def.tiles and def.tiles[1] then
-				texture = def.tiles[1]
+				if def.tiles and type(def.tiles[1]) == "string" then
+					texture = def.tiles[1]
+				end
 			end
 		end
 	end


### PR DESCRIPTION
Fixes #2945 by simply checking whether the tile is a `string`.

More complex tile types (see https://github.com/minetest/minetest/blob/master/doc/lua_api.txt#L7544-L7564) could be supported (in particular colorized tiles are equivalent to `tex^[multiply:color`); for animations, an arbitrary frame could be picked, but this complexity isn't really worth it as the code's current intention appears to be only a rough approximation of the dropped node texture as a fallback for older clients.
