### PR TITLE
Remove wearing screwdriver

### DIFF
--- a/mods/screwdriver/init.lua
+++ b/mods/screwdriver/init.lua
@@ -157,10 +157,6 @@ screwdriver.handler = function(itemstack, user, pointed_thing, mode, uses)
 		minetest.check_for_falling(pos)
 	end
 
-	if not minetest.is_creative_enabled(player_name) then
-		itemstack:add_wear_by_uses(uses or 200)
-	end
-
 	return itemstack
 end
 


### PR DESCRIPTION
The screwdriver in the game does not exist to make the game less casual, wearing for the screwdriver is the worst idea you could come up with. If a player wants to unwrap an item and doesn't want to do it manually, do you think he would want to craft 100 non-stacking screwdrivers?