### PR TITLE
Tweak beds moving check

### DIFF
--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -97,7 +97,7 @@ local function lay_down(player, pos, bed_pos, state, skip)
 		end
 
 		-- Check if player is moving
-		if vector.length(player:get_velocity()) > 0.001 then
+		if vector.length(player:get_velocity()) > 0.05 then
 			minetest.chat_send_player(name, S("You have to stop moving before going to bed!"))
 			return false
 		end


### PR DESCRIPTION
checking player movement is too sensative with 0.001 as the value, changing to 0.05 works a lot better especially when 3rd party mods that change player physics is in use.