### PR TITLE
Add color_* groups to wool

### DIFF
--- a/mods/wool/init.lua
+++ b/mods/wool/init.lua
@@ -8,19 +8,21 @@ local dyes = dye.dyes
 for i = 1, #dyes do
 	local name, desc = unpack(dyes[i])
 
+	local color_group = "color_" .. name
+
 	minetest.register_node("wool:" .. name, {
 		description = S(desc .. " Wool"),
 		tiles = {"wool_" .. name .. ".png"},
 		is_ground_content = false,
 		groups = {snappy = 2, choppy = 2, oddly_breakable_by_hand = 3,
-				flammable = 3, wool = 1},
+				flammable = 3, wool = 1, [color_group] = 1},
 		sounds = default.node_sound_defaults(),
 	})
 
 	minetest.register_craft{
 		type = "shapeless",
 		output = "wool:" .. name,
-		recipe = {"group:dye,color_" .. name, "group:wool"},
+		recipe = {"group:dye," .. color_group, "group:wool"},
 	}
 end
 


### PR DESCRIPTION
This should allow mod authors to use `group:wool,color_something` in their recipes, allowing for easier game-agnostic recipes. It also makes wool consistent with dyes.