### PR TITLE
Teach screwdriver to rotate 4dir nodes

### DIFF
--- a/mods/screwdriver/init.lua
+++ b/mods/screwdriver/init.lua
@@ -60,6 +60,19 @@ end
 
 screwdriver.rotate.colorfacedir = screwdriver.rotate.facedir
 
+screwdriver.rotate["4dir"] = function(pos, node, mode)
+	if mode ~= screwdriver.ROTATE_FACE then
+		-- Can only rotate 4dir nodes in face mode
+		return nil
+	end
+	local rotation = node.param2 % 4 -- get first 2 bits
+	local other = node.param2 - rotation
+	rotation = (rotation + 1) % 4
+	return rotation + other
+end
+
+screwdriver.rotate["color4dir"] = screwdriver.rotate["4dir"]
+
 local wallmounted_tbl = {
 	[screwdriver.ROTATE_FACE] = {[2] = 5, [3] = 4, [4] = 2, [5] = 3, [1] = 0, [0] = 1},
 	[screwdriver.ROTATE_AXIS] = {[2] = 5, [3] = 4, [4] = 2, [5] = 1, [1] = 0, [0] = 3}
@@ -113,6 +126,10 @@ screwdriver.handler = function(itemstack, user, pointed_thing, mode, uses)
 	local new_param2
 	if fn then
 		new_param2 = fn(pos, node, mode)
+		if not new_param2 then
+			-- rotation refused
+			return itemstack
+		end
 	else
 		new_param2 = node.param2
 	end


### PR DESCRIPTION
The `4dir` and `color4dir` paramtype2s are pretty new, and the MTG screwdriver did not support them yet.

This PR teaches the screwdriver to rotate `4dir` and `color4dir` nodes. Previously, the screwdriver ignored these.
If you use the punch key ("face rotation") on a 4dir node, it will be rotated one step to the left, just like with facedir nodes.

The "axis rotation" (place key) does nothing and does not wear out the screwdriver, because 4dir always "rotates" around one axis. This behavior was chosen so the screwdriver is consistent with facedir rotation behavior.

## How to test

Use this test node:

```
minetest.register_node("test_4dir:4dir", {
	description = "4dir Test Node",
	paramtype2 = "4dir",
	tiles = {
		"default_furnace_top.png", "default_furnace_bottom.png",
		"default_furnace_side.png", "default_furnace_side.png",
		"default_furnace_side.png", "default_furnace_front.png"
	},
	groups = { dig_immediate = 3 },
	color = "yellow",
})
```

1. Add this code in a new mod named `test_4dir` in your `mods` directory and start MTG with it (disable Creative Mode)
2. Give yourself `test_4dir:4dir` and a `screwdriver:screwdriver`
3. Place the test node
4. Use the screwdriver on it with the punch key (expected: the node rotates to the left and screwdriver wears out)
5. Use the screwdriver on it with the placement key (expected: nothing happens, no wear out)
6. Test the screwdriver on various other nodes at will to make sure nothing else was broken