### PR TITLE
Fix optimize_textures.sh

### DIFF
--- a/utils/optimize_textures.sh
+++ b/utils/optimize_textures.sh
@@ -3,4 +3,4 @@
 # Colors with 0 alpha need to be preserved, because opaque leaves ignore alpha.
 # For that purpose, the use of indexed colors is disabled (-nc).
 
-find -name '../*.png' -print0 | xargs -0 optipng -o7 -zm1-9 -nc -strip all -clobber
+find .. -name '*.png' -print0 | xargs -0 optipng -o7 -zm1-9 -nc -strip all -clobber


### PR DESCRIPTION
I don't know when it stopped working, but now it gives the following error:

> find: warning: ‘-name’ matches against basenames only, but the given pattern contains a directory separator (‘/’), thus the expression will evaluate to false all the time.  Did you mean ‘-wholename’?

Changing it from `find -name '../*.png'` to `find .. -name '*.png'` fixed it for me.