### PR TITLE
Simplify Butterfly and Firefly codes

### DIFF
--- a/mods/butterflies/init.lua
+++ b/mods/butterflies/init.lua
@@ -43,18 +43,8 @@ for i in ipairs (butter_list) do
 			fixed = {-0.1, -0.1, -0.1, 0.1, 0.1, 0.1},
 		},
 		floodable = true,
-		on_place = function(itemstack, placer, pointed_thing)
-			local player_name = placer and placer:get_player_name() or ""
-			local pos = pointed_thing.above
-
-			if not minetest.is_protected(pos, player_name) and
-					not minetest.is_protected(pointed_thing.under, player_name) and
-					minetest.get_node(pos).name == "air" then
-				minetest.set_node(pos, {name = "butterflies:butterfly_"..name})
-				minetest.get_node_timer(pos):start(1)
-				itemstack:take_item()
-			end
-			return itemstack
+		on_construct = function(pos)
+			minetest.get_node_timer(pos):start(1)
 		end,
 		on_timer = function(pos, elapsed)
 			if minetest.get_node_light(pos) < 11 then
@@ -76,18 +66,8 @@ for i in ipairs (butter_list) do
 		drop = "",
 		groups = {not_in_creative_inventory = 1},
 		floodable = true,
-		on_place = function(itemstack, placer, pointed_thing)
-			local player_name = placer and placer:get_player_name() or ""
-			local pos = pointed_thing.above
-
-			if not minetest.is_protected(pos, player_name) and
-					not minetest.is_protected(pointed_thing.under, player_name) and
-					minetest.get_node(pos).name == "air" then
-				minetest.set_node(pos, {name = "butterflies:hidden_butterfly_"..name})
-				minetest.get_node_timer(pos):start(1)
-				itemstack:take_item()
-			end
-			return itemstack
+		on_construct = function(pos)
+			minetest.get_node_timer(pos):start(1)
 		end,
 		on_timer = function(pos, elapsed)
 			if minetest.get_node_light(pos) >= 11 then

--- a/mods/fireflies/init.lua
+++ b/mods/fireflies/init.lua
@@ -33,18 +33,8 @@ minetest.register_node("fireflies:firefly", {
 	},
 	light_source = 6,
 	floodable = true,
-	on_place = function(itemstack, placer, pointed_thing)
-		local player_name = placer:get_player_name()
-		local pos = pointed_thing.above
-
-		if not minetest.is_protected(pos, player_name) and
-				not minetest.is_protected(pointed_thing.under, player_name) and
-				minetest.get_node(pos).name == "air" then
-			minetest.set_node(pos, {name = "fireflies:firefly"})
-			minetest.get_node_timer(pos):start(1)
-			itemstack:take_item()
-		end
-		return itemstack
+	on_construct = function(pos)
+		minetest.get_node_timer(pos):start(1)
 	end,
 	on_timer = function(pos, elapsed)
 		if minetest.get_node_light(pos) > 11 then
@@ -68,18 +58,8 @@ minetest.register_node("fireflies:hidden_firefly", {
 	drop = "",
 	groups = {not_in_creative_inventory = 1},
 	floodable = true,
-	on_place = function(itemstack, placer, pointed_thing)
-		local player_name = placer:get_player_name()
-		local pos = pointed_thing.above
-
-		if not minetest.is_protected(pos, player_name) and
-				not minetest.is_protected(pointed_thing.under, player_name) and
-				minetest.get_node(pos).name == "air" then
-			minetest.set_node(pos, {name = "fireflies:hidden_firefly"})
-			minetest.get_node_timer(pos):start(1)
-			itemstack:take_item()
-		end
-		return itemstack
+	on_construct = function(pos)
+		minetest.get_node_timer(pos):start(1)
 	end,
 	on_timer = function(pos, elapsed)
 		if minetest.get_node_light(pos) <= 11 then
@@ -95,27 +75,11 @@ minetest.register_tool("fireflies:bug_net", {
 	description = S("Bug Net"),
 	inventory_image = "fireflies_bugnet.png",
 	pointabilities = {nodes = {["group:catchable"] = true}},
-	on_use = function(itemstack, player, pointed_thing)
-		local player_name = player and player:get_player_name() or ""
-		if not pointed_thing or pointed_thing.type ~= "node" or
-				minetest.is_protected(pointed_thing.under, player_name) then
-			return
-		end
-		local node_name = minetest.get_node(pointed_thing.under).name
-		local inv = player:get_inventory()
-		if minetest.get_item_group(node_name, "catchable") == 1 then
-			minetest.remove_node(pointed_thing.under)
-			local stack = ItemStack(node_name.." 1")
-			local leftover = inv:add_item("main", stack)
-			if leftover:get_count() > 0 then
-				minetest.add_item(pointed_thing.under, node_name.." 1")
-			end
-		end
-		if not minetest.is_creative_enabled(player_name) then
-			itemstack:add_wear_by_uses(256)
-			return itemstack
-		end
-	end
+	tool_capabilities = {
+		groupcaps = {
+			catchable = { maxlevel = 1, uses = 256, times = { [1] = 0, [2] = 0, [3] = 0 } }
+		},
+	},
 })
 
 minetest.register_craft( {


### PR DESCRIPTION
This PR simplifies the code of butterflies and fireflies. Changes are listed below:

1. The engine now handles the placement of butterflies and fireflies. An `on_construct` callback is added to handle node timers.
2. The bug nest now uses the engine `tool_capabilities` field to handle bug-catching. As a side effect, the capabilities of the bare hands are inherited.

As the typical node placing and digging routines are used, placements are logged and protection violation callbacks are called.

This PR conflicts with #3116. That PR still uses custom code, and this PR replaces those with the engine's routines.

Fixes #2987 by using the engine's routine. Unlike #3116, this PR does not fix &#8203;#3102 as it is another unrelated issue.

This PR is ready for review.