### PR TITLE
Implement API to disable weather

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -1147,3 +1147,36 @@ the log.
    that log corresponding actions
  * `def`     See [Node definition]
  * `name`    Description of the node in the log message
+
+
+Weather API
+-------
+
+The weather API allows you to enable / disable weather effects programmatically
+and also to modify weather effects before they are applied to the player.
+
+`weather.is_enabled()`
+
+* Returns true if weather mod is enabled or false if disabled
+* Will return false regardless of whether the mod has been disabled via the settings or via `set_enabled`.
+* Will return true even if selected worldgen doesn't support cloud updates. This is the case for v6 and singlenode types.
+
+`weather.set_enabled(enable)`
+
+* `enable` Boolean. Set to `true` to enable weather globally or `false` to disable it.
+* Setting this to `false` is only advised if you want to disable the weather effects __permanently__ and for every player.
+  Re-enabling effects later on will work but might conflict with other mods doing the same.
+  Override `weather.on_update` if you want to disable temporarily or need a higher level of control.
+* If the `enable_weather` setting is set to `false` in minetest.conf then this function will __not__ do nothing.
+
+`weather.on_update(player, overrides)`
+
+* Override this function to manipulate weather effects before they are applied to the player.
+* Calling this function on its own will do nothing. You have to override it in order to modify its behavior.
+* `player` The player entity that is about to be updated
+* `overrides` Defines which changes are about to be made. It is a table consisting of the following values:
+  * `overrides.clouds` A table (or `nil`) with cloud data following the same format as used for `player:set_clouds()`.
+  * `overrides.lighting` A table (or `nil`) with lighting data following the same format as used for `player:set_lighting()`.
+* This function is expected to return a table in the same format as `overrides`.
+  When overriding this function, the return value will be applied to the player instead of the original values.
+  Setting `clouds` or `lighting` to `nil` will __prevent__ that table from getting updated.

--- a/game_api.txt
+++ b/game_api.txt
@@ -1167,9 +1167,9 @@ and also to modify weather effects before they are applied to the player.
 * Setting this to `false` is only advised if you want to disable the weather effects __permanently__ and for every player.
   Re-enabling effects later on will work but might conflict with other mods doing the same.
   Override `weather.on_update` if you want to disable temporarily or need a higher level of control.
-* If the `enable_weather` setting is set to `false` in minetest.conf then this function will __not__ do nothing.
+* If the `enable_weather` setting is set to `false` in minetest.conf then this function will not do anything.
 
-`weather.on_update(player, overrides)`
+`weather.on_update = function(player, overrides)`
 
 * Override this function to manipulate weather effects before they are applied to the player.
 * Calling this function on its own will do nothing. You have to override it in order to modify its behavior.

--- a/mods/weather/init.lua
+++ b/mods/weather/init.lua
@@ -69,8 +69,8 @@ local os_time_0 = os.time()
 local t_offset = math.random(0, 300000)
 
 -- set a default shadow intensity for mgv6 and singlenode
-local function set_default_lighting(playerset)
-	for playername, _ in pairs(playerset) do
+local function set_default_lighting(players)
+	for playername, _ in pairs(players) do
 		local player = minetest.get_player_by_name(playername)
 		player:set_lighting({
 			shadows = { intensity = 0.33 }
@@ -78,10 +78,10 @@ local function set_default_lighting(playerset)
 	end
 end
 
-local function update_weather(playerset)
+local function update_weather(players)
 	-- skip cloud randomization if worldgen not supported
 	if not randomize_clouds then
-		set_default_lighting(playerset)
+		set_default_lighting(players)
 		return
 	end
 	-- Time in seconds.
@@ -98,7 +98,7 @@ local function update_weather(playerset)
 	local n_speedx = nobj_speedx:get_2d({x = time, y = 0}) -- -1 to 1
 	local n_speedz = nobj_speedz:get_2d({x = time, y = 0}) -- -1 to 1
 
-	for playername, _ in pairs(playerset) do
+	for playername, _ in pairs(players) do
 		local player = minetest.get_player_by_name(playername)
 		-- Fallback to mid-value 50 for very old worlds
 		local humid = minetest.get_humidity(player:get_pos()) or 50

--- a/mods/weather/init.lua
+++ b/mods/weather/init.lua
@@ -74,7 +74,7 @@ local function set_default_lighting(players)
 		local lighting = {
 			shadows = { intensity = 0.33 }
 		}
-		local overrides = weather.on_update(player, { lighting })
+		local overrides = weather.on_update(player, { lighting = lighting })
 		if overrides.lighting ~= nil then
 			player:set_lighting(overrides.lighting)
 		end

--- a/mods/weather/init.lua
+++ b/mods/weather/init.lua
@@ -125,7 +125,7 @@ local function update_weather(players)
 			shadows = { intensity = 0.7 * (1 - density) }
 		}
 		-- check for API overrides and then apply
-		local overrides = weather.on_update(player, { clouds, lighting })
+		local overrides = weather.on_update(player, { clouds = clouds, lighting = lighting })
 		if overrides ~= nil and overrides.clouds ~= nil then
 			player:set_clouds(overrides.clouds)
 		end

--- a/mods/weather/init.lua
+++ b/mods/weather/init.lua
@@ -137,7 +137,7 @@ end
 
 -- Update clouds periodically for all players
 
-local timer = nil
+local timer
 local function cyclic_update()
 	local players = minetest.get_connected_players()
 	update_weather(players)

--- a/mods/weather/init.lua
+++ b/mods/weather/init.lua
@@ -116,7 +116,7 @@ local function update_weather(players)
 			-- small scattered clouds at extreme low humidity.
 			density = density,
 			thickness = math.max(math.floor(
-				rangelim(32 * humid / 100, 8, 32) * n_thickness
+					rangelim(32 * humid / 100, 8, 32) * n_thickness
 				), 2),
 			speed = {x = n_speedx * 4, z = n_speedz * 4},
 		}
