### PR TITLE
sethome: Fix error if `/home` is executed from irc, discord, etc

### DIFF
--- a/mods/sethome/init.lua
+++ b/mods/sethome/init.lua
@@ -52,6 +52,9 @@ end
 
 sethome.get = function(name)
 	local player = minetest.get_player_by_name(name)
+	if not player then
+		return nil
+	end
 	local player_meta = player:get_meta()
 	local pos = minetest.string_to_pos(player_meta:get_string("sethome:home"))
 	if pos then

--- a/mods/sethome/init.lua
+++ b/mods/sethome/init.lua
@@ -89,6 +89,10 @@ minetest.register_chatcommand("home", {
 	description = S("Teleport you to your home point"),
 	privs = {home = true},
 	func = function(name)
+		local player = minetest.get_player_by_name(name)
+		if not player then
+			return false, "This command can be executed in-game only"
+		end
 		if sethome.go(name) then
 			return true, S("Teleported to home!")
 		end

--- a/mods/sethome/init.lua
+++ b/mods/sethome/init.lua
@@ -91,7 +91,7 @@ minetest.register_chatcommand("home", {
 	func = function(name)
 		local player = minetest.get_player_by_name(name)
 		if not player then
-			return false, "This command can be executed in-game only"
+			return false, S("This command can be executed in-game only!")
 		end
 		if sethome.go(name) then
 			return true, S("Teleported to home!")

--- a/mods/sethome/init.lua
+++ b/mods/sethome/init.lua
@@ -53,7 +53,7 @@ end
 sethome.get = function(name)
 	local player = minetest.get_player_by_name(name)
 	if not player then
-		return nil
+		return false, S("This command can only be executed in-game!")
 	end
 	local player_meta = player:get_meta()
 	local pos = minetest.string_to_pos(player_meta:get_string("sethome:home"))
@@ -91,7 +91,7 @@ minetest.register_chatcommand("home", {
 	func = function(name)
 		local player = minetest.get_player_by_name(name)
 		if not player then
-			return false, S("This command can be executed in-game only!")
+			return false, S("This command can only be executed in-game!")
 		end
 		if sethome.go(name) then
 			return true, S("Teleported to home!")

--- a/mods/sethome/locale/sethome.ru.tr
+++ b/mods/sethome/locale/sethome.ru.tr
@@ -6,3 +6,4 @@ Set a home using /sethome=Установите домашнюю точку, ис
 Set your home point=Установите вашу домашнюю точку
 Home set!=Домашняя точка установлена!
 Player not found!=Игрок не обнаружен!
+This command can be executed in-game only!=Эта команда может быть использована только в игре!


### PR DESCRIPTION
Running `/home` by any player in the remote chat utilities(for example IRC, discordmt) was crashing the server if the player with the same name is not on the server.
This bug can be abused on a popular servers if the owners are not experienced enough to fix it themselves