### PR TITLE
Set bloom intensity

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -1205,7 +1205,7 @@ Weather API
 -----------
 
 The weather mod will constantly adjust weather effects seen by the player
-(that is: cloud parameters, shadow intensity and volumetric lighting).
+(that is: cloud parameters, shadow intensity, bloom and volumetric lighting).
 These can be influenced using this API.
 
 #### `weather.get = function(player)`

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -72,8 +72,8 @@ default:torch 99,default:cobble 99
 # Helps rivers create more sound, especially on level sections.
 #river_source_sounds = false
 
-# If enabled, the 'weather' mod will control cloud parameters, shadow intensity
-# and volumetric lighting.
+# If enabled, the 'weather' mod will control cloud parameters, shadow intensity,
+# bloom and volumetric lighting.
 # Non-functional in V6 or Singlenode mapgens.
 #enable_weather = true
 

--- a/mods/weather/init.lua
+++ b/mods/weather/init.lua
@@ -13,6 +13,7 @@ if mg_name == "v6" or mg_name == "singlenode" then
 	minetest.register_on_joinplayer(function(player)
 		player:set_lighting({
 			shadows = { intensity = 0.33 },
+			bloom = { intensity = 0.05 },
 			volumetric_light = { strength = 0.2 },
 		})
 	end)
@@ -121,6 +122,7 @@ function weather.get(player)
 		},
 		lighting = {
 			shadows = { intensity = 0.7 * (1 - density) },
+			bloom = { intensity = 0.05 },
 			volumetric_light = { strength = 0.2 },
 		}
 	}

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -72,8 +72,8 @@ engine_spawn (Use engine spawn search) bool false
 #    Helps rivers create more sound, especially on level sections.
 river_source_sounds (River source node sounds) bool false
 
-#    If enabled, the 'weather' mod will control cloud parameters, shadow intensity
-#    and volumetric lighting.
+#    If enabled, the 'weather' mod will control cloud parameters, shadow intensity,
+#    bloom and volumetric lighting.
 #    Non-functional in V6 or Singlenode mapgens.
 enable_weather (Enable weather) bool true
 


### PR DESCRIPTION
Since https://github.com/minetest/minetest/pull/15231 has been merged, it's now MTG's responsibility as a game to set a value here.

> The default value is to be changed from 0.05 to 0 in the future. If you wish to keep the current default value, you should set it explicitly.
> ~ [lua_api.md](https://github.com/minetest/minetest/blob/7435ea0d4eae807bfd88e27fbee4521e336af367/doc/lua_api.md?plain=1#L8793-L8795)

Note that bloom intensity > 0 is also needed for volumetric lighting to work.

Previously: #3158