### PR TITLE
beds: allow setting spawn point during daytime

### DIFF
--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -277,7 +277,6 @@ function beds.on_rightclick(pos, player)
 	if tod > beds.day_interval.start and tod < beds.day_interval.finish then
 		beds.set_spawns(player, pos)
 		if beds.player[name] then
-			
 			lay_down(player, nil, nil, false)
 		end
 		minetest.chat_send_player(name, S("You can only sleep at night."))
@@ -288,7 +287,6 @@ function beds.on_rightclick(pos, player)
 	-- move to bed
 	if not beds.player[name] then
 		lay_down(player, ppos, pos)
-		
 		beds.set_spawns(player, pos) -- save respawn positions when entering bed
 	else
 		lay_down(player, nil, nil, false)

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -275,20 +275,19 @@ function beds.on_rightclick(pos, player)
 	local tod = minetest.get_timeofday()
 
 	if tod > beds.day_interval.start and tod < beds.day_interval.finish then
-    if beds.player[name] then
-        lay_down(player, nil, nil, false)
-    end
+		if beds.player[name] then
+			lay_down(player, nil, nil, false)
+		end
+		local current_spawn = beds.spawn[name]
+		if not current_spawn or vector.distance(current_spawn, pos) > 0.1 then
+			beds.set_spawns(player, pos)
+			minetest.chat_send_player(name, S("Spawn point set."))
+		else
+			minetest.chat_send_player(name, S("You can only sleep at night."))
+		end
+		return
+	end
 
-    -- Only set spawn if not already set to this bed
-    local current_spawn = beds.spawn[name]
-    if not current_spawn or vector.distance(current_spawn, pos) > 0.1 then
-        beds.set_spawns(player, pos)
-        minetest.chat_send_player(name, S("Spawn point set."))
-    end
-
-    minetest.chat_send_player(name, S("You can only sleep at night."))
-    return
-end
 
 	-- move to bed
 	if not beds.player[name] then

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -275,14 +275,20 @@ function beds.on_rightclick(pos, player)
 	local tod = minetest.get_timeofday()
 
 	if tod > beds.day_interval.start and tod < beds.day_interval.finish then
-		beds.set_spawns(player, pos)
-		if beds.player[name] then
-			lay_down(player, nil, nil, false)
-		end
-		minetest.chat_send_player(name, S("You can only sleep at night."))
-		minetest.chat_send_player(name, S("Spawn point set."))
-		return
-	end
+    if beds.player[name] then
+        lay_down(player, nil, nil, false)
+    end
+
+    -- Only set spawn if not already set to this bed
+    local current_spawn = beds.spawn[name]
+    if not current_spawn or vector.distance(current_spawn, pos) > 0.1 then
+        beds.set_spawns(player, pos)
+        minetest.chat_send_player(name, S("Spawn point set."))
+    end
+
+    minetest.chat_send_player(name, S("You can only sleep at night."))
+    return
+end
 
 	-- move to bed
 	if not beds.player[name] then

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -281,13 +281,12 @@ function beds.on_rightclick(pos, player)
 		local current_spawn = beds.spawn[name]
 		if not current_spawn or vector.distance(current_spawn, pos) > 0.1 then
 			beds.set_spawns(player, pos)
-			minetest.chat_send_player(name, S("Spawn point set."))
+			core.chat_send_player(name, S("Spawn point set."))
 		else
-			minetest.chat_send_player(name, S("You can only sleep at night."))
+			core.chat_send_player(name, S("You can only sleep at night."))
 		end
 		return
 	end
-
 
 	-- move to bed
 	if not beds.player[name] then

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -275,17 +275,21 @@ function beds.on_rightclick(pos, player)
 	local tod = minetest.get_timeofday()
 
 	if tod > beds.day_interval.start and tod < beds.day_interval.finish then
+		beds.set_spawns(player, pos)
 		if beds.player[name] then
+			
 			lay_down(player, nil, nil, false)
 		end
 		minetest.chat_send_player(name, S("You can only sleep at night."))
+		minetest.chat_send_player(name, S("Spawn point set."))
 		return
 	end
 
 	-- move to bed
 	if not beds.player[name] then
 		lay_down(player, ppos, pos)
-		beds.set_spawns() -- save respawn positions when entering bed
+		
+		beds.set_spawns(player, pos) -- save respawn positions when entering bed
 	else
 		lay_down(player, nil, nil, false)
 	end

--- a/mods/beds/spawns.lua
+++ b/mods/beds/spawns.lua
@@ -52,6 +52,7 @@ end
 
 function beds.set_spawns(player, bed_pos)
     local name = player:get_player_name()
+    -- don't change spawn location if borrowing a bed
     if not core.is_protected(bed_pos, name) then
         beds.spawn[name] = bed_pos
         beds.save_spawns()

--- a/mods/beds/spawns.lua
+++ b/mods/beds/spawns.lua
@@ -50,16 +50,12 @@ function beds.save_spawns()
 	io.close(output)
 end
 
-function beds.set_spawns()
-	for name,_ in pairs(beds.player) do
-		local player = minetest.get_player_by_name(name)
-		local p = player:get_pos()
-		-- but don't change spawn location if borrowing a bed
-		if not minetest.is_protected(p, name) then
-			beds.spawn[name] = p
-		end
-	end
-	beds.save_spawns()
+function beds.set_spawns(player, bed_pos)
+    local name = player:get_player_name()
+    if not minetest.is_protected(bed_pos, name) then
+        beds.spawn[name] = bed_pos
+        beds.save_spawns()
+    end
 end
 
 function beds.remove_spawns_at(pos)

--- a/mods/beds/spawns.lua
+++ b/mods/beds/spawns.lua
@@ -52,7 +52,7 @@ end
 
 function beds.set_spawns(player, bed_pos)
     local name = player:get_player_name()
-    if not minetest.is_protected(bed_pos, name) then
+    if not core.is_protected(bed_pos, name) then
         beds.spawn[name] = bed_pos
         beds.save_spawns()
     end


### PR DESCRIPTION
## Summary
Allow players to set their spawn point by right-clicking a bed during daytime.

## Changes
- Set spawn point on right-click even during daytime
- Kept existing night sleep behavior unchanged

## Motivation
Improves convenience without affecting existing mechanics.

Closes #3151