### PR TITLE
Make bugs only pointable with Bug Net

### DIFF
--- a/mods/butterflies/init.lua
+++ b/mods/butterflies/init.lua
@@ -3,6 +3,9 @@
 -- Load support for MT game translation.
 local S = minetest.get_translator("butterflies")
 
+-- Legacy compatibility, when pointabilities don't exist, pointable is set to true.
+local pointable_compat = not minetest.features.item_specific_pointabilities
+
 -- register butterflies
 local butter_list = {
 	{"white",  S("White Butterfly")},
@@ -33,7 +36,7 @@ for i in ipairs (butter_list) do
 		sunlight_propagates = true,
 		buildable_to = true,
 		walkable = false,
-		pointable = false,
+		pointable = pointable_compat,
 		groups = {catchable = 1},
 		selection_box = {
 			type = "fixed",

--- a/mods/butterflies/init.lua
+++ b/mods/butterflies/init.lua
@@ -33,6 +33,7 @@ for i in ipairs (butter_list) do
 		sunlight_propagates = true,
 		buildable_to = true,
 		walkable = false,
+		pointable = false,
 		groups = {catchable = 1},
 		selection_box = {
 			type = "fixed",

--- a/mods/fireflies/init.lua
+++ b/mods/fireflies/init.lua
@@ -23,6 +23,7 @@ minetest.register_node("fireflies:firefly", {
 	sunlight_propagates = true,
 	buildable_to = true,
 	walkable = false,
+	pointable = false,
 	groups = {catchable = 1},
 	selection_box = {
 		type = "fixed",
@@ -91,6 +92,7 @@ minetest.register_node("fireflies:hidden_firefly", {
 minetest.register_tool("fireflies:bug_net", {
 	description = S("Bug Net"),
 	inventory_image = "fireflies_bugnet.png",
+	pointabilities = {nodes = {["group:catchable"] = true}},
 	on_use = function(itemstack, player, pointed_thing)
 		local player_name = player and player:get_player_name() or ""
 		if not pointed_thing or pointed_thing.type ~= "node" or

--- a/mods/fireflies/init.lua
+++ b/mods/fireflies/init.lua
@@ -3,6 +3,8 @@
 -- Load support for MT game translation.
 local S = minetest.get_translator("fireflies")
 
+-- Legacy compatibility, when pointabilities don't exist, pointable is set to true.
+local pointable_compat = not minetest.features.item_specific_pointabilities
 
 minetest.register_node("fireflies:firefly", {
 	description = S("Firefly"),
@@ -23,7 +25,7 @@ minetest.register_node("fireflies:firefly", {
 	sunlight_propagates = true,
 	buildable_to = true,
 	walkable = false,
-	pointable = false,
+	pointable = pointable_compat,
 	groups = {catchable = 1},
 	selection_box = {
 		type = "fixed",


### PR DESCRIPTION
### Problem
Sometimes a firefly or a butterfly is in your way when you want to dig something, and it can't be destroyed by punching it.
It basically behaves like punching stone with a bare hand. This is unreasonable and annoying.

### What does this PR do?
This PR makes fireflies and butterflies only pointable using a bug net.
It utilizes the new pointabilities feature.

### Alternatives
- Make fireflies and butterflies digable without dropping anything.
- Move fireflies and butterflies to an adjacent position if someone tries to punch them.