### PR TITLE
Fix crafting for fences etc. starting with colon

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -324,7 +324,7 @@ Allows creation of new fences with "fencelike" drawtype.
 	name = "default:fence_wood",
 	description = "Wooden Fence",
 	texture = "default_wood.png",
-	material = "default:wood",
+	material = "default:wood", -- `nil` if you don't want the recipe
 	groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 2},
 	sounds = default.node_sound_wood_defaults(),
 

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -499,7 +499,7 @@ function default.register_mesepost(name, def)
 		recipe = {
 			{'', 'default:glass', ''},
 			{'default:mese_crystal', 'default:mese_crystal', 'default:mese_crystal'},
-			{'', def.material, ''},
+			{'', material, ''},
 		}
 	})
 end

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -364,9 +364,7 @@ function default.register_fence(name, def)
 
 	-- Register crafting recipe, trim away starting colon if any
 	if not material then return end
-	if string.sub(name, 1,1) == ":" then
-		name = string.sub(name, 2)
-	end
+	name = string.gsub(name, "^:", "")
 	minetest.register_craft({
 		output = name .. " 4",
 		recipe = {
@@ -438,9 +436,7 @@ function default.register_fence_rail(name, def)
 
 	-- Register crafting recipe, trim away starting colon if any
 	if not material then return end
-	if string.sub(name, 1,1) == ":" then
-		name = string.sub(name, 2)
-	end
+	name = string.gsub(name, "^:", "")
 	minetest.register_craft({
 		output = name .. " 16",
 		recipe = {
@@ -491,9 +487,7 @@ function default.register_mesepost(name, def)
 
 	-- Register crafting recipe, trim away starting colon if any
 	if not material then return end
-	if string.sub(name, 1,1) == ":" then
-		name = string.sub(name, 2)
-	end
+	name = string.gsub(name, "^:", "")
 	minetest.register_craft({
 		output = name .. " 4",
 		recipe = {

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -309,14 +309,6 @@ end
 local fence_collision_extra = minetest.settings:get_bool("enable_fence_tall") and 3/8 or 0
 
 function default.register_fence(name, def)
-	minetest.register_craft({
-		output = name .. " 4",
-		recipe = {
-			{ def.material, 'group:stick', def.material },
-			{ def.material, 'group:stick', def.material },
-		}
-	})
-
 	local fence_texture = "default_fence_overlay.png^" .. def.texture ..
 			"^default_fence_overlay.png^[makealpha:255,126,126"
 	-- Allow almost everything to be overridden
@@ -364,10 +356,24 @@ function default.register_fence(name, def)
 	-- Always add to the fence group, even if no group provided
 	def.groups.fence = 1
 
+	local material = def.material
 	def.texture = nil
 	def.material = nil
 
 	minetest.register_node(name, def)
+
+	-- Register crafting recipe, trim away starting colon if any
+	if not material then return end
+	if string.sub(name, 1,1) == ":" then
+		name = string.sub(name, 2)
+	end
+	minetest.register_craft({
+		output = name .. " 4",
+		recipe = {
+			{ material, 'group:stick', material },
+			{ material, 'group:stick', material },
+		}
+	})
 end
 
 
@@ -376,15 +382,6 @@ end
 --
 
 function default.register_fence_rail(name, def)
-	minetest.register_craft({
-		output = name .. " 16",
-		recipe = {
-			{ def.material, def.material },
-			{ "", ""},
-			{ def.material, def.material },
-		}
-	})
-
 	local fence_rail_texture = "default_fence_rail_overlay.png^" .. def.texture ..
 			"^default_fence_rail_overlay.png^[makealpha:255,126,126"
 	-- Allow almost everything to be overridden
@@ -433,10 +430,25 @@ function default.register_fence_rail(name, def)
 	-- Always add to the fence group, even if no group provided
 	def.groups.fence = 1
 
+	local material = def.material
 	def.texture = nil
 	def.material = nil
 
 	minetest.register_node(name, def)
+
+	-- Register crafting recipe, trim away starting colon if any
+	if not material then return end
+	if string.sub(name, 1,1) == ":" then
+		name = string.sub(name, 2)
+	end
+	minetest.register_craft({
+		output = name .. " 16",
+		recipe = {
+			{ material, material },
+			{ "", ""},
+			{ material, material },
+		}
+	})
 end
 
 --
@@ -444,15 +456,6 @@ end
 --
 
 function default.register_mesepost(name, def)
-	minetest.register_craft({
-		output = name .. " 4",
-		recipe = {
-			{'', 'default:glass', ''},
-			{'default:mese_crystal', 'default:mese_crystal', 'default:mese_crystal'},
-			{'', def.material, ''},
-		}
-	})
-
 	local post_texture = def.texture .. "^default_mese_post_light_side.png^[makealpha:0,0,0"
 	local post_texture_dark = def.texture .. "^default_mese_post_light_side_dark.png^[makealpha:0,0,0"
 	-- Allow almost everything to be overridden
@@ -480,10 +483,25 @@ function default.register_mesepost(name, def)
 		end
 	end
 
+	local material = def.material
 	def.texture = nil
 	def.material = nil
 
 	minetest.register_node(name, def)
+
+	-- Register crafting recipe, trim away starting colon if any
+	if not material then return end
+	if string.sub(name, 1,1) == ":" then
+		name = string.sub(name, 2)
+	end
+	minetest.register_craft({
+		output = name .. " 4",
+		recipe = {
+			{'', 'default:glass', ''},
+			{'default:mese_crystal', 'default:mese_crystal', 'default:mese_crystal'},
+			{'', def.material, ''},
+		}
+	})
 end
 
 --


### PR DESCRIPTION
Fixes #3127

This PR fixes the crafting recipes of fences, fence rails, and mese post lights. After the changes, even if the node name starts with a colon, the crafting recipe still exists.

This PR is ready for review.