### PR TITLE
Fix the possibility to put fire in a protected area

### DIFF
--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -100,15 +100,19 @@ minetest.register_tool("fire:flint_and_steel", {
 			if not nodedef then
 				return
 			end
-			if minetest.is_protected(pointed_thing.under, player_name)
-					or minetest.is_protected(pointed_thing.above, player_name) then
-				minetest.chat_send_player(player_name, "This area is protected")
+			if minetest.is_protected(pointed_thing.under, player_name) then
+				minetest.record_protection_violation(pointed_thing.under, player_name)
 				return
 			end
 			if nodedef.on_ignite then
 				nodedef.on_ignite(pointed_thing.under, user)
 			elseif minetest.get_item_group(node_under, "flammable") >= 1
 					and minetest.get_node(pointed_thing.above).name == "air" then
+				if minetest.is_protected(pointed_thing.above, player_name) then
+					minetest.record_protection_violation(pointed_thing.above, player_name)
+					return
+				end
+
 				minetest.set_node(pointed_thing.above, {name = "fire:basic_flame"})
 			end
 		end

--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -100,7 +100,8 @@ minetest.register_tool("fire:flint_and_steel", {
 			if not nodedef then
 				return
 			end
-			if minetest.is_protected(pointed_thing.under, player_name) then
+			if minetest.is_protected(pointed_thing.under, player_name)
+					or minetest.is_protected(pointed_thing.above, player_name) then
 				minetest.chat_send_player(player_name, "This area is protected")
 				return
 			end


### PR DESCRIPTION
It's currently possible to put fire in a protected area which is adjacent to a non-protected one. That's because when putting fire with a "Flint and Steel", it only checks the protection of the area in which the pointed node resides, but doesn't check the protection of the area, in which the fire will be actually put in. So, it's possible to put fire in a protected area if the pointed node at the same time resides in a non-protected one.