### PR TITLE
Update bookshelf on move

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -2555,6 +2555,9 @@ local default_bookshelf_def = {
 	on_metadata_inventory_take = function(pos)
 		update_bookshelf(pos)
 	end,
+	on_metadata_inventory_move = function(pos)
+		update_bookshelf(pos)
+	end,
 	on_blast = function(pos)
 		local drops = {}
 		default.get_inventory_drops(pos, "books", drops)


### PR DESCRIPTION
Otherwise the empty book slot icon does not get replaced. Follows on from #3037 and #3038 which fixed the infotext but not this bug with the inventory icons.