### PR TITLE
Fix syntax errors in bones.sv.tr

### DIFF
--- a/mods/bones/locale/bones.sv.tr
+++ b/mods/bones/locale/bones.sv.tr
@@ -1,8 +1,8 @@
 # textdomain: bones
 Bones=Ben
 @1's old bones=@1s Gamla ben
-@1 died at @2.=@1 dog på @a.
-@1 died at @2, and dropped their inventory.=@1 dog på @a, och tappade deras saker.
+@1 died at @2.=@1 dog på @2.
+@1 died at @2, and dropped their inventory.=@1 dog på @2, och tappade deras saker.
 @1 died at @2, and bones were placed.=@1 dog på @2, och deras ben var placerade.
 @1's fresh bones=@1s färska ben
 @1's bones=@1s ben


### PR DESCRIPTION
I've found technical syntax errors in the translation file `bones.sv.tr`. The `@2` symbol accidentally became an `@a` in the translations.

Disclaimer: I do not speak Swedish but since I am only touching symbols, this should be fine.