### PR TITLE
Clear animation data when appearance is updated

### DIFF
--- a/mods/player_api/api.lua
+++ b/mods/player_api/api.lua
@@ -71,6 +71,10 @@ function player_api.set_model(player, model_name)
 
 	local model = models[model_name]
 	if model then
+		if (model.animations) then
+			player_data.animation = nil
+			player_data.animation_speed = nil
+		}
 		player:set_properties({
 			mesh = model_name,
 			textures = player_data.textures or model.textures,


### PR DESCRIPTION
Discord/#modding

*nil — Today at 8:33 AM
```lua
    if player_data.animation == anim_name and player_data.animation_speed == speed then
        return
    end
```
this check doesn't check whether the model has changed
so you get an early return because it's the same anim with the same speed, but the model has changed

*nil — Today at 8:35 AM
player_data.animation and player_data.animation_speed ought to be cleared in set_model
I'll patch this after lunch

nocwiz — Today at 8:41 AM
Confirmed working