### PR TITLE
Fix minus character (`-`) being striped from signs

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -2620,7 +2620,7 @@ local function register_sign(material, desc, def)
 				minetest.chat_send_player(player_name, S("Text too long"))
 				return
 			end
-			text = text:gsub("[%z-\8\11-\31\127]", "") -- strip naughty control characters (keeps \t and \n)
+			text = text:gsub("[%z\1-\8\11-\31\127]", "") -- strip naughty control characters (keeps \t and \n)
 			default.log_player_action(sender, ("wrote %q to the sign at"):format(text), pos)
 			local meta = minetest.get_meta(pos)
 			meta:set_string("text", text)


### PR DESCRIPTION
## Summary

Minus `-` was removed from signs.

Seems to be an oversight of https://github.com/luanti-org/minetest_game/pull/3022/commits/72cb7dbdb2954922f52c14591ec99658f68dd8cf in #3022.
cc @appgurueu 

## Reproduction

* Place a sign.
* Write `a-b` into it.
* `ab` will be written in master.