### PR TITLE
Validate & sanitize formspec fields

### DIFF
--- a/mods/creative/inventory.lua
+++ b/mods/creative/inventory.lua
@@ -196,7 +196,7 @@ function creative.register_tab(name, title, items)
 					and fields.creative_filter then
 				inv.start_i = 0
 				inv.filter = fields.creative_filter:sub(1, 128) -- truncate to a sane length
-						:gsub("[%z-\8\11-\31\127]", "") -- strip naughty control characters (keeps \t and \n)
+						:gsub("[%z\1-\8\11-\31\127]", "") -- strip naughty control characters (keeps \t and \n)
 						:lower() -- search is case insensitive
 				sfinv.set_player_inventory_formspec(player, context)
 			elseif not fields.quit then

--- a/mods/creative/inventory.lua
+++ b/mods/creative/inventory.lua
@@ -191,10 +191,13 @@ function creative.register_tab(name, title, items)
 				inv.start_i = 0
 				inv.filter = ""
 				sfinv.set_player_inventory_formspec(player, context)
-			elseif fields.creative_search or
-					fields.key_enter_field == "creative_filter" then
+			elseif (fields.creative_search or
+					fields.key_enter_field == "creative_filter")
+					and fields.creative_filter then
 				inv.start_i = 0
-				inv.filter = fields.creative_filter:lower()
+				inv.filter = fields.creative_filter:sub(1, 1e3) -- truncate to a sane length
+						:gsub("[%z-\8\11-\31\127]", "") -- strip naughty control characters (keeps \t and \n)
+						:lower() -- search is case insensitive
 				sfinv.set_player_inventory_formspec(player, context)
 			elseif not fields.quit then
 				local start_i = inv.start_i or 0

--- a/mods/creative/inventory.lua
+++ b/mods/creative/inventory.lua
@@ -195,7 +195,7 @@ function creative.register_tab(name, title, items)
 					fields.key_enter_field == "creative_filter")
 					and fields.creative_filter then
 				inv.start_i = 0
-				inv.filter = fields.creative_filter:sub(1, 1e3) -- truncate to a sane length
+				inv.filter = fields.creative_filter:sub(1, 128) -- truncate to a sane length
 						:gsub("[%z-\8\11-\31\127]", "") -- strip naughty control characters (keeps \t and \n)
 						:lower() -- search is case insensitive
 				sfinv.set_player_inventory_formspec(player, context)

--- a/mods/default/craftitems.lua
+++ b/mods/default/craftitems.lua
@@ -179,7 +179,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		data.description = S("\"@1\" by @2", short_title, data.owner)
 		data.text = fields.text:sub(1, max_text_size)
 		data.text = data.text:gsub("\r\n", "\n"):gsub("\r", "\n")
