### PR TITLE
Use add_wear_by_uses to fix incorrect uses counts

### DIFF
--- a/mods/farming/api.lua
+++ b/mods/farming/api.lua
@@ -66,7 +66,7 @@ farming.hoe_on_use = function(itemstack, user, pointed_thing, uses)
 	if not minetest.is_creative_enabled(player_name) then
 		-- wear tool
 		local wdef = itemstack:get_definition()
-		itemstack:add_wear(65535/(uses-1))
+		itemstack:add_wear_by_uses(uses)
 		-- tool break sound
 		if itemstack:get_count() == 0 and wdef.sound and wdef.sound.breaks then
 			minetest.sound_play(wdef.sound.breaks, {pos = pt.above,

--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -114,7 +114,7 @@ minetest.register_tool("fire:flint_and_steel", {
 		if not minetest.is_creative_enabled(player_name) then
 			-- Wear tool
 			local wdef = itemstack:get_definition()
-			itemstack:add_wear(1000)
+			itemstack:add_wear_by_uses(66)
 
 			-- Tool break sound
 			if itemstack:get_count() == 0 and wdef.sound and wdef.sound.breaks then

--- a/mods/fireflies/init.lua
+++ b/mods/fireflies/init.lua
@@ -108,7 +108,7 @@ minetest.register_tool("fireflies:bug_net", {
 			end
 		end
 		if not minetest.is_creative_enabled(player_name) then
-			itemstack:add_wear(256)
+			itemstack:add_wear_by_uses(256)
 			return itemstack
 		end
 	end

--- a/mods/screwdriver/init.lua
+++ b/mods/screwdriver/init.lua
@@ -141,7 +141,7 @@ screwdriver.handler = function(itemstack, user, pointed_thing, mode, uses)
 	end
 
 	if not minetest.is_creative_enabled(player_name) then
-		itemstack:add_wear(65535 / ((uses or 200) - 1))
+		itemstack:add_wear_by_uses(uses or 200)
 	end
 
 	return itemstack


### PR DESCRIPTION
Fixes #2929.

This replaces the `add_wear` calls by the more modern `add_wear_by_uses` calls which allows to specify the uses count directly. Since this method ensures the correct uses count, it will fix the hoe uses count being slightly off.

Note: The effective uses count of bug net, screwdriver and flint and steel will not change, this is more for consistency.
For example: For flint and steel, adding 1000 wear every time (the old method) is equivalent to 66 uses because with the 66th use, wear would be 66000, which is above 65535. You can do similar calculations for bug net and screwdriver.