### PR TITLE
Don't check protection of air when placing bones

### DIFF
--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -224,7 +224,7 @@ minetest.register_on_dieplayer(function(player)
 	-- check if it's possible to place bones, if not find space near player
 	if bones_mode == "bones" and not may_replace(pos, player) then
 		local air = minetest.find_node_near(pos, 1, {"air"})
-		if air and not minetest.is_protected(air, player_name) then
+		if air then
 			pos = air
 		else
 			bones_mode = "drop"


### PR DESCRIPTION
It doesn't make sense to check the protection of air nodes, and it makes bone placement fail more often.