@@ -155,14 +155,12 @@ local function purge_effects()
 	-- reset changed player tables to default values
 	for _, player in ipairs(minetest.get_connected_players()) do
 		if randomize_clouds then
-		player:set_clouds({})
-	end
-	-- NOTE: set_lighting doesn't allow empty table to reset
-	player:set_lighting({
-		shadows = {
-			intensity = 0
-		}
-	})
+			player:set_clouds({})
+		end
+		-- NOTE: set_lighting doesn't allow empty table to reset
+		player:set_lighting({
+			shadows = { intensity = 0 }
+		})
 	end
 end
 
@@ -185,7 +183,7 @@ end
 weather.set_enabled = function(enable)
 	if enable and not is_enabled then
 		-- restart stopped update cycle
-	cyclic_update()
+		cyclic_update()
 	elseif not enable and is_enabled then
 		-- stop update cycle and remove effects
 		purge_effects()

--- a/mods/weather/init.lua
+++ b/mods/weather/init.lua
@@ -1,21 +1,12 @@
--- Disable by mapgen or setting
-
+-- Check whether mod should be active
 local mg_name = minetest.get_mapgen_setting("mg_name")
-if minetest.settings:get_bool("enable_weather") == false then
-	return
-end
+local mod_enabled = minetest.settings:get_bool("enable_weather", true)
+local randomize_clouds = mod_enabled and mg_name ~= "v6" and mg_name ~= "singlenode"
 
-if mg_name == "v6" or mg_name == "singlenode" then
-	-- set a default shadow intensity for mgv6 and singlenode
-	minetest.register_on_joinplayer(function(player)
-		player:set_lighting({ shadows = { intensity = 0.33 } })
-	end)
-
-	return
-end
+weather = {}
+local playerlist = {}
 
 -- Parameters
-
 local TSCALE = 600 -- Time scale of noise variation in seconds
 local CYCLE = 8 -- Time period of cyclic clouds update in seconds
 
@@ -61,14 +52,12 @@ local np_speedz = {
 
 -- End parameters
 
-
 -- Initialise noise objects to nil
 
 local nobj_density = nil
 local nobj_thickness = nil
 local nobj_speedx = nil
 local nobj_speedz = nil
-
 
 -- Update clouds function
 
@@ -79,7 +68,7 @@ end
 local os_time_0 = os.time()
 local t_offset = math.random(0, 300000)
 
-local function update_clouds()
+local function update_clouds(players)
 	-- Time in seconds.
 	-- Add random time offset to avoid identical behaviour each server session.
 	local time = os.difftime(os.time(), os_time_0) - t_offset
@@ -94,7 +83,7 @@ local function update_clouds()
 	local n_speedx = nobj_speedx:get_2d({x = time, y = 0}) -- -1 to 1
 	local n_speedz = nobj_speedz:get_2d({x = time, y = 0}) -- -1 to 1
 
-	for _, player in ipairs(minetest.get_connected_players()) do
+	for _, player in ipairs(players) do
 		-- Fallback to mid-value 50 for very old worlds
 		local humid = minetest.get_humidity(player:get_pos()) or 50
 		-- Default and classic density value is 0.4, make this happen
@@ -114,22 +103,93 @@ local function update_clouds()
 			speed = {x = n_speedx * 4, z = n_speedz * 4},
 		})
 		-- now adjust the shadow intensity
-		player:set_lighting({ shadows = { intensity = 0.7 * (1 - density) } })
+		player:set_lighting({
+			shadows = { intensity = 0.7 * (1 - density) }
+		})
 	end
 end
 
