### PR TITLE
Replace deprecated `meta:set_string()` call

### DIFF
--- a/mods/default/chests.lua
+++ b/mods/default/chests.lua
@@ -284,7 +284,7 @@ function default.chest.register_chest(prefixed_name, d)
 			nodenames = {name},
 			action = function(pos, node)
 				local meta = minetest.get_meta(pos)
-				meta:set_string("formspec", nil)
+				meta:set_string("formspec", "")
 				local inv = meta:get_inventory()
 				local list = inv:get_list("default:chest")
 				if list then


### PR DESCRIPTION
Calling `set_string()` w/ `nil` to delete keys has been deprecated in mt 5.9. See https://github.com/minetest/minetest/pull/14396.