### PR TITLE
Refactor clay node drop

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -619,7 +619,10 @@ minetest.register_node("default:clay", {
 	description = S("Clay"),
 	tiles = {"default_clay.png"},
 	groups = {crumbly = 3},
-	drop = "default:clay_lump 4",
+	drop = {
+		max_items = 4,
+		items = {"default:clay_lump"}
+	}
 	sounds = default.node_sound_dirt_defaults(),
 })
 


### PR DESCRIPTION
I am not sure if it was old syntax but if "default:clay" should drop 4 "default:clay_lump" it should use drop tables.