-
-local function cyclic_update()
-	update_clouds()
-	minetest.after(CYCLE, cyclic_update)
+local function purge_effects(player)
+	-- reset potentially touched values to their defaults
+	if randomize_clouds then
+		player:set_clouds({
+			density = 0.4,
+			thickness = 16,
+			speed = { x = 0, z = -2 }
+		})
+	end
+	player:set_lighting({
+		shadows = { intensity = 0 }
+	})
 end
 
+-- Define API hooks
 
-minetest.after(0, cyclic_update)
+-- override to set state for newly joined players
+weather.enable_on_join = true
 
+-- returns bool for whether weather is active
+-- returns nil if player is offline or weather is disabled
+weather.get_enabled = function(player)
+	return playerlist[player]
+end
+
+-- override weather generation for individual player
+weather.set_enabled = function(player, enable)
+	if enable == playerlist[player] then
+		return
+	end
+	playerlist[player] = enable
+	if enable then
+		if randomize_clouds then
+			update_clouds({player})
+		end
+	else
+		purge_effects(player)
+	end
+end
+
+-- End API hooks
+
+-- skip event registration if mod is disabled
+if not mod_enabled then
+	return
+end
+
+if update_clouds then
+	local function cyclic_update()
+		local players = {}
+		for player, state in pairs(playerlist) do
+			if state then
+				table.insert(players, player)
+			end
+		end
+		update_clouds(players)
+		minetest.after(CYCLE, cyclic_update)
+	end
+	minetest.after(0, cyclic_update)
+end
 
 -- Update on player join to instantly alter clouds from the default
 
 minetest.register_on_joinplayer(function(player)
-	update_clouds()
+	if weather.enable_on_join then
+		playerlist[player] = true
+		if randomize_clouds then
+			update_clouds({player})
+		else
+			-- set a default shadow intensity for mgv6 and singlenode
+			player:set_lighting({
+				shadows = {
+					intensity = 0.33
+				}
+			})
+		end
+	else
+		playerlist[player] = false
+	end
+end)
+
+minetest.register_on_leaveplayer(function(player)
+	table.remove(player)
 end)

--- a/mods/weather/init.lua
+++ b/mods/weather/init.lua
@@ -191,5 +191,5 @@ minetest.register_on_joinplayer(function(player)
 end)
 
 minetest.register_on_leaveplayer(function(player)
-	table.remove(player)
+	playerlist[player] = nil
 end)

--- a/mods/weather/init.lua
+++ b/mods/weather/init.lua
@@ -153,17 +153,17 @@ local function purge_effects()
 		timer = nil
 	end
 	-- reset changed player tables to default values
-    for _, player in ipairs(minetest.get_connected_players()) do
-        if randomize_clouds then
-            player:set_clouds({})
-        end
-        -- NOTE: set_lighting doesn't allow empty table to reset
-        player:set_lighting({
-            shadows = {
-                intensity = 0
-            }
-        })
-    end
+	for _, player in ipairs(minetest.get_connected_players()) do
+		if randomize_clouds then
+		player:set_clouds({})
+	end
+	-- NOTE: set_lighting doesn't allow empty table to reset
+	player:set_lighting({
+		shadows = {
+			intensity = 0
+		}
+	})
+	end
 end
 
 
@@ -179,22 +179,22 @@ end)
 
 local is_enabled = true
 weather.is_enabled = function()
-    return settings_enabled and is_enabled
+	return settings_enabled and is_enabled
 end
 
 weather.set_enabled = function(enable)
-    if enable and not is_enabled then
+	if enable and not is_enabled then
 		-- restart stopped update cycle
-        cyclic_update()
+	cyclic_update()
 	elseif not enable and is_enabled then
 		-- stop update cycle and remove effects
 		purge_effects()
 	end
-    is_enabled = enable
+	is_enabled = enable
 end
 
 weather.on_update = function(player, overrides)
-    return overrides
+	return overrides
 end
 
 -- End API definition


### PR DESCRIPTION
I implemented an API for the weather mod. This resolves #2913 .

This is not a new feature per se, it is designed to enable compatibility between MTG and weather mods that add other effects to the sky or lighting. See the respective issue for the discussion.

This also reduces the amount of flashing due to clouds updating. When a new player joins, the sky will no longer be immediately recalculated for everyone but only for the new player.

The new API methods are exposed through a global `weather` object and are as follows:
```lua
-- returns bool for whether weather is active
weather.is_enabled()

-- enables / disables weather globally.
-- Has no effect if enable_weather == false in minetest.conf
-- If disabled, completely stops update cycle and reset every player to default values
weather.set_enabled(enable)

-- Most important part of this PR
-- Allows for overriding this function
-- Passes player object and tables that are about to be updated
-- Return values determine actual update to player object
-- Returning nil values for a table prevents it from getting updated
weather.on_update = function(player, { clouds, lighting })
```

Edit: Updated this post in line with redesign. Previous iteration suggested a `set_enable` function per-player instead of the `on_update`.

Tested on Minetest 5.6.1 and 5.7.0 RC1