### PR TITLE
Fix `player_api.set_model` not updating the animation

### DIFF
--- a/mods/player_api/api.lua
+++ b/mods/player_api/api.lua
@@ -67,7 +67,11 @@ function player_api.set_model(player, model_name)
 	if player_data.model == model_name then
 		return
 	end
+	-- Update data
 	player_data.model = model_name
+	-- Clear animation data as the model has changed
+	-- (required for setting the `stand` animation not to be a no-op)
+	player_data.animation, player_data.animation_speed = nil, nil
 
 	local model = models[model_name]
 	if model then


### PR DESCRIPTION
Bug reported by @nocturnalwizard. The previous code exhibited the following bug:

1. `character.b3d` gets set as model, the stand animation is played
2. `custom.b3d` gets set; `player_api` tries to set the `stand` animation, but since the animation name & speed are the same this is a no-op and the early return is triggered