### PR TITLE
Fix player not kicked out of bed on destruct

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -49,6 +49,7 @@ Beds API
  * `beds.can_dig(bed_pos)` Returns a boolean whether the bed at `bed_pos` may be dug
  * `beds.read_spawns() `   Returns a table containing players respawn positions
  * `beds.kick_players()`  Forces all players to leave bed
+ * `beds.kick_player_at(pos)`  Forces player out of bed at pos (returns true on success, false otherwise)
  * `beds.skip_night()`   Sets world time to morning and saves respawn position of all players currently sleeping
  * `beds.day_interval`   Is a table with keys "start" and "finish". Allows you
    to set the period of the day (timeofday format). Default: `{ start = 0.2, finish = 0.805 }`.

--- a/mods/beds/api.lua
+++ b/mods/beds/api.lua
@@ -36,6 +36,11 @@ local function destruct_bed(pos, n)
 		beds.remove_spawns_at(other)
 	end
 	beds.remove_spawns_at(pos)
+	if n == 1 then
+		beds.kick_player_at(pos)
+	elseif n == 2 and other then
+		beds.kick_player_at(other)
+	end
 end
 
 function beds.register_bed(name, def)

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -251,6 +251,23 @@ local function schedule_update()
 	end)
 end
 
+function beds.kick_player_at(kick_pos)
+	for name, bed_pos in pairs(beds.bed_position) do
+		if vector.equals(bed_pos, kick_pos) then
+			if beds.player[name] then
+				local player = core.get_player_by_name(name)
+				if not player then
+					return false
+				end
+				lay_down(player, nil, nil, false)
+				core.log("info", "[beds] Kicked "..name.." out of bed at "..core.pos_to_string(kick_pos))
+				return true
+			end
+		end
+	end
+	return false
+end
+
 function beds.on_rightclick(pos, player)
 	local name = player:get_player_name()
 	local ppos = player:get_pos()

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -260,6 +260,7 @@ function beds.kick_player_at(kick_pos)
 					return false
 				end
 				lay_down(player, nil, nil, false)
+				core.close_formspec(name, "beds_form")
 				core.log("info", "[beds] Kicked "..name.." out of bed at "..core.pos_to_string(kick_pos))
 				return true
 			end


### PR DESCRIPTION
Fixes #3167.

This guarantees any player in a given bed is kicked out of it when it is destroyed, using the `on_destruct` callback.

This PR has also been tested with the bed being destroyed by fire.

Competing PR: #3168