### PR TITLE
Make default an optional dependency for the creative mod

### DIFF
--- a/mods/creative/mod.conf
+++ b/mods/creative/mod.conf
@@ -1,3 +1,4 @@
 name = creative
 description = Minetest Game mod: creative
-depends = default, sfinv
+depends = sfinv
+optional_depends = default


### PR DESCRIPTION
The creative mod in Minetest Game only depends on default for overriding the hand to dig faster. This means the `default` dependency can be made optional without any issues, making it game-agnostic and able to be dropped into any game written from scratch which does not use `default`. (given that the game doesn't override sfinv with its own inventory)

Testing steps:
- Check so that the hand still behaves properly in creative in Minetest Game. (digs any nodes fast)
- Drop `creative` and `sfinv` into [Void](https://content.minetest.net/packages/Linuxdirk/void/) and see that it works without any changes:

![image](https://user-images.githubusercontent.com/60856959/185159806-d1f1958a-68c1-4d5b-a7d4-6db631adb5b2.png)