### PR TITLE
Bed bug fix: Remove "reverse" toggle in favor of swap_node/set_node combo

### DIFF
--- a/mods/beds/api.lua
+++ b/mods/beds/api.lua
@@ -10,11 +10,11 @@ local function destruct_bed(pos, n)
 		local dir = minetest.facedir_to_dir(node.param2)
 		other = vector.add(pos, dir)
 	end
-	local odef = minetest.registered_nodes[minetest.get_node(other).name]
-	if odef.groups.bed > 0 then
-	   --swap node leaves meta, but doesn't call destruct_bed again
-	   minetest.swap_node(other, { name = "air" })
-	   minetest.set_node(other, { name = "air" }) -- now clear the meta
+	local oname = minetest.get_node(other).name
+	if minetest.get_item_group(oname, "bed") ~= 0 then
+	   -- Swap node leaves meta, but doesn't call destruct_bed again
+	   minetest.swap_node(other, {name = "air"})
+	   minetest.remove_node(other) -- Now clear the meta
 	   minetest.check_for_falling(other)
 	   beds.remove_spawns_at(pos)
 	   beds.remove_spawns_at(other)

--- a/mods/beds/api.lua
+++ b/mods/beds/api.lua
@@ -1,6 +1,4 @@
 
-local reverse = true
-
 local function destruct_bed(pos, n)
 	local node = minetest.get_node(pos)
 	local other
@@ -12,15 +10,14 @@ local function destruct_bed(pos, n)
 		local dir = minetest.facedir_to_dir(node.param2)
 		other = vector.add(pos, dir)
 	end
-
-	if reverse then
-		reverse = not reverse
-		minetest.remove_node(other)
-		minetest.check_for_falling(other)
-		beds.remove_spawns_at(pos)
-		beds.remove_spawns_at(other)
-	else
-		reverse = not reverse
+	local odef = minetest.registered_nodes[minetest.get_node(other).name]
+	if odef.groups.bed > 0 then
+	   --swap node leaves meta, but doesn't call destruct_bed again
+	   minetest.swap_node(other, { name = "air" })
+	   minetest.set_node(other, { name = "air" }) -- now clear the meta
+	   minetest.check_for_falling(other)
+	   beds.remove_spawns_at(pos)
+	   beds.remove_spawns_at(other)
 	end
 end
 


### PR DESCRIPTION
This is a code change intended to fix the elusive "half-bed" bug. I've never been able to reproduce this in a controlled manner, but I've seen it on servers and heard about it for years.
 Unable to recreate this bug to study it, I instead scrutinized the logic of beds/api.lua and found a likely culprit in the "reverse" toggle. It's intended to ensure that when a bed top is destroyed, it removes the bottom, but that the bottom doesn't subsequently try to take out another node when its own destruct_bed is called. A measure to prevent chain reactions, it would appear, and a sensible one at first glance.

 The trouble seems to be that this is not multiplayer aware and requires a strict order to the destruction of beds: top->bottom->top->bottom. (or vice versa if it the bottom is destroyed somehow)
 If two people were to destroy beds on a server on the same server tick (and I believe lag will make this more likely), that order could end up as top->top->bottom->bottom. Each bed top could trip the singular "reverse" toggle on and then off, before either of the bed bottoms are destroyed, at which point you get two destroyed tops and only one destroyed bottom, and the toggle left in the on state to cause another bed to split if the server isn't restarted before that.

 This fix eliminates the suspect reverse toggle entirely. Now bed halves destroy their mates via swap_node (which doesn't call on_destruct) and set_node to then clear any metadata (such as ownership) that would be destroyed by the old method.
 This patch has been running on Land of Catastrophe for two months and I have had no reports of half beds appearing in that time.