### PR TITLE
Make walls connect to nodes in a new `wall_connected` group

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -341,6 +341,12 @@ walls.register(name, desc, texture, mat, sounds)
 ^ mat = "default:stone". Used to auto-generate crafting recipe.
 ^ sounds = sounds: see [#Default sounds]
 
+All walls will be connected to any nodes with one of the following groups:
+ * `wall`
+ * `stone`
+ * `fence`
+ * `wall_connected`
+
 
 Farming API
 -----------

--- a/mods/walls/init.lua
+++ b/mods/walls/init.lua
@@ -35,7 +35,7 @@ walls.register = function(wall_name, wall_desc, wall_texture_table, wall_mat, wa
 			connect_back = {-1/4,-1/2,1/4,1/4,1/2 + fence_collision_extra,1/2},
 			connect_right = {1/4,-1/2,-1/4,1/2,1/2 + fence_collision_extra,1/4},
 		},
-		connects_to = { "group:wall", "group:stone", "group:fence" },
+		connects_to = { "group:wall", "group:stone", "group:fence", "group:wall_connected" },
 		paramtype = "light",
 		is_ground_content = false,
 		tiles = wall_texture_table,


### PR DESCRIPTION
`walls`: add ability to specify group `wall_connected` for blocks to which the walls will be connected