### PR TITLE
Fix bookshelf infotext not updating properly

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -1142,8 +1142,9 @@ the log.
 
 `default.set_inventory_action_loggers(def, name)`
 
- * sets the callbacks `on_metadata_inventory_move`,
+ * hooks the callbacks `on_metadata_inventory_move`,
    `on_metadata_inventory_put` and `on_metadata_inventory_take`
    that log corresponding actions
+ * after logging the action, the original callback (if any) is called
  * `def`     See [Node definition]
  * `name`    Description of the node in the log message

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -744,16 +744,23 @@ function default.log_player_action(player, ...)
 	minetest.log("action",  msg)
 end
 
+local nop = function() end
 function default.set_inventory_action_loggers(def, name)
+	local on_move = def.on_metadata_inventory_move or nop
 	def.on_metadata_inventory_move = function(pos, from_list, from_index,
 			to_list, to_index, count, player)
 		default.log_player_action(player, "moves stuff in", name, "at", pos)
+		return on_move(pos, from_list, from_index, to_list, to_index, count, player)
 	end
+	local on_put = def.on_metadata_inventory_put or nop
 	def.on_metadata_inventory_put = function(pos, listname, index, stack, player)
 		default.log_player_action(player, "moves", stack:get_name(), "to", name, "at", pos)
+		return on_put(pos, listname, index, stack, player)
 	end
+	local on_take = def.on_metadata_inventory_take or nop
 	def.on_metadata_inventory_take = function(pos, listname, index, stack, player)
 		default.log_player_action(player, "takes", stack:get_name(), "from", name, "at", pos)
+		return on_take(pos, listname, index, stack, player)
 	end
 end
 

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -2549,6 +2549,12 @@ local default_bookshelf_def = {
 		end
 		return 0
 	end,
+	on_metadata_inventory_put = function(pos)
+		update_bookshelf(pos)
+	end,
+	on_metadata_inventory_take = function(pos)
+		update_bookshelf(pos)
+	end,
 	on_blast = function(pos)
 		local drops = {}
 		default.get_inventory_drops(pos, "books", drops)


### PR DESCRIPTION
Closes https://github.com/minetest/minetest_game/issues/3037. Split into two small commits (one to fix the bug, and one to prepare `default.set_inventory_action_loggers` to only hook rather than replace the callbacks).