### PR TITLE
Simplify and fix docker test

### DIFF
--- a/utils/test/run.sh
+++ b/utils/test/run.sh
@@ -4,8 +4,7 @@ trap 'rm -rf "$world" || :' EXIT
 
 [ -f game.conf ] || { echo "Must be run in game root folder." >&2; exit 1; }
 
-cp -v utils/test/world.mt "$world/"
-chmod -R a+rwX "$world" # needed because server runs as unprivileged user inside container
+chmod -R 777 "$world" # container uses unprivileged user inside
 
 vol=(
 	-v "$PWD/utils/test/minetest.conf":/etc/minetest/minetest.conf
@@ -14,6 +13,7 @@ vol=(
 	-v "$world":/var/lib/minetest/.minetest/world
 )
 [ -z "$DOCKER_IMAGE" ] && DOCKER_IMAGE="ghcr.io/minetest/minetest:master"
-docker run --rm -i "${vol[@]}" "$DOCKER_IMAGE"
+docker run --rm -i "${vol[@]}" "$DOCKER_IMAGE" --config /etc/minetest/minetest.conf --gameid minetest
 
+test -f "$world/map.sqlite" || exit 1
 exit 0

--- a/utils/test/world.mt
+++ b/utils/test/world.mt
@@ -1,7 +1,0 @@
-auth_backend = sqlite3
-backend = sqlite3
-creative_mode = false
-enable_damage = true
-gameid = minetest
-mod_storage_backend = sqlite3
-player_backend = sqlite3


### PR DESCRIPTION
1. `docker run` does not pass through the error code, so we check externally if starting the world actually worked
2. `--gameid minetest` works, no need to create a world.mt