### PR TITLE
Fix corals and kelps duping with mesecons' sticky piston

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -2024,7 +2024,7 @@ minetest.register_node("default:sand_with_kelp", {
 		return itemstack
 	end,
 
-	after_destruct  = function(pos, oldnode)
+	after_dig_node = function(pos, oldnode, oldmetadata, digger)
 		minetest.set_node(pos, {name = "default:sand"})
 	end
 })
@@ -2099,7 +2099,7 @@ minetest.register_node("default:coral_green", {
 
 	on_place = coral_on_place,
 
-	after_destruct  = function(pos, oldnode)
+	after_dig_node = function(pos, oldnode, oldmetadata, digger)
 		minetest.set_node(pos, {name = "default:coral_skeleton"})
 	end,
 })
@@ -2130,7 +2130,7 @@ minetest.register_node("default:coral_pink", {
 
 	on_place = coral_on_place,
 
-	after_destruct  = function(pos, oldnode)
+	after_dig_node = function(pos, oldnode, oldmetadata, digger)
 		minetest.set_node(pos, {name = "default:coral_skeleton"})
 	end,
 })
@@ -2161,7 +2161,7 @@ minetest.register_node("default:coral_cyan", {
 
 	on_place = coral_on_place,
 
-	after_destruct  = function(pos, oldnode)
+	after_dig_node = function(pos, oldnode, oldmetadata, digger)
 		minetest.set_node(pos, {name = "default:coral_skeleton"})
 	end,
 })


### PR DESCRIPTION
This pull request fixes a glitch/exploit that could be used to dupe `default:coral_skeleton` and `default:sand` nodes infinitely.
### Before patch
Place mesecons' sticky piston next to cyan/green/pink coral or `default:sand_with_kelp` and switch the piston couple times. In the result, extra `default:coral_skeleton` or `default:sand` node will appear on each piston retraction.
### After patch
The cyan/green/pink corals and `default:sand_with_kelp` are moving by piston normally, without creating extra nodes.  

![screenshot1](https://github.com/minetest/minetest_game/assets/72821250/47c7e4e2-9d92-4255-9589-2c346ff79410)
![screenshot2](https://github.com/minetest/minetest_game/assets/72821250/bb136482-1a08-4f8c-9a6e-21a8267f35e9)

