### PR TITLE
No more buggy entities

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -542,7 +542,7 @@ function default.register_ores()
 		clust_scarcity  = 16 * 16 * 16,
 		clust_size      = 5,
 		y_max           = 31000,
-		y_min           = -31000,
+		y_min           = -30000,
 		noise_threshold = 0.0,
 		noise_params    = {
 			offset = 0.5,
@@ -588,7 +588,7 @@ function default.register_ores()
 		clust_scarcity  = 16 * 16 * 16,
 		clust_size      = 5,
 		y_max           = 31000,
-		y_min           = -31000,
+		y_min           = -30000,
 		noise_threshold = 0.0,
 		noise_params    = {
 			offset = 0.5,


### PR DESCRIPTION
I have done this so that the falling nodes gravel and silver sand do not fall into the ignore when a player mistakenly punches them at the bottommost limit.

This is what happened when I mistakenly punched it.
![screenshot_20221228_124920](https://user-images.githubusercontent.com/96172170/209774124-d2a51918-82ba-406b-af5d-2b309be49bd6.png)

Please do not take this as a feature but rather as a maintenance.