### PR TITLE
Set volumetric lighting strength

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -1205,7 +1205,7 @@ Weather API
 -----------
 
 The weather mod will constantly adjust weather effects seen by the player
-(that is: cloud parameters and shadow intensity).
+(that is: cloud parameters, shadow intensity and volumetric lighting).
 These can be influenced using this API.
 
 #### `weather.get = function(player)`

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -72,7 +72,8 @@ default:torch 99,default:cobble 99
 # Helps rivers create more sound, especially on level sections.
 #river_source_sounds = false
 
-# Enable cloud and shadow intensity variation by the 'weather' mod.
+# If enabled, the 'weather' mod will control cloud parameters, shadow intensity
+# and volumetric lighting.
 # Non-functional in V6 or Singlenode mapgens.
 #enable_weather = true
 

--- a/mods/weather/init.lua
+++ b/mods/weather/init.lua
@@ -11,7 +11,10 @@ local mg_name = minetest.get_mapgen_setting("mg_name")
 if mg_name == "v6" or mg_name == "singlenode" then
 	-- set a default shadow intensity for mgv6 and singlenode
 	minetest.register_on_joinplayer(function(player)
-		player:set_lighting({ shadows = { intensity = 0.33 } })
+		player:set_lighting({
+			shadows = { intensity = 0.33 },
+			volumetric_light = { strength = 0.2 },
+		})
 	end)
 
 	return
@@ -117,7 +120,8 @@ function weather.get(player)
 			speed = {x = n_speedx * 4, z = n_speedz * 4},
 		},
 		lighting = {
-			shadows = { intensity = 0.7 * (1 - density) }
+			shadows = { intensity = 0.7 * (1 - density) },
+			volumetric_light = { strength = 0.2 },
 		}
 	}
 end

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -72,7 +72,8 @@ engine_spawn (Use engine spawn search) bool false
 #    Helps rivers create more sound, especially on level sections.
 river_source_sounds (River source node sounds) bool false
 
-#    Enable cloud and shadow intensity variation by the 'weather' mod.
+#    If enabled, the 'weather' mod will control cloud parameters, shadow intensity
+#    and volumetric lighting.
 #    Non-functional in V6 or Singlenode mapgens.
 enable_weather (Enable weather) bool true
 


### PR DESCRIPTION
As a game, it's MTG's responsibility to choose a value here so that players can use the volumetric lighting effect. It shouldn't be necessary for every MTG server install a separate mod that enables volumetric lighting if their players want to use it. This is the same situation as with dynamic shadows.

The value chosen here (0.2) results in the effective volumetric light strength originally chosen by x2048, before volumetric lighting was made game-customizable: https://github.com/minetest/minetest/blob/master/client/shaders/volumetric_light/opengl_fragment.glsl#L93-L94

It's not like this is forcing anything on players or server owners either, the weather API provides overridable callbacks or can be disabled entirely.