### PR TITLE
fix logic error in bed rotation

### DIFF
--- a/mods/beds/api.lua
+++ b/mods/beds/api.lua
@@ -115,8 +115,8 @@ function beds.register_bed(name, def)
 			local dir = minetest.facedir_to_dir(node.param2)
 			local p = vector.add(pos, dir)
 			local node2 = minetest.get_node_or_nil(p)
-			if not node2 or not minetest.get_item_group(node2.name, "bed") == 2 or
-					not node.param2 == node2.param2 then
+			if not node2 or minetest.get_item_group(node2.name, "bed") ~= 2 or
+					node.param2 ~= node2.param2 then
 				return false
 			end
 			if minetest.is_protected(p, user:get_player_name()) then


### PR DESCRIPTION
the affected code seems intended to prevent the rotation of a bed if the "top" of the bed has been replaced or rotated. 

this was discovered by a simple script that was checking for this type of logic error. 