### PR TITLE
Fix crash if bones punched by non-player

### DIFF
--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -27,7 +27,7 @@ local drop = function(pos, itemstack)
 	end
 end
 
-local dropContents = function(pos)
+local drop_contents = function(pos)
 	local inv = minetest.get_meta(pos):get_inventory()
 
 	for i = 1, inv:get_size("main") do
@@ -109,7 +109,8 @@ local bones_def = {
 		end
 
 		if not player:is_player() then
-			dropContents(pos)
+			drop_contents(pos)
+			return
 		end
 
 		if minetest.get_meta(pos):get_string("infotext") == "" then

--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -16,7 +16,7 @@ local function is_owner(pos, name)
 	return false
 end
 
-local drop = function(pos, itemstack)
+local function drop(pos, itemstack)
 	local obj = minetest.add_item(pos, itemstack:take_item(itemstack:get_count()))
 	if obj then
 		obj:set_velocity({

--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -27,7 +27,7 @@ local function drop(pos, itemstack)
 	end
 end
 
-local drop_contents = function(pos)
+local function drop_contents(pos)
 	local inv = minetest.get_meta(pos):get_inventory()
 
 	for i = 1, inv:get_size("main") do

--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -16,6 +16,27 @@ local function is_owner(pos, name)
 	return false
 end
 
+local drop = function(pos, itemstack)
+	local obj = minetest.add_item(pos, itemstack:take_item(itemstack:get_count()))
+	if obj then
+		obj:set_velocity({
+			x = math.random(-10, 10) / 9,
+			y = 5,
+			z = math.random(-10, 10) / 9,
+		})
+	end
+end
+
+local dropContents = function(pos)
+	local inv = minetest.get_meta(pos):get_inventory()
+
+	for i = 1, inv:get_size("main") do
+		local stk = inv:get_stack("main", i)
+		drop(pos, stk)
+	end
+	minetest.remove_node(pos)
+end
+
 local bones_formspec =
 	"size[8,9]" ..
 	"list[current_name;main;0,0.3;8,4;]" ..
@@ -85,6 +106,10 @@ local bones_def = {
 	on_punch = function(pos, node, player)
 		if not is_owner(pos, player:get_player_name()) then
 			return
+		end
+
+		if not player:is_player() then
+			dropContents(pos)
 		end
 
 		if minetest.get_meta(pos):get_string("infotext") == "" then
@@ -169,17 +194,6 @@ local function may_replace(pos, player)
 	-- default to each nodes buildable_to; if a placed block would replace it, why shouldn't bones?
 	-- flowers being squished by bones are more realistical than a squished stone, too
 	return node_definition.buildable_to
-end
-
-local drop = function(pos, itemstack)
-	local obj = minetest.add_item(pos, itemstack:take_item(itemstack:get_count()))
-	if obj then
-		obj:set_velocity({
-			x = math.random(-10, 10) / 9,
-			y = 5,
-			z = math.random(-10, 10) / 9,
-		})
-	end
 end
 
 local player_inventory_lists = { "main", "craft" }


### PR DESCRIPTION
- Added check for player:is_player()
- if bones are fresh and the bones are punched nothing happens
- if bones are old, the inventory is dropped as entities and the bones node is removed