### PR TITLE
Add dialog when starting Minetest Game without mods

### DIFF
--- a/mods/mod_me/init.lua
+++ b/mods/mod_me/init.lua
@@ -1,0 +1,59 @@
+local S = minetest.get_translator("mod_me")
+
+-- Don't show the dialog if previously confirmed
+if minetest.settings:get_bool("minetest_game.mod_me_dismissed", false) then
+	return
+end
+
+local game_path = minetest.get_game_info().path
+
+-- Exit if extra mods are installed
+for _, name in ipairs(minetest.get_modnames()) do
+	local mod_path = minetest.get_modpath(name)
+	if mod_path:sub(1, #game_path) ~= game_path then
+		return
+	end
+end
+
+minetest.register_on_joinplayer(function(player)
+	if not minetest.is_singleplayer() and player:get_player_name() ~= minetest.settings:get("name") then
+		return
+	end
+
+	local markup = table.concat({
+		"<big>", S("Minetest Game is meant to be modded"), "</big>\n",
+		S("You've started a world with Minetest Game but you don't have any mods installed."), " ",
+		S("Minetest Game is intentionally left bare so that you can mod it how you like."),
+		"\n",
+		S("We recommend going back to the Content tab in the main menu and finding some mods."), " ",
+		S("If you don't want to have to choose mods, you can download another game from the same menu."),
+		"\n"
+	}, "")
+
+	local fs = {
+		"formspec_version[6]",
+		"size[10.666,6]",
+		"hypertext[0.375,0.375;9.916,4.14;ht;", minetest.formspec_escape(markup), "]",
+		"button_exit[0.375,4.765;4,0.86;back;", S("Exit to Menu"), "]",
+		"button_exit[6.291,4.765;4,0.86;okay;", S("Continue"), "]",
+	}
+
+	minetest.show_formspec(player:get_player_name(), "mod_me:alert", table.concat(fs, ""))
+end)
+
+
+minetest.register_on_player_receive_fields(function(player, formname, fields)
+	if formname ~= "mod_me:alert" then
+		return false
+	end
+
+	if fields.back then
+		minetest.request_shutdown("Exiting to main menu")
+		return true
+	end
+
+	if fields.okay then
+		minetest.settings:set_bool("minetest_game.mod_me_dismissed", true)
+		return true
+	end
+end)

--- a/mods/mod_me/mod.conf
+++ b/mods/mod_me/mod.conf
@@ -1,0 +1,2 @@
+name = mod_me
+description = Shows a dialog when MTG is started without third-party mods

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -78,3 +78,6 @@ enable_weather (Enable weather) bool true
 
 #    If enabled, non-player actions are logged
 log_non_player_actions (Log non-player action) bool false
+
+#    If true, the dialog when starting Minetest Game without mods won't be shown
+minetest_game.mod_me_dismissed (Minetest Game mod me dialog dismissed) bool false


### PR DESCRIPTION
Players often try out Minetest Game and are disappointed by how bare it is. This dialog educates players on the point of Minetest Game and directs them to install mods/games from the content browser

Suggestions to improve wording are welcome

![image](https://github.com/minetest/minetest_game/assets/2122943/16b9c572-e8d7-4d9f-bb77-cd2ce7dcca9d)
