### PR TITLE
Beds: allow digging stray top nodes

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -7,6 +7,7 @@ globals = {
 
 read_globals = {
 	"DIR_DELIM",
+	"core",
 	"minetest",
 	"dump",
 	"vector",

--- a/mods/beds/api.lua
+++ b/mods/beds/api.lua
@@ -10,6 +10,9 @@ end
 local function get_other_bed_pos(pos, n)
 	local node = core.get_node(pos)
 	local dir = core.facedir_to_dir(node.param2)
+	if not dir then
+		return -- There are 255 possible param2 values. Ignore bad ones.
+	end
 	local other
 	if n == 2 then
 		other = vector.subtract(pos, dir)
@@ -124,6 +127,9 @@ function beds.register_bed(name, def)
 
 		on_rotate = function(pos, node, user, _, new_param2)
 			local dir = minetest.facedir_to_dir(node.param2)
+			if not dir then
+				return false
+			end
 			-- old position of the top node
 			local p = vector.add(pos, dir)
 			local node2 = minetest.get_node_or_nil(p)

--- a/mods/beds/api.lua
+++ b/mods/beds/api.lua
@@ -6,23 +6,33 @@ local function remove_no_destruct(pos)
 	minetest.check_for_falling(pos)
 end
 
-local function destruct_bed(pos, n)
-	local node = minetest.get_node(pos)
+--- returns the position of the other bed half (or nil on failure)
+local function get_other_bed_pos(pos, n)
+	local node = core.get_node(pos)
+	local dir = core.facedir_to_dir(node.param2)
 	local other
-
 	if n == 2 then
-		local dir = minetest.facedir_to_dir(node.param2)
 		other = vector.subtract(pos, dir)
 	elseif n == 1 then
-		local dir = minetest.facedir_to_dir(node.param2)
 		other = vector.add(pos, dir)
+	else
+		return nil
 	end
-	local oname = minetest.get_node(other).name
-	if minetest.get_item_group(oname, "bed") ~= 0 then
-	   remove_no_destruct(other)
-	   beds.remove_spawns_at(pos)
-	   beds.remove_spawns_at(other)
+
+	local onode = core.get_node(other)
+	if onode.param2 == node.param2 and core.get_item_group(onode.name, "bed") ~= 0 then
+		return other
 	end
+	return nil
+end
+
+local function destruct_bed(pos, n)
+	local other = get_other_bed_pos(pos, n)
+	if other then
+		remove_no_destruct(other)
+		beds.remove_spawns_at(other)
+	end
+	beds.remove_spawns_at(pos)
 end
 
 function beds.register_bed(name, def)
@@ -157,23 +167,25 @@ function beds.register_bed(name, def)
 		paramtype = "light",
 		paramtype2 = "facedir",
 		is_ground_content = false,
-		pointable = false,
 		groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 3, bed = 2,
 				not_in_creative_inventory = 1},
 		sounds = def.sounds or default.node_sound_wood_defaults(),
-		drop = name .. "_bottom",
+		drop = "",
 		node_box = {
 			type = "fixed",
 			fixed = def.nodebox.top,
+		},
+		selection_box = {
+			type = "fixed",
+			-- Small selection box to allow digging stray top nodes
+			fixed = {-0.3, -0.3, -0.3, 0.3, -0.1, 0.3},
 		},
 		on_destruct = function(pos)
 			destruct_bed(pos, 2)
 		end,
 		can_dig = function(pos, player)
-			local node = minetest.get_node(pos)
-			local dir = minetest.facedir_to_dir(node.param2)
-			local p = vector.add(pos, dir)
-			return beds.can_dig(p)
+			local other = get_other_bed_pos(pos, 2)
+			return (not other) or beds.can_dig(other)
 		end,
 	})
 


### PR DESCRIPTION
Stray nodes (or half beds) may occur by ...
1. rotating the bottom bed node without calling the 'on_rotate' callback for various reasons
2. and digging one of the two nodes.
In master, the top node cannot be dug and is left in a bugged state. You cannot place another bed on top to fix it. The placement aborts. Hence this PR allows digging the top node as well without causing item duplication or item loss.

This PR might or might not fix #3171 (unconfirmed bug)

## How to test

Test 1:
1. Check whether normal bed placement and digging works.

Test 2:
1. Rotate the bed (bottom) node using any manipulation tool. I used the technic sonic screwdriver for this.
4. Dig the bottom node. -> You must receive a bed drop
5. Dig the top node. -> There must not be a drop

Test 3:
1. Rotate the bed (bottom) node
2. Dig the top node. -> There must not be a drop
4. Dig the bottom node. -> You must receive a bed drop

Test 4:
1. Rotate the nodes in any way
2. No errors or anomalies must occur.