### PR TITLE
Mapgen: Don't clear biomes, decorations and ores

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -2476,9 +2476,6 @@ end
 -- Detect mapgen to select functions
 --
 
-minetest.clear_registered_biomes()
-minetest.clear_registered_ores()
-minetest.clear_registered_decorations()
 
 local mg_name = minetest.get_mapgen_setting("mg_name")
 


### PR DESCRIPTION
I might be unaware of the intention behind this clearing, but for *vanilla MTG it should be a no-op* as nothing is registered before. For modded MTG however this had the potential to *silently unregister the biomes, decorations and ores of mods that don't depend on default and are thus loaded before it*.
For decorations and ores in particular this should most likely not be done; for biomes I don't see the point either, but there *might be a point I'm missing*.

`git blame` yields https://github.com/minetest/minetest_game/commit/2e950ac6 which provides no reason for the clearings either. @paramat please explain.