### PR TITLE
Fix description of overridden `give` privilege

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -2,7 +2,7 @@ unused_args = false
 allow_defined_top = true
 
 globals = {
-	"default"
+	"default",
 }
 
 read_globals = {
@@ -33,3 +33,6 @@ files["mods/player_api/api.lua"].globals = { "minetest" }
 
 -- Don't report on legacy definitions of globals.
 files["mods/default/legacy.lua"].global = false
+
+-- Overwrites a description of a privilege
+files["mods/default/chat.lua"].globals = { "core.registered_privileges" }

--- a/mods/default/chat.lua
+++ b/mods/default/chat.lua
@@ -1,6 +1,5 @@
 -- mods/default/chat.lua
 
--- support for MT game translation.
 local S = default.get_translator
 
 local function match_old(privs)
@@ -17,6 +16,7 @@ end
 
 -- Change /pulverize and /clearinv to not require give, like it used to be
 -- before Luanti 5.15
+local command_overridden = false
 for _, cmd in ipairs({"pulverize", "clearinv"}) do
 	local def = core.registered_chatcommands[cmd]
 	if def then
@@ -24,6 +24,7 @@ for _, cmd in ipairs({"pulverize", "clearinv"}) do
 			core.override_chatcommand(cmd, {
 				privs = {interact=true},
 			})
+			command_overridden = true
 		else
 			minetest.log("info", "Privileges of command /" .. cmd .. " look modified, not overriding them.")
 		end
@@ -31,6 +32,6 @@ for _, cmd in ipairs({"pulverize", "clearinv"}) do
 end
 
 -- Revert description of 'give' privilege to what it was in Luanti 5.14
-if core.registered_privileges["give"] then
+if command_overridden and core.registered_privileges["give"] then
 	core.registered_privileges["give"].description = S("Can use /give and /giveme")
 end

--- a/mods/default/chat.lua
+++ b/mods/default/chat.lua
@@ -1,5 +1,8 @@
 -- mods/default/chat.lua
 
+-- support for MT game translation.
+local S = default.get_translator
+
 local function match_old(privs)
 	local ok = false
 	for k, v in pairs(privs) do
@@ -25,4 +28,9 @@ for _, cmd in ipairs({"pulverize", "clearinv"}) do
 			minetest.log("info", "Privileges of command /" .. cmd .. " look modified, not overriding them.")
 		end
 	end
+end
+
+-- Revert description of 'give' privilege to what it was in Luanti 5.14
+if core.registered_privileges["give"] then
+	core.registered_privileges["give"].description = S("Can use /give and /giveme")
 end

--- a/mods/default/locale/default.bg.tr
+++ b/mods/default/locale/default.bg.tr
@@ -1,4 +1,5 @@
 # textdomain: default
+Can use /give and /giveme=Може да използва /give и /giveme
 Locked Chest=Заключен сандък
 Locked Chest (owned by @1)=Заключен сандък (собственост на @1)
 You do not own this chest.=Не притежавате този сандък.

--- a/mods/default/locale/default.da.tr
+++ b/mods/default/locale/default.da.tr
@@ -1,4 +1,5 @@
 # textdomain: default
+Can use /give and /giveme=
 Locked Chest=Låst kiste
 Locked Chest (owned by @1)=Låst kiste (ejet af @1)
 You do not own this chest.=Du ejer ikke denne kiste.

--- a/mods/default/locale/default.de.tr
+++ b/mods/default/locale/default.de.tr
@@ -1,4 +1,5 @@
 # textdomain: default
+Can use /give and /giveme=Kann /give und /giveme benutzen
 Locked Chest=Abgeschlossene Truhe
 Locked Chest (owned by @1)=Abgeschlossene Truhe (Eigentum von @1)
 You do not own this chest.=Ihnen gehört diese Truhe nicht.

--- a/mods/default/locale/default.eo.tr
+++ b/mods/default/locale/default.eo.tr
@@ -1,4 +1,5 @@
 # textdomain: default
+Can use /give and /giveme=Povas uzi /give kaj /giveme
 Locked Chest=Ŝlosita kesto
 Locked Chest (owned by @1)=Ŝlosita kesto (de @1)
 You do not own this chest.=Vi ne posedas ĉi tiun keston.

--- a/mods/default/locale/default.es.tr
+++ b/mods/default/locale/default.es.tr
@@ -1,4 +1,5 @@
 # textdomain: default
+Can use /give and /giveme=
 Locked Chest=Cofre cerrado
 Locked Chest (owned by @1)=Cofre cerrado (propiedad de @1)
 You do not own this chest.=Este cofre no te pertenece.

--- a/mods/default/locale/default.eu.tr
+++ b/mods/default/locale/default.eu.tr
@@ -1,4 +1,5 @@
 # textdomain: default
+Can use /give and /giveme=
 Locked Chest=Itxitako kutxa
 Locked Chest (owned by @1)=Itxitako kutxa (jabea: @1)
 You do not own this chest.=Kutxa hau ez da zurea.

--- a/mods/default/locale/default.fr.tr
+++ b/mods/default/locale/default.fr.tr
@@ -1,4 +1,5 @@
 # textdomain: default
+Can use /give and /giveme=Peut utiliser /give et /giveme
 Locked Chest=Coffre verrouillé
 Locked Chest (owned by @1)=Coffre verrouillé (possédé par @1)
 You do not own this chest.=Ce coffre ne vous appartient pas.

--- a/mods/default/locale/default.hu.tr
+++ b/mods/default/locale/default.hu.tr
@@ -1,4 +1,5 @@
 # textdomain: default
+Can use /give and /giveme=
 Locked Chest=Lezárt láda
 Locked Chest (owned by @1)=Lezárt láda (@1 tulajdona)
 You do not own this chest.=Nem a tiéd ez a láda.

--- a/mods/default/locale/default.id.tr
+++ b/mods/default/locale/default.id.tr
@@ -1,4 +1,5 @@
 # textdomain: default
+Can use /give and /giveme=Dapat menggunakan /give dan /giveme
 Locked Chest=Peti Terkunci
 Locked Chest (owned by @1)=Peti Terkunci (milik @1)
 You do not own this chest.=Anda bukan pemilik peti ini.

--- a/mods/default/locale/default.it.tr
+++ b/mods/default/locale/default.it.tr
@@ -1,4 +1,5 @@
 # textdomain: default
+Can use /give and /giveme=Si possono usare /give e /give me
 Locked Chest=Baule chiuso a chiave
 Locked Chest (owned by @1)=Baule chiuso a chiave (di proprietà di @1)
 You do not own this chest.=Questo baule non ti appartiene.

--- a/mods/default/locale/default.ja.tr
+++ b/mods/default/locale/default.ja.tr
@@ -1,4 +1,5 @@
 # textdomain: default
+Can use /give and /giveme=
 Locked Chest=鍵のかかったチェスト
 Locked Chest (owned by @1)=鍵のかかったチェスト(@1所有)
 You do not own this chest.=あなたはこのチェストの所有者ではありません。

--- a/mods/default/locale/default.jbo.tr
+++ b/mods/default/locale/default.jbo.tr
@@ -1,4 +1,5 @@
 # textdomain: default
+Can use /give and /giveme=
 Locked Chest=lo selstela gairvau
 Locked Chest (owned by @1)=.i ti selstela gairvau po la'o zo'i.@1.zo'i
 You do not own this chest.=.i do na ponse lo ti gairvau

--- a/mods/default/locale/default.lv.tr
+++ b/mods/default/locale/default.lv.tr
@@ -1,4 +1,5 @@
 # textdomain: default
+Can use /give and /giveme=
 Locked Chest=Aizslēgta lāde
 Locked Chest (owned by @1)=Aizslēgta lāde (Saimnieks: @1)
 You do not own this chest.=Jums nepieder šī lāde.

--- a/mods/default/locale/default.ms.tr
+++ b/mods/default/locale/default.ms.tr
@@ -1,4 +1,5 @@
 # textdomain: default
+Can use /give and /giveme=Boleh menggunakan /give dan /giveme
 Locked Chest=Peti Berkunci
 Locked Chest (owned by @1)=Peti Berkunci (milik @1)
 You do not own this chest.=Ini bukan peti milik anda.

--- a/mods/default/locale/default.pl.tr
+++ b/mods/default/locale/default.pl.tr
@@ -1,4 +1,5 @@
 # textdomain: default
+Can use /give and /giveme=
 Locked Chest=Zablokowana skrzynia
 Locked Chest (owned by @1)=Zablokowana skrzynia (właściciel: @1)
 You do not own this chest.=Nie jesteś właścicielem tej skrzyni.

--- a/mods/default/locale/default.pt.tr
+++ b/mods/default/locale/default.pt.tr
@@ -1,4 +1,5 @@
 # textdomain: default
+Can use /give and /giveme=
 Locked Chest=Baú Trancado
 Locked Chest (owned by @1)=Baú Trancado (pertence a @1)
 You do not own this chest.=Você não é dono deste baú.

--- a/mods/default/locale/default.pt_BR.tr
+++ b/mods/default/locale/default.pt_BR.tr
@@ -1,4 +1,5 @@
 # textdomain: default
+Can use /give and /giveme=Pode usar /give e /giveme
 Locked Chest=Baú Trancado
 Locked Chest (owned by @1)=Baú Trancado (pertence a @1)
 You do not own this chest.=Você não é dono deste baú.

--- a/mods/default/locale/default.ru.tr
+++ b/mods/default/locale/default.ru.tr
@@ -1,4 +1,5 @@
 # textdomain: default
+Can use /give and /giveme=Может использовать /give и /giveme
 Locked Chest=Запертый сундук
 Locked Chest (owned by @1)=Запертый сундук (владелец: @1)
 You do not own this chest.=Вы не владелец этого сундука.

--- a/mods/default/locale/default.sk.tr
+++ b/mods/default/locale/default.sk.tr
@@ -1,4 +1,5 @@
 # textdomain: default
+Can use /give and /giveme=
 Locked Chest=Uzamknutá truhlica
 Locked Chest (owned by @1)=Uzamknutá truhlica (Vlastník - @1)
 You do not own this chest.=Túto truhlicu nevlastníš.

--- a/mods/default/locale/default.sv.tr
+++ b/mods/default/locale/default.sv.tr
@@ -1,4 +1,5 @@
 # textdomain: default
+Can use /give and /giveme=
 Locked Chest=Låst kista
 Locked Chest (owned by @1)=Låst kista (Ägd av @1)
 You do not own this chest.=Du äger inte denna kista.

--- a/mods/default/locale/default.uk.tr
+++ b/mods/default/locale/default.uk.tr
@@ -1,4 +1,5 @@
 # textdomain: default
+Can use /give and /giveme=
 Locked Chest=Замкнена скриня
 Locked Chest (owned by @1)=Замкнена скриня (власник — @1)
 You do not own this chest.=Ви — не власник цієї скрині.

--- a/mods/default/locale/default.zh_CN.tr
+++ b/mods/default/locale/default.zh_CN.tr
@@ -1,4 +1,5 @@
 # textdomain: default
+Can use /give and /giveme=
 Locked Chest=已上锁的箱子
 Locked Chest (owned by @1)=已上锁的箱子（属于@1）
 You do not own this chest.=这个箱子不属于你所有。

--- a/mods/default/locale/default.zh_TW.tr
+++ b/mods/default/locale/default.zh_TW.tr
@@ -1,4 +1,5 @@
 # textdomain: default
+Can use /give and /giveme=
 Locked Chest=已上鎖的箱子
 Locked Chest (owned by @1)=已上鎖的箱子（屬於@1所有）
 You do not own this chest.=這個箱子不屬於你所有。

--- a/mods/default/locale/template.txt
+++ b/mods/default/locale/template.txt
@@ -1,4 +1,5 @@
 # textdomain: default
+Can use /give and /giveme=
 Locked Chest=
 Locked Chest (owned by @1)=
 You do not own this chest.=


### PR DESCRIPTION
Fixes #3224.

This also imports the translations of the old `give` priv description from Luanti pre-5.15.

##### How to test

1. Start game in Luanti 5.15
2. Enter `/help privs`
3. Read the description of the `give` privilege

It should only mention `/give` and `/giveme` commands but no other command.