### PR TITLE
Rename Minetest to Luanti

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ place it in `.../minetest/games/`
 
 - GNU/Linux: If you use a system-wide installation place it in `~/.minetest/games/`.
 
-The Minetest engine can be found at [GitHub](https://github.com/minetest/minetest).
+The Luanti engine can be found at [GitHub](https://github.com/minetest/minetest).
 
 For further information or help, see: [Installing Mods](https://wiki.minetest.net/Installing_Mods).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Minetest Game
 
-[![ContentDB](https://content.minetest.net/packages/Minetest/minetest_game/shields/title/)](https://content.minetest.net/packages/Minetest/minetest_game/)
+[![ContentDB](https://content.luanti.org/packages/Minetest/minetest_game/shields/title/)](https://content.luanti.org/packages/Minetest/minetest_game/)
 
 Minetest Game (abbreviated MTG) is a simple and peaceful sandbox game, with no
 real goals or built-in enemy mobs.
@@ -17,7 +17,7 @@ gameplay features or anything else that breaks compatibility (see
 ### ContentDB
 
 * Content > Browse Online Content
-* Search for "[Minetest Game](https://content.minetest.net/packages/Minetest/minetest_game/)"
+* Search for "[Minetest Game](https://content.luanti.org/packages/Minetest/minetest_game/)"
 * Click Install
 
 ### Manually
@@ -29,7 +29,7 @@ place it in `.../minetest/games/`
 
 The Luanti engine can be found at [GitHub](https://github.com/minetest/minetest).
 
-For further information or help, see: [Installing Mods](https://wiki.minetest.net/Installing_Mods).
+For further information or help, see: [Installing Mods](https://wiki.luanti.org/Installing_Mods).
 
 ## Compatibility
 

--- a/game.conf
+++ b/game.conf
@@ -1,4 +1,3 @@
 title       = Minetest Game
-author      = Minetest
 description = A basic exploration, mining, crafting, and building, sandbox game with no NPCs, monsters, or animals. Minetest Game is usually used with mods added, and many mods are available for this game. Reliably maintained by Luanti core developers.
 min_minetest_version = 5.8

--- a/game.conf
+++ b/game.conf
@@ -1,4 +1,4 @@
 title       = Minetest Game
 author      = Minetest
-description = A basic exploration, mining, crafting, and building, sandbox game with no NPCs, monsters, or animals. Minetest Game is usually used with mods added, and many mods are available for this game. Reliably maintained by Minetest Engine core developers.
+description = A basic exploration, mining, crafting, and building, sandbox game with no NPCs, monsters, or animals. Minetest Game is usually used with mods added, and many mods are available for this game. Reliably maintained by Luanti core developers.
 min_minetest_version = 5.8

--- a/game_api.txt
+++ b/game_api.txt
@@ -6,12 +6,12 @@ GitHub Repo: https://github.com/minetest/minetest_game
 Introduction
 ------------
 
-The Minetest Game game offers multiple new possibilities in addition to the Minetest engine's built-in API,
+The Minetest Game game offers multiple new possibilities in addition to the Luanti engine's built-in API,
 allowing you to add new plants to farming mod, buckets for new liquids, new stairs and custom panes.
-For information on the Minetest API, visit https://github.com/minetest/minetest/blob/master/doc/lua_api.txt
+For information on the Luanti API, visit https://github.com/minetest/minetest/blob/master/doc/lua_api.txt
 Please note:
 
- * [XYZ] refers to a section the Minetest API
+ * [XYZ] refers to a section the Luanti API
  * [#ABC] refers to a section in this document
  * [pos] refers to a position table `{x = -5, y = 0, z = 200}`
 

--- a/mods/beds/README.txt
+++ b/mods/beds/README.txt
@@ -5,7 +5,7 @@ See license.txt for license information.
 Authors of source code
 ----------------------
 Originally by BlockMen (MIT)
-Various Luanti developers and contributors (MIT)
+Various Minetest Game developers and contributors (MIT)
 
 Authors of media (textures)
 ---------------------------

--- a/mods/beds/README.txt
+++ b/mods/beds/README.txt
@@ -5,7 +5,7 @@ See license.txt for license information.
 Authors of source code
 ----------------------
 Originally by BlockMen (MIT)
-Various Minetest developers and contributors (MIT)
+Various Luanti developers and contributors (MIT)
 
 Authors of media (textures)
 ---------------------------
@@ -15,7 +15,7 @@ BlockMen (CC BY-SA 3.0)
 TumeniNodes (CC BY-SA 3.0)
  beds_bed_under.png
 
-This mod adds a bed to Minetest which allows players to skip the night.
+This mod adds a bed which allows players to skip the night.
 To sleep, right click on the bed. If playing in singleplayer mode the night gets skipped
 immediately. If playing multiplayer you get shown how many other players are in bed too,
 if all players are sleeping the night gets skipped. The night skip can be forced if more

--- a/mods/beds/license.txt
+++ b/mods/beds/license.txt
@@ -3,7 +3,7 @@ License of source code
 
 The MIT License (MIT)
 Copyright (C) 2014-2016 BlockMen
-Copyright (C) 2014-2016 Various Luanti developers and contributors
+Copyright (C) 2014-2016 Various Minetest Game developers and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/mods/beds/license.txt
+++ b/mods/beds/license.txt
@@ -3,7 +3,7 @@ License of source code
 
 The MIT License (MIT)
 Copyright (C) 2014-2016 BlockMen
-Copyright (C) 2014-2016 Various Minetest developers and contributors
+Copyright (C) 2014-2016 Various Luanti developers and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/mods/boats/README.txt
+++ b/mods/boats/README.txt
@@ -5,7 +5,7 @@ See license.txt for license information.
 Authors of source code
 ----------------------
 Originally by PilzAdam (MIT)
-Various Minetest developers and contributors (MIT)
+Various Luanti developers and contributors (MIT)
 
 Authors of media (textures and model)
 -------------------------------------

--- a/mods/boats/README.txt
+++ b/mods/boats/README.txt
@@ -5,7 +5,7 @@ See license.txt for license information.
 Authors of source code
 ----------------------
 Originally by PilzAdam (MIT)
-Various Luanti developers and contributors (MIT)
+Various Minetest Game developers and contributors (MIT)
 
 Authors of media (textures and model)
 -------------------------------------

--- a/mods/boats/license.txt
+++ b/mods/boats/license.txt
@@ -3,7 +3,7 @@ License of source code
 
 The MIT License (MIT)
 Copyright (C) 2012-2016 PilzAdam
-Copyright (C) 2012-2016 Various Minetest developers and contributors
+Copyright (C) 2012-2016 Various Luanti developers and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/mods/boats/license.txt
+++ b/mods/boats/license.txt
@@ -3,7 +3,7 @@ License of source code
 
 The MIT License (MIT)
 Copyright (C) 2012-2016 PilzAdam
-Copyright (C) 2012-2016 Various Luanti developers and contributors
+Copyright (C) 2012-2016 Various Minetest Game developers and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/mods/bones/README.txt
+++ b/mods/bones/README.txt
@@ -5,7 +5,7 @@ See license.txt for license information.
 Authors of source code
 ----------------------
 Originally by PilzAdam (MIT)
-Various Luanti developers and contributors (MIT)
+Various Minetest Game developers and contributors (MIT)
 
 Authors of media (textures)
 ---------------------------

--- a/mods/bones/README.txt
+++ b/mods/bones/README.txt
@@ -5,7 +5,7 @@ See license.txt for license information.
 Authors of source code
 ----------------------
 Originally by PilzAdam (MIT)
-Various Minetest developers and contributors (MIT)
+Various Luanti developers and contributors (MIT)
 
 Authors of media (textures)
 ---------------------------

--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -1,6 +1,6 @@
 -- bones/init.lua
 
--- Minetest 0.4 mod: bones
+-- Minetest Game mod: bones
 -- See README.txt for licensing and other information.
 
 -- Load support for MT game translation.

--- a/mods/bones/license.txt
+++ b/mods/bones/license.txt
@@ -3,7 +3,7 @@ License of source code
 
 The MIT License (MIT)
 Copyright (C) 2012-2016 PilzAdam
-Copyright (C) 2012-2016 Various Minetest developers and contributors
+Copyright (C) 2012-2016 Various Luanti developers and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/mods/bones/license.txt
+++ b/mods/bones/license.txt
@@ -3,7 +3,7 @@ License of source code
 
 The MIT License (MIT)
 Copyright (C) 2012-2016 PilzAdam
-Copyright (C) 2012-2016 Various Luanti developers and contributors
+Copyright (C) 2012-2016 Various Minetest Game developers and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/mods/bucket/README.txt
+++ b/mods/bucket/README.txt
@@ -6,7 +6,7 @@ Authors of source code
 ----------------------
 Kahrl <kahrl@gmx.net> (LGPLv2.1+)
 celeron55, Perttu Ahola <celeron55@gmail.com> (LGPLv2.1+)
-Various Minetest developers and contributors (LGPLv2.1+)
+Various Luanti developers and contributors (LGPLv2.1+)
 
 Authors of media (textures)
 ---------------------------

--- a/mods/bucket/README.txt
+++ b/mods/bucket/README.txt
@@ -6,7 +6,7 @@ Authors of source code
 ----------------------
 Kahrl <kahrl@gmx.net> (LGPLv2.1+)
 celeron55, Perttu Ahola <celeron55@gmail.com> (LGPLv2.1+)
-Various Luanti developers and contributors (LGPLv2.1+)
+Various Minetest Game developers and contributors (LGPLv2.1+)
 
 Authors of media (textures)
 ---------------------------

--- a/mods/bucket/init.lua
+++ b/mods/bucket/init.lua
@@ -1,4 +1,4 @@
--- Minetest 0.4 mod: bucket
+-- Minetest Game mod: bucket
 -- See README.txt for licensing and other information.
 
 -- Load support for MT game translation.

--- a/mods/bucket/license.txt
+++ b/mods/bucket/license.txt
@@ -4,7 +4,7 @@ License of source code
 GNU Lesser General Public License, version 2.1
 Copyright (C) 2011-2016 Kahrl <kahrl@gmx.net>
 Copyright (C) 2011-2016 celeron55, Perttu Ahola <celeron55@gmail.com>
-Copyright (C) 2011-2016 Various Minetest developers and contributors
+Copyright (C) 2011-2016 Various Luanti developers and contributors
 
 This program is free software; you can redistribute it and/or modify it under the terms
 of the GNU Lesser General Public License as published by the Free Software Foundation;

--- a/mods/bucket/license.txt
+++ b/mods/bucket/license.txt
@@ -4,7 +4,7 @@ License of source code
 GNU Lesser General Public License, version 2.1
 Copyright (C) 2011-2016 Kahrl <kahrl@gmx.net>
 Copyright (C) 2011-2016 celeron55, Perttu Ahola <celeron55@gmail.com>
-Copyright (C) 2011-2016 Various Luanti developers and contributors
+Copyright (C) 2011-2016 Various Minetest Game developers and contributors
 
 This program is free software; you can redistribute it and/or modify it under the terms
 of the GNU Lesser General Public License as published by the Free Software Foundation;

--- a/mods/carts/license.txt
+++ b/mods/carts/license.txt
@@ -5,7 +5,7 @@ License of source code
 The MIT License (MIT)
 Copyright (C) 2012-2016 PilzAdam
 Copyright (C) 2014-2016 SmallJoker
-Copyright (C) 2012-2016 Various Luanti developers and contributors
+Copyright (C) 2012-2016 Various Minetest Game developers and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/mods/carts/license.txt
+++ b/mods/carts/license.txt
@@ -5,7 +5,7 @@ License of source code
 The MIT License (MIT)
 Copyright (C) 2012-2016 PilzAdam
 Copyright (C) 2014-2016 SmallJoker
-Copyright (C) 2012-2016 Various Minetest developers and contributors
+Copyright (C) 2012-2016 Various Luanti developers and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/mods/default/README.txt
+++ b/mods/default/README.txt
@@ -5,7 +5,7 @@ See license.txt for license information.
 Authors of source code
 ----------------------
 Originally by celeron55, Perttu Ahola <celeron55@gmail.com> (LGPLv2.1+)
-Various Luanti developers and contributors (LGPLv2.1+)
+Various Minetest Game developers and contributors (LGPLv2.1+)
 
 The torch code was derived by sofar from the 'torches' mod by
 BlockMen (LGPLv2.1+)

--- a/mods/default/README.txt
+++ b/mods/default/README.txt
@@ -5,7 +5,7 @@ See license.txt for license information.
 Authors of source code
 ----------------------
 Originally by celeron55, Perttu Ahola <celeron55@gmail.com> (LGPLv2.1+)
-Various Minetest developers and contributors (LGPLv2.1+)
+Various Luanti developers and contributors (LGPLv2.1+)
 
 The torch code was derived by sofar from the 'torches' mod by
 BlockMen (LGPLv2.1+)

--- a/mods/default/init.lua
+++ b/mods/default/init.lua
@@ -1,4 +1,4 @@
--- Minetest 0.4 mod: default
+-- Minetest Game mod: default
 -- See README.txt for licensing and other information.
 
 -- The API documentation in here was moved into game_api.txt

--- a/mods/default/license.txt
+++ b/mods/default/license.txt
@@ -3,7 +3,7 @@ License of source code
 
 GNU Lesser General Public License, version 2.1
 Copyright (C) 2011-2018 celeron55, Perttu Ahola <celeron55@gmail.com>
-Copyright (C) 2011-2018 Various Minetest developers and contributors
+Copyright (C) 2011-2018 Various Luanti developers and contributors
 
 This program is free software; you can redistribute it and/or modify it under the terms
 of the GNU Lesser General Public License as published by the Free Software Foundation;

--- a/mods/default/license.txt
+++ b/mods/default/license.txt
@@ -3,7 +3,7 @@ License of source code
 
 GNU Lesser General Public License, version 2.1
 Copyright (C) 2011-2018 celeron55, Perttu Ahola <celeron55@gmail.com>
-Copyright (C) 2011-2018 Various Luanti developers and contributors
+Copyright (C) 2011-2018 Various Minetest Game developers and contributors
 
 This program is free software; you can redistribute it and/or modify it under the terms
 of the GNU Lesser General Public License as published by the Free Software Foundation;

--- a/mods/doors/README.txt
+++ b/mods/doors/README.txt
@@ -14,7 +14,7 @@ Re-implemented most of the door algorithms, added meshes, UV wrapped texture.
 Added doors API to facilitate coding mods accessing and operating doors.
 Added Fence Gate model, code, and sounds.
 
-Various Luanti developers and contributors (MIT)
+Various Minetest Game developers and contributors (MIT)
 
 
 Authors of media (textures)

--- a/mods/doors/README.txt
+++ b/mods/doors/README.txt
@@ -14,7 +14,7 @@ Re-implemented most of the door algorithms, added meshes, UV wrapped texture.
 Added doors API to facilitate coding mods accessing and operating doors.
 Added Fence Gate model, code, and sounds.
 
-Various Minetest developers and contributors (MIT)
+Various Luanti developers and contributors (MIT)
 
 
 Authors of media (textures)

--- a/mods/doors/license.txt
+++ b/mods/doors/license.txt
@@ -5,7 +5,7 @@ The MIT License (MIT)
 Copyright (C) 2012-2016 PilzAdam
 Copyright (C) 2014-2016 BlockMen
 Copyright (C) 2015-2016 sofar (sofar@foo-projects.org)
-Copyright (C) 2012-2016 Various Minetest developers and contributors
+Copyright (C) 2012-2016 Various Luanti developers and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/mods/doors/license.txt
+++ b/mods/doors/license.txt
@@ -5,7 +5,7 @@ The MIT License (MIT)
 Copyright (C) 2012-2016 PilzAdam
 Copyright (C) 2014-2016 BlockMen
 Copyright (C) 2015-2016 sofar (sofar@foo-projects.org)
-Copyright (C) 2012-2016 Various Luanti developers and contributors
+Copyright (C) 2012-2016 Various Minetest Game developers and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/mods/dye/README.txt
+++ b/mods/dye/README.txt
@@ -6,7 +6,7 @@ See init.lua for documentation.
 Authors of source code
 ----------------------
 Originally by Perttu Ahola (celeron55) <celeron55@gmail.com> (MIT)
-Various Luanti developers and contributors (MIT)
+Various Minetest Game developers and contributors (MIT)
 
 Authors of media (textures)
 ---------------------------

--- a/mods/dye/README.txt
+++ b/mods/dye/README.txt
@@ -6,7 +6,7 @@ See init.lua for documentation.
 Authors of source code
 ----------------------
 Originally by Perttu Ahola (celeron55) <celeron55@gmail.com> (MIT)
-Various Minetest developers and contributors (MIT)
+Various Luanti developers and contributors (MIT)
 
 Authors of media (textures)
 ---------------------------

--- a/mods/dye/license.txt
+++ b/mods/dye/license.txt
@@ -3,7 +3,7 @@ License of source code
 
 The MIT License (MIT)
 Copyright (C) 2012-2016 Perttu Ahola (celeron55) <celeron55@gmail.com>
-Copyright (C) 2012-2016 Various Luanti developers and contributors
+Copyright (C) 2012-2016 Various Minetest Game developers and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/mods/dye/license.txt
+++ b/mods/dye/license.txt
@@ -3,7 +3,7 @@ License of source code
 
 The MIT License (MIT)
 Copyright (C) 2012-2016 Perttu Ahola (celeron55) <celeron55@gmail.com>
-Copyright (C) 2012-2016 Various Minetest developers and contributors
+Copyright (C) 2012-2016 Various Luanti developers and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/mods/farming/README.txt
+++ b/mods/farming/README.txt
@@ -6,7 +6,7 @@ Authors of source code
 ----------------------
 Originally by PilzAdam (MIT)
 webdesigner97 (MIT)
-Various Minetest developers and contributors (MIT)
+Various Luanti developers and contributors (MIT)
 
 Authors of media (textures)
 ---------------------------

--- a/mods/farming/README.txt
+++ b/mods/farming/README.txt
@@ -6,7 +6,7 @@ Authors of source code
 ----------------------
 Originally by PilzAdam (MIT)
 webdesigner97 (MIT)
-Various Luanti developers and contributors (MIT)
+Various Minetest Game developers and contributors (MIT)
 
 Authors of media (textures)
 ---------------------------

--- a/mods/farming/license.txt
+++ b/mods/farming/license.txt
@@ -4,7 +4,7 @@ License of source code
 The MIT License (MIT)
 Copyright (C) 2012-2016 PilzAdam
 Copyright (C) 2014-2016 webdesigner97
-Copyright (C) 2012-2016 Various Luanti developers and contributors
+Copyright (C) 2012-2016 Various Minetest Game developers and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/mods/farming/license.txt
+++ b/mods/farming/license.txt
@@ -4,7 +4,7 @@ License of source code
 The MIT License (MIT)
 Copyright (C) 2012-2016 PilzAdam
 Copyright (C) 2014-2016 webdesigner97
-Copyright (C) 2012-2016 Various Minetest developers and contributors
+Copyright (C) 2012-2016 Various Luanti developers and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/mods/fire/README.txt
+++ b/mods/fire/README.txt
@@ -5,7 +5,7 @@ See license.txt for license information.
 Authors of source code
 ----------------------
 Originally by Perttu Ahola (celeron55) <celeron55@gmail.com> (LGPLv2.1+)
-Various Luanti developers and contributors (LGPLv2.1+)
+Various Minetest Game developers and contributors (LGPLv2.1+)
 
 Authors of media (textures and sounds)
 --------------------------------------

--- a/mods/fire/README.txt
+++ b/mods/fire/README.txt
@@ -5,7 +5,7 @@ See license.txt for license information.
 Authors of source code
 ----------------------
 Originally by Perttu Ahola (celeron55) <celeron55@gmail.com> (LGPLv2.1+)
-Various Minetest developers and contributors (LGPLv2.1+)
+Various Luanti developers and contributors (LGPLv2.1+)
 
 Authors of media (textures and sounds)
 --------------------------------------

--- a/mods/fire/license.txt
+++ b/mods/fire/license.txt
@@ -3,7 +3,7 @@ License of source code
 
 GNU Lesser General Public License, version 2.1
 Copyright (C) 2012-2016 celeron55, Perttu Ahola <celeron55@gmail.com>
-Copyright (C) 2012-2016 Various Luanti developers and contributors
+Copyright (C) 2012-2016 Various Minetest Game developers and contributors
 
 This program is free software; you can redistribute it and/or modify it under the terms
 of the GNU Lesser General Public License as published by the Free Software Foundation;

--- a/mods/fire/license.txt
+++ b/mods/fire/license.txt
@@ -3,7 +3,7 @@ License of source code
 
 GNU Lesser General Public License, version 2.1
 Copyright (C) 2012-2016 celeron55, Perttu Ahola <celeron55@gmail.com>
-Copyright (C) 2012-2016 Various Minetest developers and contributors
+Copyright (C) 2012-2016 Various Luanti developers and contributors
 
 This program is free software; you can redistribute it and/or modify it under the terms
 of the GNU Lesser General Public License as published by the Free Software Foundation;

--- a/mods/flowers/README.txt
+++ b/mods/flowers/README.txt
@@ -5,7 +5,7 @@ See license.txt for license information.
 Authors of source code
 ----------------------
 Originally by Ironzorg (MIT) and VanessaE (MIT)
-Various Minetest developers and contributors (MIT)
+Various Luanti developers and contributors (MIT)
 
 Authors of media (textures)
 ---------------------------

--- a/mods/flowers/README.txt
+++ b/mods/flowers/README.txt
@@ -5,7 +5,7 @@ See license.txt for license information.
 Authors of source code
 ----------------------
 Originally by Ironzorg (MIT) and VanessaE (MIT)
-Various Luanti developers and contributors (MIT)
+Various Minetest Game developers and contributors (MIT)
 
 Authors of media (textures)
 ---------------------------

--- a/mods/flowers/init.lua
+++ b/mods/flowers/init.lua
@@ -1,6 +1,6 @@
 -- flowers/init.lua
 
--- Minetest 0.4 mod: default
+-- Minetest Game mod: flowers
 -- See README.txt for licensing and other information.
 
 

--- a/mods/flowers/license.txt
+++ b/mods/flowers/license.txt
@@ -3,7 +3,7 @@ License of source code
 
 The MIT License (MIT)
 Copyright (C) 2012-2016 Ironzorg, VanessaE
-Copyright (C) 2012-2016 Various Luanti developers and contributors
+Copyright (C) 2012-2016 Various Minetest Game developers and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/mods/flowers/license.txt
+++ b/mods/flowers/license.txt
@@ -3,7 +3,7 @@ License of source code
 
 The MIT License (MIT)
 Copyright (C) 2012-2016 Ironzorg, VanessaE
-Copyright (C) 2012-2016 Various Minetest developers and contributors
+Copyright (C) 2012-2016 Various Luanti developers and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/mods/give_initial_stuff/README.txt
+++ b/mods/give_initial_stuff/README.txt
@@ -5,4 +5,4 @@ See license.txt for license information.
 Authors of source code
 ----------------------
 Perttu Ahola (celeron55) <celeron55@gmail.com> (MIT)
-Various Luanti developers and contributors (MIT)
+Various Minetest Game developers and contributors (MIT)

--- a/mods/give_initial_stuff/README.txt
+++ b/mods/give_initial_stuff/README.txt
@@ -5,4 +5,4 @@ See license.txt for license information.
 Authors of source code
 ----------------------
 Perttu Ahola (celeron55) <celeron55@gmail.com> (MIT)
-Various Minetest developers and contributors (MIT)
+Various Luanti developers and contributors (MIT)

--- a/mods/give_initial_stuff/license.txt
+++ b/mods/give_initial_stuff/license.txt
@@ -3,7 +3,7 @@ License of source code
 
 The MIT License (MIT)
 Copyright (C) 2012-2016 Perttu Ahola (celeron55) <celeron55@gmail.com>
-Copyright (C) 2012-2016 Various Luanti developers and contributors
+Copyright (C) 2012-2016 Various Minetest Game developers and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/mods/give_initial_stuff/license.txt
+++ b/mods/give_initial_stuff/license.txt
@@ -3,7 +3,7 @@ License of source code
 
 The MIT License (MIT)
 Copyright (C) 2012-2016 Perttu Ahola (celeron55) <celeron55@gmail.com>
-Copyright (C) 2012-2016 Various Minetest developers and contributors
+Copyright (C) 2012-2016 Various Luanti developers and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/mods/keys/README.txt
+++ b/mods/keys/README.txt
@@ -5,7 +5,7 @@ See license.txt for license information.
 Authors of source code
 ----------------------
 Originally by celeron55, Perttu Ahola <celeron55@gmail.com> (LGPLv2.1+)
-Various Minetest developers and contributors (LGPLv2.1+)
+Various Luanti developers and contributors (LGPLv2.1+)
 
 Authors of media (textures, sounds, models and schematics)
 ----------------------------------------------------------

--- a/mods/keys/README.txt
+++ b/mods/keys/README.txt
@@ -5,7 +5,7 @@ See license.txt for license information.
 Authors of source code
 ----------------------
 Originally by celeron55, Perttu Ahola <celeron55@gmail.com> (LGPLv2.1+)
-Various Luanti developers and contributors (LGPLv2.1+)
+Various Minetest Game developers and contributors (LGPLv2.1+)
 
 Authors of media (textures, sounds, models and schematics)
 ----------------------------------------------------------

--- a/mods/keys/init.lua
+++ b/mods/keys/init.lua
@@ -1,4 +1,4 @@
--- Minetest mod: keys
+-- Minetest Game mod: keys
 local keys_path = minetest.get_modpath("keys")
 
 dofile(keys_path.."/craftitems.lua")

--- a/mods/keys/license.txt
+++ b/mods/keys/license.txt
@@ -3,7 +3,7 @@ License of source code
 
 GNU Lesser General Public License, version 2.1
 Copyright (C) 2011-2018 celeron55, Perttu Ahola <celeron55@gmail.com>
-Copyright (C) 2011-2018 Various Minetest developers and contributors
+Copyright (C) 2011-2018 Various Luanti developers and contributors
 
 This program is free software; you can redistribute it and/or modify it under the terms
 of the GNU Lesser General Public License as published by the Free Software Foundation;

--- a/mods/keys/license.txt
+++ b/mods/keys/license.txt
@@ -3,7 +3,7 @@ License of source code
 
 GNU Lesser General Public License, version 2.1
 Copyright (C) 2011-2018 celeron55, Perttu Ahola <celeron55@gmail.com>
-Copyright (C) 2011-2018 Various Luanti developers and contributors
+Copyright (C) 2011-2018 Various Minetest Game developers and contributors
 
 This program is free software; you can redistribute it and/or modify it under the terms
 of the GNU Lesser General Public License as published by the Free Software Foundation;

--- a/mods/player_api/README.txt
+++ b/mods/player_api/README.txt
@@ -9,7 +9,7 @@ This mod is only for content related to the Player API and the player object.
 Authors of source code
 ----------------------
 Originally by celeron55, Perttu Ahola <celeron55@gmail.com> (LGPLv2.1+)
-Various Luanti developers and contributors (LGPLv2.1+)
+Various Minetest Game developers and contributors (LGPLv2.1+)
 
 Authors of media (textures, models and sounds)
 ----------------------------------------------

--- a/mods/player_api/README.txt
+++ b/mods/player_api/README.txt
@@ -9,7 +9,7 @@ This mod is only for content related to the Player API and the player object.
 Authors of source code
 ----------------------
 Originally by celeron55, Perttu Ahola <celeron55@gmail.com> (LGPLv2.1+)
-Various Minetest developers and contributors (LGPLv2.1+)
+Various Luanti developers and contributors (LGPLv2.1+)
 
 Authors of media (textures, models and sounds)
 ----------------------------------------------

--- a/mods/player_api/license.txt
+++ b/mods/player_api/license.txt
@@ -3,7 +3,7 @@ License of source code
 
 GNU Lesser General Public License, version 2.1
 Copyright (C) 2011 celeron55, Perttu Ahola <celeron55@gmail.com>
-Copyright (C) 2011 Various Luanti developers and contributors
+Copyright (C) 2011 Various Minetest Game developers and contributors
 
 This program is free software; you can redistribute it and/or modify it under the terms
 of the GNU Lesser General Public License as published by the Free Software Foundation;

--- a/mods/player_api/license.txt
+++ b/mods/player_api/license.txt
@@ -3,7 +3,7 @@ License of source code
 
 GNU Lesser General Public License, version 2.1
 Copyright (C) 2011 celeron55, Perttu Ahola <celeron55@gmail.com>
-Copyright (C) 2011 Various Minetest developers and contributors
+Copyright (C) 2011 Various Luanti developers and contributors
 
 This program is free software; you can redistribute it and/or modify it under the terms
 of the GNU Lesser General Public License as published by the Free Software Foundation;

--- a/mods/screwdriver/README.txt
+++ b/mods/screwdriver/README.txt
@@ -5,7 +5,7 @@ See license.txt for license information.
 License of source code
 ----------------------
 Originally by RealBadAngel, Maciej Kasatkin (LGPLv2.1+)
-Various Minetest developers and contributors (LGPLv2.1+)
+Various Luanti developers and contributors (LGPLv2.1+)
 
 License of media (textures)
 ---------------------------

--- a/mods/screwdriver/README.txt
+++ b/mods/screwdriver/README.txt
@@ -5,7 +5,7 @@ See license.txt for license information.
 License of source code
 ----------------------
 Originally by RealBadAngel, Maciej Kasatkin (LGPLv2.1+)
-Various Luanti developers and contributors (LGPLv2.1+)
+Various Minetest Game developers and contributors (LGPLv2.1+)
 
 License of media (textures)
 ---------------------------

--- a/mods/screwdriver/license.txt
+++ b/mods/screwdriver/license.txt
@@ -3,7 +3,7 @@ License of source code
 
 GNU Lesser General Public License, version 2.1
 Copyright (C) 2013-2016 RealBadAngel, Maciej Kasatkin
-Copyright (C) 2013-2016 Various Minetest developers and contributors
+Copyright (C) 2013-2016 Various Luanti developers and contributors
 
 This program is free software; you can redistribute it and/or modify it under the terms
 of the GNU Lesser General Public License as published by the Free Software Foundation;

--- a/mods/screwdriver/license.txt
+++ b/mods/screwdriver/license.txt
@@ -3,7 +3,7 @@ License of source code
 
 GNU Lesser General Public License, version 2.1
 Copyright (C) 2013-2016 RealBadAngel, Maciej Kasatkin
-Copyright (C) 2013-2016 Various Luanti developers and contributors
+Copyright (C) 2013-2016 Various Minetest Game developers and contributors
 
 This program is free software; you can redistribute it and/or modify it under the terms
 of the GNU Lesser General Public License as published by the Free Software Foundation;

--- a/mods/sfinv/README.txt
+++ b/mods/sfinv/README.txt
@@ -6,7 +6,7 @@ Simple Fast Inventory.
 A cleaner, simpler, solution to having an advanced inventory in Luanti.
 See game_api.txt for this mod's API.
 Available for use outside of MTG here:
-https://forum.minetest.net/viewtopic.php?t=19765
+https://forum.luanti.org/viewtopic.php?t=19765
 
 Authors of source code
 ----------------------

--- a/mods/sfinv/README.txt
+++ b/mods/sfinv/README.txt
@@ -3,7 +3,7 @@ Minetest Game mod: sfinv
 See license.txt for license information.
 
 Simple Fast Inventory.
-A cleaner, simpler, solution to having an advanced inventory in Minetest.
+A cleaner, simpler, solution to having an advanced inventory in Luanti.
 See game_api.txt for this mod's API.
 Available for use outside of MTG here:
 https://forum.minetest.net/viewtopic.php?t=19765

--- a/mods/stairs/README.txt
+++ b/mods/stairs/README.txt
@@ -6,7 +6,7 @@ Authors of source code
 ----------------------
 Originally by Kahrl <kahrl@gmx.net> (LGPLv2.1+) and
 celeron55, Perttu Ahola <celeron55@gmail.com> (LGPLv2.1+)
-Various Luanti developers and contributors (LGPLv2.1+)
+Various Minetest Game developers and contributors (LGPLv2.1+)
 
 Authors of media (textures)
 ---------------------------

--- a/mods/stairs/README.txt
+++ b/mods/stairs/README.txt
@@ -6,7 +6,7 @@ Authors of source code
 ----------------------
 Originally by Kahrl <kahrl@gmx.net> (LGPLv2.1+) and
 celeron55, Perttu Ahola <celeron55@gmail.com> (LGPLv2.1+)
-Various Minetest developers and contributors (LGPLv2.1+)
+Various Luanti developers and contributors (LGPLv2.1+)
 
 Authors of media (textures)
 ---------------------------

--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -1,6 +1,6 @@
 -- stairs/init.lua
 
--- Minetest 0.4 mod: stairs
+-- Minetest Game mod: stairs
 -- See README.txt for licensing and other information.
 
 

--- a/mods/stairs/license.txt
+++ b/mods/stairs/license.txt
@@ -4,7 +4,7 @@ License of source code
 GNU Lesser General Public License, version 2.1
 Copyright (C) 2011-2017 Kahrl <kahrl@gmx.net>
 Copyright (C) 2011-2017 celeron55, Perttu Ahola <celeron55@gmail.com>
-Copyright (C) 2012-2017 Various Luanti developers and contributors
+Copyright (C) 2012-2017 Various Minetest Game developers and contributors
 
 This program is free software; you can redistribute it and/or modify it under the terms
 of the GNU Lesser General Public License as published by the Free Software Foundation;

--- a/mods/stairs/license.txt
+++ b/mods/stairs/license.txt
@@ -4,7 +4,7 @@ License of source code
 GNU Lesser General Public License, version 2.1
 Copyright (C) 2011-2017 Kahrl <kahrl@gmx.net>
 Copyright (C) 2011-2017 celeron55, Perttu Ahola <celeron55@gmail.com>
-Copyright (C) 2012-2017 Various Minetest developers and contributors
+Copyright (C) 2012-2017 Various Luanti developers and contributors
 
 This program is free software; you can redistribute it and/or modify it under the terms
 of the GNU Lesser General Public License as published by the Free Software Foundation;

--- a/mods/tnt/README.txt
+++ b/mods/tnt/README.txt
@@ -7,7 +7,7 @@ Authors of source code
 PilzAdam (MIT)
 ShadowNinja (MIT)
 sofar (sofar@foo-projects.org) (MIT)
-Various Luanti developers and contributors (MIT)
+Various Minetest Game developers and contributors (MIT)
 
 Authors of media
 ----------------

--- a/mods/tnt/README.txt
+++ b/mods/tnt/README.txt
@@ -7,7 +7,7 @@ Authors of source code
 PilzAdam (MIT)
 ShadowNinja (MIT)
 sofar (sofar@foo-projects.org) (MIT)
-Various Minetest developers and contributors (MIT)
+Various Luanti developers and contributors (MIT)
 
 Authors of media
 ----------------
@@ -45,8 +45,7 @@ by frankelmedico (CC0 1.0)
 
 Introduction
 ------------
-This mod adds TNT to Minetest. TNT is a tool to help the player
-in mining.
+This mod adds TNT. TNT is a tool to help the player in mining.
 
 How to use the mod:
 

--- a/mods/tnt/license.txt
+++ b/mods/tnt/license.txt
@@ -5,7 +5,7 @@ The MIT License (MIT)
 Copyright (C) 2014-2016 PilzAdam
 Copyright (C) 2014-2016 ShadowNinja
 Copyright (C) 2016 sofar (sofar@foo-projects.org)
-Copyright (C) 2014-2016 Various Minetest developers and contributors
+Copyright (C) 2014-2016 Various Luanti developers and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/mods/tnt/license.txt
+++ b/mods/tnt/license.txt
@@ -5,7 +5,7 @@ The MIT License (MIT)
 Copyright (C) 2014-2016 PilzAdam
 Copyright (C) 2014-2016 ShadowNinja
 Copyright (C) 2016 sofar (sofar@foo-projects.org)
-Copyright (C) 2014-2016 Various Luanti developers and contributors
+Copyright (C) 2014-2016 Various Minetest Game developers and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/mods/vessels/README.txt
+++ b/mods/vessels/README.txt
@@ -6,7 +6,7 @@ Authors of source code
 ----------------------
 Originally by Vanessa Ezekowitz (LGPLv2.1+)
 Modified by Perttu Ahola <celeron55@gmail.com> (LGPLv2.1+)
-Various Minetest developers and contributors (LGPLv2.1+)
+Various Luanti developers and contributors (LGPLv2.1+)
 
 Authors of media (textures)
 ---------------------------

--- a/mods/vessels/README.txt
+++ b/mods/vessels/README.txt
@@ -6,7 +6,7 @@ Authors of source code
 ----------------------
 Originally by Vanessa Ezekowitz (LGPLv2.1+)
 Modified by Perttu Ahola <celeron55@gmail.com> (LGPLv2.1+)
-Various Luanti developers and contributors (LGPLv2.1+)
+Various Minetest Game developers and contributors (LGPLv2.1+)
 
 Authors of media (textures)
 ---------------------------

--- a/mods/vessels/init.lua
+++ b/mods/vessels/init.lua
@@ -1,6 +1,6 @@
 -- vessels/init.lua
 
--- Minetest 0.4 mod: vessels
+-- Minetest Game mod: vessels
 -- See README.txt for licensing and other information.
 
 -- Load support for MT game translation.

--- a/mods/vessels/license.txt
+++ b/mods/vessels/license.txt
@@ -4,7 +4,7 @@ License of source code
 GNU Lesser General Public License, version 2.1
 Copyright (C) 2012-2016 Vanessa Ezekowitz
 Copyright (C) 2012-2016 celeron55, Perttu Ahola <celeron55@gmail.com>
-Copyright (C) 2012-2016 Various Minetest developers and contributors
+Copyright (C) 2012-2016 Various Luanti developers and contributors
 
 This program is free software; you can redistribute it and/or modify it under the terms
 of the GNU Lesser General Public License as published by the Free Software Foundation;

--- a/mods/vessels/license.txt
+++ b/mods/vessels/license.txt
@@ -4,7 +4,7 @@ License of source code
 GNU Lesser General Public License, version 2.1
 Copyright (C) 2012-2016 Vanessa Ezekowitz
 Copyright (C) 2012-2016 celeron55, Perttu Ahola <celeron55@gmail.com>
-Copyright (C) 2012-2016 Various Luanti developers and contributors
+Copyright (C) 2012-2016 Various Minetest Game developers and contributors
 
 This program is free software; you can redistribute it and/or modify it under the terms
 of the GNU Lesser General Public License as published by the Free Software Foundation;

--- a/mods/wool/README.txt
+++ b/mods/wool/README.txt
@@ -5,7 +5,7 @@ See license.txt for license information.
 Authors of source code
 ----------------------
 Originally by Perttu Ahola (celeron55) <celeron55@gmail.com> (MIT)
-Various Minetest developers and contributors (MIT)
+Various Luanti developers and contributors (MIT)
 
 Authors of media (textures)
 ---------------------------

--- a/mods/wool/README.txt
+++ b/mods/wool/README.txt
@@ -5,7 +5,7 @@ See license.txt for license information.
 Authors of source code
 ----------------------
 Originally by Perttu Ahola (celeron55) <celeron55@gmail.com> (MIT)
-Various Luanti developers and contributors (MIT)
+Various Minetest Game developers and contributors (MIT)
 
 Authors of media (textures)
 ---------------------------

--- a/mods/wool/license.txt
+++ b/mods/wool/license.txt
@@ -3,7 +3,7 @@ License of source code
 
 The MIT License (MIT)
 Copyright (C) 2012-2016 Perttu Ahola (celeron55) <celeron55@gmail.com>
-Copyright (C) 2012-2016 Various Luanti developers and contributors
+Copyright (C) 2012-2016 Various Minetest Game developers and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/mods/wool/license.txt
+++ b/mods/wool/license.txt
@@ -3,7 +3,7 @@ License of source code
 
 The MIT License (MIT)
 Copyright (C) 2012-2016 Perttu Ahola (celeron55) <celeron55@gmail.com>
-Copyright (C) 2012-2016 Various Minetest developers and contributors
+Copyright (C) 2012-2016 Various Luanti developers and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/mods/xpanes/README.txt
+++ b/mods/xpanes/README.txt
@@ -7,7 +7,7 @@ Authors of source code
 Originally by xyz (MIT)
 BlockMen (MIT)
 sofar (MIT)
-Various Luanti developers and contributors (MIT)
+Various Minetest Game developers and contributors (MIT)
 
 Authors of media (textures)
 ---------------------------

--- a/mods/xpanes/README.txt
+++ b/mods/xpanes/README.txt
@@ -7,7 +7,7 @@ Authors of source code
 Originally by xyz (MIT)
 BlockMen (MIT)
 sofar (MIT)
-Various Minetest developers and contributors (MIT)
+Various Luanti developers and contributors (MIT)
 
 Authors of media (textures)
 ---------------------------

--- a/mods/xpanes/license.txt
+++ b/mods/xpanes/license.txt
@@ -5,7 +5,7 @@ The MIT License (MIT)
 Copyright (C) 2014-2016 xyz
 Copyright (C) 2014-2016 BlockMen
 Copyright (C) 2016 Auke Kok <sofar@foo-projects.org>
-Copyright (C) 2014-2016 Various Luanti developers and contributors
+Copyright (C) 2014-2016 Various Minetest Game developers and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/mods/xpanes/license.txt
+++ b/mods/xpanes/license.txt
@@ -5,7 +5,7 @@ The MIT License (MIT)
 Copyright (C) 2014-2016 xyz
 Copyright (C) 2014-2016 BlockMen
 Copyright (C) 2016 Auke Kok <sofar@foo-projects.org>
-Copyright (C) 2014-2016 Various Minetest developers and contributors
+Copyright (C) 2014-2016 Various Luanti developers and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/schematic_tables.txt
+++ b/schematic_tables.txt
@@ -10,7 +10,7 @@ convert the Lua tables into .mts files. Such mods often have two functions to
 process two formats of the 'data' table:
 
 The standard table format is described in the 'Schematic specifier' section of
-the lua_api.txt file in the Minetest Engine.
+the lua_api.txt file in Luanti.
 The 'data' table appears as a sequence of vertical slices through the structure
 the schematic describes.
 Each XY-plane slice has the X-rows formatted in order of increasing Y, so the


### PR DESCRIPTION
This PR changes the name "Minetest" to "Luanti" in all files. Fixes #3164.

It also changes the links from minetest.net to luanti.org domains (all tested).

Finally, the `game.conf` author is changed from "Minetest" to "Luanti". This is done in a separate commit because I'm not sure if doing so is safe. If this is a problem, just drop that commit.