### PR TITLE
close chest: don't replace a node if it's not the expected open chest

### DIFF
--- a/mods/default/chests.lua
+++ b/mods/default/chests.lua
@@ -51,7 +51,7 @@ function default.chest.chest_lid_close(pn)
 			-- the chest has already been replaced, don't try to replace what's there.
 			return
 		end
-		minetest.swap_node( pos, { name = swap, param2 = node.param2 })
+		minetest.swap_node(pos, {name = swap, param2 = node.param2})
 		minetest.sound_play(sound, {gain = 0.3, pos = pos,
 			max_hear_distance = 10}, true)
 	end)

--- a/mods/default/chests.lua
+++ b/mods/default/chests.lua
@@ -38,16 +38,23 @@ function default.chest.chest_lid_close(pn)
 
 	default.chest.open_chests[pn] = nil
 	for k, v in pairs(default.chest.open_chests) do
-		if v.pos.x == pos.x and v.pos.y == pos.y and v.pos.z == pos.z then
+		if vector.equals(v.pos, pos) then
+			-- another player is also looking at the chest
 			return true
 		end
 	end
 
 	local node = minetest.get_node(pos)
-	minetest.after(0.2, minetest.swap_node, pos, { name = swap,
-			param2 = node.param2 })
-	minetest.sound_play(sound, {gain = 0.3, pos = pos,
-		max_hear_distance = 10}, true)
+	minetest.after(0.2, function()
+		local current_node = minetest.get_node(pos)
+		if current_node.name ~= swap .. "_open" then
+			-- the chest has already been replaced, don't try to replace what's there.
+			return
+		end
+		minetest.swap_node( pos, { name = swap, param2 = node.param2 })
+		minetest.sound_play(sound, {gain = 0.3, pos = pos,
+			max_hear_distance = 10}, true)
+	end)
 end
 
 default.chest.open_chests = {}


### PR DESCRIPTION
this is similar to #3045. currently, closing a chest dialogue will replace *anything* currently at the location of the chest when the dialogue was opened, even if it's another node or air. currently this can be exploited very reliably w/ mesecons sticky pistons, but other players have reported that it can be exploited unreliably w/ tnt (even though open chests should be tnt-proof?). but in general, there's no way to guarantee that the node hasn't changed since we opened it. 