-		data.text = data.text:gsub("[%z-\8\11-\31\127]", "") -- strip naughty control characters (keeps \t and \n)
+		data.text = data.text:gsub("[%z\1-\8\11-\31\127]", "") -- strip naughty control characters (keeps \t and \n)
 		data.page = 1
 		data.page_max = math.ceil((#data.text:gsub("[^\n]", "") + 1) / lpp)
 

--- a/mods/default/craftitems.lua
+++ b/mods/default/craftitems.lua
@@ -148,7 +148,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		return
 	end
 
-	if fields.close then
+	if fields.quit then
 		book_writers[player_name] = nil
 	end
 
@@ -179,6 +179,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		data.description = S("\"@1\" by @2", short_title, data.owner)
 		data.text = fields.text:sub(1, max_text_size)
 		data.text = data.text:gsub("\r\n", "\n"):gsub("\r", "\n")
+		data.text = data.text:gsub("[%z-\8\11-\31\127]", "") -- strip naughty control characters (keeps \t and \n)
 		data.page = 1
 		data.page_max = math.ceil((#data.text:gsub("[^\n]", "") + 1) / lpp)
 

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -2597,12 +2597,12 @@ local function register_sign(material, desc, def)
 			if not text then
 				return
 			end
-			if string.len(text) > 512 then
+			if #text > 512 then
 				minetest.chat_send_player(player_name, S("Text too long"))
 				return
 			end
-			default.log_player_action(sender, "wrote \"" .. text ..
-				"\" to the sign at", pos)
+			text = text:gsub("[%z-\8\11-\31\127]", "") -- strip naughty control characters (keeps \t and \n)
+			default.log_player_action(sender, ("wrote %q to the sign at"):format(text), pos)
 			local meta = minetest.get_meta(pos)
 			meta:set_string("text", text)
 

--- a/mods/mtg_craftguide/init.lua
+++ b/mods/mtg_craftguide/init.lua
@@ -345,8 +345,11 @@ local function on_receive_fields(player, fields)
 		data.items = init_items
 		return true
 
-	elseif fields.key_enter_field == "filter" or fields.search then
-		local new = fields.filter:lower()
+	elseif (fields.key_enter_field == "filter" or fields.search)
+			and fields.filter then
+		local new = fields.filter:sub(1, 1e3) -- truncate to a sane length
+				:gsub("[%z-\8\11-\31\127]", "") -- strip naughty control characters (keeps \t and \n)
+				:lower() -- search is case insensitive
 		if data.filter == new then
 			return
 		end

--- a/mods/mtg_craftguide/init.lua
+++ b/mods/mtg_craftguide/init.lua
@@ -348,7 +348,7 @@ local function on_receive_fields(player, fields)
 	elseif (fields.key_enter_field == "filter" or fields.search)
 			and fields.filter then
 		local new = fields.filter:sub(1, 128) -- truncate to a sane length
-				:gsub("[%z-\8\11-\31\127]", "") -- strip naughty control characters (keeps \t and \n)
+				:gsub("[%z\1-\8\11-\31\127]", "") -- strip naughty control characters (keeps \t and \n)
 				:lower() -- search is case insensitive
 		if data.filter == new then
 			return

--- a/mods/mtg_craftguide/init.lua
+++ b/mods/mtg_craftguide/init.lua
@@ -347,7 +347,7 @@ local function on_receive_fields(player, fields)
 
 	elseif (fields.key_enter_field == "filter" or fields.search)
 			and fields.filter then
-		local new = fields.filter:sub(1, 1e3) -- truncate to a sane length
+		local new = fields.filter:sub(1, 128) -- truncate to a sane length
 				:gsub("[%z-\8\11-\31\127]", "") -- strip naughty control characters (keeps \t and \n)
 				:lower() -- search is case insensitive
 		if data.filter == new then


### PR DESCRIPTION
@luk3yx has reported that the creative / crafting guide formspecs can be abused to trigger a crash by sending fields with a button press but `filter = nil`. He also reported that too long filter fields crash the server as well (since the escaped formspec string then exceeds the length limit).

This PR attempts to fix both by adding appropriate checks and truncating the filters. In addition, I have included stripping naughty control characters. I've gone through all field handling code, which led me to fix a bug in the books formspec field handling and to sanitize the logging of signs. See the list here:

* sfinv: Plenty of checks, seems fine.
* Beds: Doesn't seem crashable.
* Creative:
  * Clearing & pagination seem fine.
  * `fields.creative_filter` is assumed to be non-nil. This can be exploited to trigger a crash.
* Chests: Doesn't seem crashable.
* Books (`default/craftitems.lua`):
  * Should have sufficient checks following the fix of the book duplication bug.
  * Fixed what seems like a bug (there is no `fields.close`, ought to be `fields.quit`).
  * However, the text doesn't seem to be length-limited either.
  * Also, there are no checks against control characters.
* Signs (`default/nodes.lua`):
  * There is a length check (yay!)
  * There is no check against naughty characters though.
    * Problematic: Logging uses `default.log_player_action(sender, "wrote \"" .. text .. "\" to the sign at", pos)`.
      This probably allows faking log entries by inserting newlines in the text.
* Crafting Guide:
  * Same vulnerabilities as creative: Filter isn't length-limited and is assumed to be non-nil.

Note: There is some code duplication between creative and craftguide. Ideally that would be fixed by introducing a library mod as a common dependency, but that's out of scope for this PR.