### PR TITLE
Fix furnace fire sound stopping too late

### DIFF
--- a/mods/default/furnace.lua
+++ b/mods/default/furnace.lua
@@ -99,7 +99,7 @@ local function stop_furnace_sound(pos, fadeout_step)
 	local sound_ids = furnace_fire_sounds[hash]
 	if sound_ids then
 		for _, sound_id in ipairs(sound_ids) do
-			minetest.sound_fade(sound_ids, -1, 0)
+			minetest.sound_fade(sound_id, -1, 0)
 		end
 		furnace_fire_sounds[hash] = nil
 	end
@@ -276,6 +276,21 @@ local function furnace_node_timer(pos, elapsed)
 			if #furnace_fire_sounds[hash] > 3 then
 				table.remove(furnace_fire_sounds[hash], 1)
 			end
+			-- Remove the sound ID automatically from table after 11 seconds
+			minetest.after(11, function(t)
+				if not furnace_fire_sounds[t.hash] then
+					return
+				end
+				for f=#furnace_fire_sounds[t.hash], 1, -1 do
+					if furnace_fire_sounds[t.hash][f] == t.sound_id then
+						minetest.log("error", "remove_after:"..t.sound_id)
+						table.remove(furnace_fire_sounds[t.hash], f)
+					end
+				end
+				if #furnace_fire_sounds[t.hash] == 0 then
+					furnace_fire_sounds[t.hash] = nil
+				end
+			end, {sound_id=sound_id, hash=hash})
 		end
 	else
 		if fuellist and not fuellist[1]:is_empty() then

--- a/mods/default/furnace.lua
+++ b/mods/default/furnace.lua
@@ -98,8 +98,8 @@ local function stop_furnace_sound(pos, fadeout_step)
 	local hash = minetest.hash_node_position(pos)
 	local sound_ids = furnace_fire_sounds[hash]
 	if sound_ids then
-		for s=1, #sound_ids do
-			minetest.sound_fade(sound_ids[s], -1, 0)
+		for _, sound_id in ipairs(sound_ids) do
+			minetest.sound_fade(sound_ids, -1, 0)
 		end
 		furnace_fire_sounds[hash] = nil
 	end
@@ -270,14 +270,11 @@ local function furnace_node_timer(pos, elapsed)
 			local sound_id = minetest.sound_play("default_furnace_active",
 				{pos = pos, max_hear_distance = 16, gain = 0.25})
 			local hash = minetest.hash_node_position(pos)
-			if not furnace_fire_sounds[hash] then
-				furnace_fire_sounds[hash] = { sound_id }
-			else
-				table.insert(furnace_fire_sounds[hash], sound_id)
-				-- Only remember the 3 last sound handles
-				if #furnace_fire_sounds[hash] > 3 then
-					table.remove(furnace_fire_sounds[hash], 1)
-				end
+			furnace_fire_sounds[hash] = furnace_fire_sounds[hash] or {}
+			table.insert(furnace_fire_sounds[hash], sound_id)
+			-- Only remember the 3 last sound handles
+			if #furnace_fire_sounds[hash] > 3 then
+				table.remove(furnace_fire_sounds[hash], 1)
 			end
 		end
 	else

--- a/mods/default/furnace.lua
+++ b/mods/default/furnace.lua
@@ -277,20 +277,19 @@ local function furnace_node_timer(pos, elapsed)
 				table.remove(furnace_fire_sounds[hash], 1)
 			end
 			-- Remove the sound ID automatically from table after 11 seconds
-			minetest.after(11, function(t)
-				if not furnace_fire_sounds[t.hash] then
+			minetest.after(11, function()
+				if not furnace_fire_sounds[hash] then
 					return
 				end
-				for f=#furnace_fire_sounds[t.hash], 1, -1 do
-					if furnace_fire_sounds[t.hash][f] == t.sound_id then
-						minetest.log("error", "remove_after:"..t.sound_id)
-						table.remove(furnace_fire_sounds[t.hash], f)
+				for f=#furnace_fire_sounds[hash], 1, -1 do
+					if furnace_fire_sounds[hash][f] == sound_id then
+						table.remove(furnace_fire_sounds[hash], f)
 					end
 				end
-				if #furnace_fire_sounds[t.hash] == 0 then
-					furnace_fire_sounds[t.hash] = nil
+				if #furnace_fire_sounds[hash] == 0 then
+					furnace_fire_sounds[hash] = nil
 				end
-			end, {sound_id=sound_id, hash=hash})
+			end)
 		end
 	else
 		if fuellist and not fuellist[1]:is_empty() then


### PR DESCRIPTION
Partial fix of #2836 (this is a monster issue with multiple issues in one). This will be fixed:

> The furnace sound doesn't stop once the fire stops, but continues for a few seconds

This PR does the following:

When the furnace fire goes out, or when the `default:furnace_active` node destructs, the fire sound fade out. Because fire sounds can overlap (the sound effect is 10 seconds long, and is repeated every 5 seconds), the table that holds the sound handles needs to hold multiple sound handles for the same node at once (up to 3). When the sound needs to be stopped, `minetest.sound_fade` is called for every remembered sound handle of that node, then sets the table entry to `nil`.
I chose `sound_fade` rather than `sound_stop` because it sounds nicer.

How to test:

Test 1: Place a furnace. Activate it. Dig it while the fire is still burning.
Test 2: Place a furnace. Activate it and let the flame go out.

Expected: The fire sound should quickly fade out.
Previous buggy behavior: The fire sound continues to play for about 5 to 10 seconds.