### PR TITLE
Limit furnace sound volume on catch-up smelting

### DIFF
--- a/mods/default/furnace.lua
+++ b/mods/default/furnace.lua
@@ -134,6 +134,7 @@ local function furnace_node_timer(pos, elapsed)
 	local fuel
 
 	local update = true
+	local items_smelt = 0
 	while elapsed > 0 and update do
 		update = false
 
@@ -171,9 +172,7 @@ local function furnace_node_timer(pos, elapsed)
 					else
 						dst_full = true
 					end
-					-- Play cooling sound
-					minetest.sound_play("default_cool_lava",
-						{pos = pos, max_hear_distance = 16, gain = 0.07}, true)
+					items_smelt = items_smelt + 1
 				else
 					-- Item could not be cooked: probably missing fuel
 					update = true
@@ -224,6 +223,11 @@ local function furnace_node_timer(pos, elapsed)
 		elapsed = elapsed - el
 	end
 
+	if items_smelt ~= 0 then
+		-- Play cooling sound
+		minetest.sound_play("default_cool_lava",
+			{ pos = pos, max_hear_distance = 16, gain = 0.07 * math.min(items_smelt, 7) }, true)
+	end
 	if fuel and fuel_totaltime > fuel.time then
 		fuel_totaltime = fuel.time
 	end

--- a/mods/default/furnace.lua
+++ b/mods/default/furnace.lua
@@ -223,7 +223,7 @@ local function furnace_node_timer(pos, elapsed)
 		elapsed = elapsed - el
 	end
 
-	if items_smelt ~= 0 then
+	if items_smelt > 0 then
 		-- Play cooling sound
 		minetest.sound_play("default_cool_lava",
 			{ pos = pos, max_hear_distance = 16, gain = 0.07 * math.min(items_smelt, 7) }, true)


### PR DESCRIPTION
This PR limits the volume of smelting sound if the furnace smelts multiple items in the same timer step.

This PR is ready for review. 