### PR TITLE
Allow overriding the loop flag on `player_api.set_animation`

### DIFF
--- a/mods/player_api/api.lua
+++ b/mods/player_api/api.lua
@@ -71,7 +71,7 @@ function player_api.set_model(player, model_name)
 	player_data.model = model_name
 	-- Clear animation data as the model has changed
 	-- (required for setting the `stand` animation not to be a no-op)
-	player_data.animation, player_data.animation_speed = nil, nil
+	player_data.animation, player_data.animation_speed, player_data.animation_loop = nil, nil, nil
 
 	local model = models[model_name]
 	if model then
@@ -123,16 +123,20 @@ function player_api.set_animation(player, anim_name, speed, loop)
 		return
 	end
 	speed = speed or model.animation_speed
-	if player_data.animation == anim_name and player_data.animation_speed == speed then
-		return
-	end
 	if loop == nil then
 		loop = true
+	end
+	if player_data.animation == anim_name
+		and player_data.animation_speed == speed
+		and player_data.animation_loop == loop
+	then
+		return
 	end
 	local previous_anim = model.animations[player_data.animation] or {}
 	local anim = model.animations[anim_name]
 	player_data.animation = anim_name
 	player_data.animation_speed = speed
+	player_data.animation_loop = loop
 	-- If necessary change the local animation (only seen by the client of *that* player)
 	-- `override_local` <=> suspend local animations while this one is active
 	-- (this is basically a hack, proper engine feature needed...)

--- a/mods/player_api/api.lua
+++ b/mods/player_api/api.lua
@@ -116,7 +116,7 @@ function player_api.set_texture(player, index, texture)
 	player_api.set_textures(player, textures)
 end
 
-function player_api.set_animation(player, anim_name, speed)
+function player_api.set_animation(player, anim_name, speed, loop)
 	local player_data = get_player_data(player)
 	local model = models[player_data.model]
 	if not (model and model.animations[anim_name]) then
@@ -125,6 +125,9 @@ function player_api.set_animation(player, anim_name, speed)
 	speed = speed or model.animation_speed
 	if player_data.animation == anim_name and player_data.animation_speed == speed then
 		return
+	end
+	if loop == nil then
+		loop = true
 	end
 	local previous_anim = model.animations[player_data.animation] or {}
 	local anim = model.animations[anim_name]
@@ -146,7 +149,7 @@ function player_api.set_animation(player, anim_name, speed)
 		end
 	end
 	-- Set the animation seen by everyone else
-	player:set_animation(anim, speed, animation_blend)
+	player:set_animation(anim, speed, animation_blend, loop)
 	-- Update related properties if they changed
 	if anim._equals ~= previous_anim._equals then
 		player:set_properties({


### PR DESCRIPTION
Things added/changed:

- Allow overriding the loop flag on `player_api.set_animation`.
  - Closes #3095.
