### PR TITLE
Better sapling grow system

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,6 +1,10 @@
 unused_args = false
 allow_defined_top = true
 
+globals = {
+	"default"
+}
+
 read_globals = {
 	"DIR_DELIM",
 	"minetest",

--- a/game_api.txt
+++ b/game_api.txt
@@ -1041,9 +1041,7 @@ Trees
 		{
 			can_grow = default.can_grow, -- Function called to determine whether the sapling can grow, should return a boolean 
 			on_grow_failed = default.on_grow_failed, -- Function called when the growth fails
-			grow_callback = function(pos) -- Function called when the growth has success. Conventionally, this should replace the sapling with a tree
-				default.grow_tree(pos, random(1, 4) == 1)
-			end
+			grow = function(pos) -- Function called when the growth has success. This should replace the sapling with a tree.
 		}
 	)
  * default.grow_sapling(pos)

--- a/game_api.txt
+++ b/game_api.txt
@@ -1028,6 +1028,28 @@ Trees
  * `default.grow_blueberry_bush(pos)`
   * Grows a blueberry bush at pos
 
+ * `default.on_grow_failed(pos)`
+  * Reset the node timer to 300 seconds, used as default callback when the growth of a sapling fails
+
+ * `default.sapling_growth_defs`
+  * Table that contains all the definitions for the growable saplings, see `default.register_sapling_growth`
+
+ * `default.register_sapling_growth(name, def)`
+  * Register a new sapling growth configuration. Useful to add custom sapling and trees to the game in a compact way.
+	default.register_sapling_growth(
+		"default:sapling", -- Name of the sapling
+		{
+			can_grow = default.can_grow, -- Function called to determine whether the sapling can grow, should return a boolean 
+			on_grow_failed = default.on_grow_failed, -- Function called when the growth fails
+			grow_callback = function(pos) -- Function called when the growth has success. Conventionally, this should replace the sapling with a tree
+				default.grow_tree(pos, random(1, 4) == 1)
+			end
+		}
+	)
+ * default.grow_sapling(pos)
+  * Attempt to grow a sapling at the given position. Useful as on_timer callback.
+
+
 
 Carts
 -----

--- a/game_api.txt
+++ b/game_api.txt
@@ -1044,7 +1044,8 @@ Trees
 			grow = function(pos) -- Function called when the growth has success. This should replace the sapling with a tree.
 		}
 	)
- * default.grow_sapling(pos)
+
+ * `default.grow_sapling(pos)`
   * Attempt to grow a sapling at the given position. Useful as on_timer callback.
 
 

--- a/mods/default/trees.lua
+++ b/mods/default/trees.lua
@@ -594,7 +594,7 @@ register_sapling_growth("acacia_bush_sapling", default.grow_acacia_bush)
 register_sapling_growth("pine_bush_sapling", default.grow_pine_bush)
 register_sapling_growth("emergent_jungle_sapling", default.grow_new_emergent_jungle_tree)
 
--- TODO: Is it correct for this to omit some saplings?
+-- Backwards compatibility for saplings that used to use ABMs; does not need to include newer saplings.
 minetest.register_lbm({
 	name = "default:convert_saplings_to_node_timer",
 	nodenames = {"default:sapling", "default:junglesapling",

--- a/mods/default/trees.lua
+++ b/mods/default/trees.lua
@@ -547,7 +547,7 @@ function default.grow_sapling(pos)
 	local sapling_def = default.sapling_growth_defs[node.name]
 
 	if not sapling_def then
-		minetest.log("warning", "default.grow_sapling called on undefined sapling .. " .. node.name)
+		minetest.log("warning", "default.grow_sapling called on undefined sapling " .. node.name)
 		return
 	end
 

--- a/mods/default/trees.lua
+++ b/mods/default/trees.lua
@@ -539,7 +539,6 @@ function default.register_sapling_growth(name, def)
 end
 
 function default.grow_sapling(pos)
-	local mg_name = minetest.get_mapgen_setting("mg_name")
 	local node = minetest.get_node(pos)
 	local sapling_def = default.sapling_growth_defs[node.name]
 
@@ -553,8 +552,7 @@ function default.grow_sapling(pos)
 		return
 	end
 
-	minetest.log("action", "Growing sapling " .. 
-		node.name .. " at " .. minetest.pos_to_string(pos))
+	minetest.log("action", "Growing sapling " .. node.name .. " at " .. minetest.pos_to_string(pos))
 	local grow_callback = sapling_def.grow_callback
 	if not grow_callback then
 		minetest.log("warning", "Unknown grow callback for sapling " .. node.name)


### PR DESCRIPTION
This pull requests implements the changes proposed in issue #3050 to clean the sapling growth system implemented in the default game. My modifications add a generic register_sapling_growth function that may be linked as a public API, although I am not sure this is idiomatic in the way the game is developed. A further step may be to separate the tree growing system to a separate module such that other modules may register their own trees with ease and without interacting with "default".