### PR TITLE
Make fences connects to nodes with `fence_connected` node

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -321,6 +321,13 @@ Allows creation of new fences with "fencelike" drawtype.
  nodedef fields here except drawtype. The fence group will always be added
  for this node.
 
+ All fences will be connected to any nodes with one of the following groups:
+ * `fence`
+ * `wood`
+ * `tree`
+ * `wall`
+ * `fence_connected`
+
 ### fence definition
 
 	name = "default:fence_wood",

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -356,7 +356,7 @@ function default.register_fence(name, def)
 			connect_back =  {-1/8, -1/2,  1/8,  1/8, 1/2 + fence_collision_extra,  1/2},
 			connect_right = { 1/8, -1/2, -1/8,  1/2, 1/2 + fence_collision_extra,  1/8}
 		},
-		connects_to = {"group:fence", "group:wood", "group:tree", "group:wall"},
+		connects_to = {"group:fence", "group:wood", "group:tree", "group:wall", "group:fence_connected"},
 		inventory_image = fence_texture,
 		wield_image = fence_texture,
 		tiles = {def.texture},


### PR DESCRIPTION
`default`: fences: add ability to specify group `fence_connected` for blocks that the fences can connect to.

Same as #3159