### PR TITLE
Add new recipe for strings from any wool block

### DIFF
--- a/mods/wool/init.lua
+++ b/mods/wool/init.lua
@@ -28,8 +28,8 @@ end
 
 -- Alternative recipe for strings.
 minetest.register_craft({
-		output="farming:string 4",
-		recipe={{"group:wool"}}
+	output = "farming:string 4",
+	recipe = {{"group:wool"}},
 })
 		
 -- Legacy

--- a/mods/wool/init.lua
+++ b/mods/wool/init.lua
@@ -26,6 +26,12 @@ for i = 1, #dyes do
 	}
 end
 
+-- Alternative recipe for strings.
+minetest.register_craft({
+		output="farming:string 4",
+		recipe={{"group:wool"}}
+})
+		
 -- Legacy
 -- Backwards compatibility with jordach's 16-color wool mod
 minetest.register_alias("wool:dark_blue", "wool:blue")


### PR DESCRIPTION
It would make mods such as Animalia(creating saddles require strings) or any bow/crossbow mod integrate much more naturally to MTG, since cotton is very hard to find, or impossible depending on the biome.

Also this recipe makes a lot of sense IMO.