### PR TITLE
[no sq] Kick players from beds that have ceased existing

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -8,6 +8,7 @@ globals = {
 read_globals = {
 	"DIR_DELIM",
 	"minetest",
+	"core",
 	"dump",
 	"vector",
 	"VoxelManip", "VoxelArea",

--- a/game_api.txt
+++ b/game_api.txt
@@ -47,6 +47,7 @@ Beds API
 
  * `beds.can_dig(bed_pos)` Returns a boolean whether the bed at `bed_pos` may be dug
  * `beds.read_spawns() `   Returns a table containing players respawn positions
+ * `beds.kick(player)`    Forces `player` to leave bed
  * `beds.kick_players()`  Forces all players to leave bed
  * `beds.skip_night()`   Sets world time to morning and saves respawn position of all players currently sleeping
  * `beds.day_interval`   Is a table with keys "start" and "finish". Allows you

--- a/mods/beds/api.lua
+++ b/mods/beds/api.lua
@@ -25,8 +25,15 @@ local function destruct_bed(pos, n)
 	end
 end
 
+beds.is_bed_node = {}
+
+local function register_bed_node(name, def)
+	beds.is_bed_node[name] = true
+	core.register_node(name, def)
+end
+
 function beds.register_bed(name, def)
-	minetest.register_node(name .. "_bottom", {
+	register_bed_node(name .. "_bottom", {
 		description = def.description,
 		inventory_image = def.inventory_image,
 		wield_image = def.wield_image,
@@ -150,7 +157,7 @@ function beds.register_bed(name, def)
 		end,
 	})
 
-	minetest.register_node(name .. "_top", {
+	register_bed_node(name .. "_top", {
 		drawtype = "nodebox",
 		tiles = def.tiles.top,
 		use_texture_alpha = "clip",

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -170,20 +170,20 @@ end
 
 -- Public functions
 
-function beds.kick_player(player)
+function beds.kick(player)
 	lay_down(player, nil, nil, false)
 end
 
 function beds.kick_players()
 	for name in pairs(beds.player) do
-		beds.kick_players(core.get_player_by_name(name))
+		beds.kick(core.get_player_by_name(name))
 	end
 end
 
 core.register_globalstep(function()
 	for name, bed_pos in pairs(beds.bed_position) do
 		if not beds.is_bed_node[core.get_node(bed_pos).name] then
-			beds.kick_player(core.get_player_by_name(name))
+			beds.kick(core.get_player_by_name(name))
 		end
 	end
 end)

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -170,12 +170,23 @@ end
 
 -- Public functions
 
+function beds.kick_player(player)
+	lay_down(player, nil, nil, false)
+end
+
 function beds.kick_players()
-	for name, _ in pairs(beds.player) do
-		local player = minetest.get_player_by_name(name)
-		lay_down(player, nil, nil, false)
+	for name in pairs(beds.player) do
+		beds.kick_players(core.get_player_by_name(name))
 	end
 end
+
+core.register_globalstep(function()
+	for name, bed_pos in pairs(beds.bed_position) do
+		if not beds.is_bed_node[core.get_node(bed_pos).name] then
+			beds.kick_player(core.get_player_by_name(name))
+		end
+	end
+end)
 
 function beds.skip_night()
 	minetest.set_timeofday(0.23)


### PR DESCRIPTION
Fixes #3167. Done via a globalstep, which is not a concern. I believe this to be the most straightforward approach; it is unrealistic to efficiently hook all possible ways the node could be removed.