### PR TITLE
Add {soulbound} check to Bones.

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -85,7 +85,7 @@ in `bones.player_inventory_lists`.
 
 e.g. `table.insert(bones.player_inventory_lists, "backpack")`
 
-Also note that items with the {soulbound=1} group will not be dropped on death.
+Items with the group `soulbond = 1` will not be moved out of the inventory on death.
 
 
 Creative API

--- a/game_api.txt
+++ b/game_api.txt
@@ -85,6 +85,8 @@ in `bones.player_inventory_lists`.
 
 e.g. `table.insert(bones.player_inventory_lists, "backpack")`
 
+Also note that items with the {soulbound=1} group will not be dropped on death.
+
 
 Creative API
 ------------

--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -4,20 +4,20 @@
 -- See README.txt for licensing and other information.
 
 -- Load support for MT game translation.
-local S = minetest.get_translator("bones")
+local S = core.get_translator("bones")
 
 bones = {}
 
 local function is_owner(pos, name)
-	local owner = minetest.get_meta(pos):get_string("owner")
-	if owner == "" or owner == name or minetest.check_player_privs(name, "protection_bypass") then
+	local owner = core.get_meta(pos):get_string("owner")
+	if owner == "" or owner == name or core.check_player_privs(name, "protection_bypass") then
 		return true
 	end
 	return false
 end
 
 local function drop(pos, itemstack)
-	local obj = minetest.add_item(pos, itemstack:take_item(itemstack:get_count()))
+	local obj = core.add_item(pos, itemstack:take_item(itemstack:get_count()))
 	if obj then
 		obj:set_velocity({
 			x = math.random(-10, 10) / 9,
@@ -28,13 +28,13 @@ local function drop(pos, itemstack)
 end
 
 local function drop_contents(pos)
-	local inv = minetest.get_meta(pos):get_inventory()
+	local inv = core.get_meta(pos):get_inventory()
 
 	for i = 1, inv:get_size("main") do
 		local stk = inv:get_stack("main", i)
 		drop(pos, stk)
 	end
-	minetest.remove_node(pos)
+	core.remove_node(pos)
 end
 
 local bones_formspec =
@@ -46,8 +46,8 @@ local bones_formspec =
 	"listring[current_player;main]" ..
 	default.get_hotbar_bg(0,4.85)
 
-local share_bones_time = tonumber(minetest.settings:get("share_bones_time")) or 1200
-local share_bones_time_early = tonumber(minetest.settings:get("share_bones_time_early")) or share_bones_time / 4
+local share_bones_time = tonumber(core.settings:get("share_bones_time")) or 1200
+local share_bones_time_early = tonumber(core.settings:get("share_bones_time_early")) or share_bones_time / 4
 
 local bones_def = {
 	description = S("Bones"),
@@ -64,7 +64,7 @@ local bones_def = {
 	sounds = default.node_sound_gravel_defaults(),
 
 	can_dig = function(pos, player)
-		local inv = minetest.get_meta(pos):get_inventory()
+		local inv = core.get_meta(pos):get_inventory()
 		local name = ""
 		if player then
 			name = player:get_player_name()
@@ -91,15 +91,15 @@ local bones_def = {
 	end,
 
 	on_metadata_inventory_take = function(pos, listname, index, stack, player)
-		local meta = minetest.get_meta(pos)
+		local meta = core.get_meta(pos)
 		if meta:get_inventory():is_empty("main") then
 			local inv = player:get_inventory()
 			if inv:room_for_item("main", {name = "bones:bones"}) then
 				inv:add_item("main", {name = "bones:bones"})
 			else
-				minetest.add_item(pos, "bones:bones")
+				core.add_item(pos, "bones:bones")
 			end
-			minetest.remove_node(pos)
+			core.remove_node(pos)
 		end
 	end,
 
@@ -113,11 +113,11 @@ local bones_def = {
 			return
 		end
 
-		if minetest.get_meta(pos):get_string("infotext") == "" then
+		if core.get_meta(pos):get_string("infotext") == "" then
 			return
 		end
 
-		local inv = minetest.get_meta(pos):get_inventory()
+		local inv = core.get_meta(pos):get_inventory()
 		local player_inv = player:get_inventory()
 		local has_space = true
 
@@ -137,14 +137,14 @@ local bones_def = {
 			if player_inv:room_for_item("main", {name = "bones:bones"}) then
 				player_inv:add_item("main", {name = "bones:bones"})
 			else
-				minetest.add_item(pos,"bones:bones")
+				core.add_item(pos,"bones:bones")
 			end
-			minetest.remove_node(pos)
+			core.remove_node(pos)
 		end
 	end,
 
 	on_timer = function(pos, elapsed)
-		local meta = minetest.get_meta(pos)
+		local meta = core.get_meta(pos)
 		local time = meta:get_int("time") + elapsed
 		if time >= share_bones_time then
 			meta:set_string("infotext", S("@1's old bones", meta:get_string("owner")))
@@ -160,11 +160,11 @@ local bones_def = {
 
 default.set_inventory_action_loggers(bones_def, "bones")
 
-minetest.register_node("bones:bones", bones_def)
+core.register_node("bones:bones", bones_def)
 
 local function may_replace(pos, player)
-	local node_name = minetest.get_node(pos).name
-	local node_definition = minetest.registered_nodes[node_name]
+	local node_name = core.get_node(pos).name
+	local node_definition = core.registered_nodes[node_name]
 
 	-- if the node is unknown, we return false
 	if not node_definition then
@@ -177,7 +177,7 @@ local function may_replace(pos, player)
 	end
 
 	-- don't replace nodes inside protections
-	if minetest.is_protected(pos, player:get_player_name()) then
+	if core.is_protected(pos, player:get_player_name()) then
 		return false
 	end
 
@@ -210,39 +210,39 @@ local function is_all_empty(player_inv)
 end
 
 minetest.register_on_dieplayer(function(player)
-	local bones_mode = minetest.settings:get("bones_mode") or "bones"
+	local bones_mode = core.settings:get("bones_mode") or "bones"
 	if bones_mode ~= "bones" and bones_mode ~= "drop" and bones_mode ~= "keep" then
 		bones_mode = "bones"
 	end
 
-	local bones_position_message = minetest.settings:get_bool("bones_position_message") == true
+	local bones_position_message = core.settings:get_bool("bones_position_message") == true
 	local player_name = player:get_player_name()
 	local pos = vector.round(player:get_pos())
-	local pos_string = minetest.pos_to_string(pos)
+	local pos_string = core.pos_to_string(pos)
 
 	-- return if keep inventory set or in creative mode
-	if bones_mode == "keep" or minetest.is_creative_enabled(player_name) then
-		minetest.log("action", player_name .. " dies at " .. pos_string ..
+	if bones_mode == "keep" or core.is_creative_enabled(player_name) then
+		core.log("action", player_name .. " dies at " .. pos_string ..
 			". No bones placed")
 		if bones_position_message then
-			minetest.chat_send_player(player_name, S("@1 died at @2.", player_name, pos_string))
+			core.chat_send_player(player_name, S("@1 died at @2.", player_name, pos_string))
 		end
 		return
 	end
 
 	local player_inv = player:get_inventory()
 	if is_all_empty(player_inv) then
-		minetest.log("action", player_name .. " dies at " .. pos_string ..
+		core.log("action", player_name .. " dies at " .. pos_string ..
 			". No bones placed")
 		if bones_position_message then
-			minetest.chat_send_player(player_name, S("@1 died at @2.", player_name, pos_string))
+			core.chat_send_player(player_name, S("@1 died at @2.", player_name, pos_string))
 		end
 		return
 	end
 
 	-- check if it's possible to place bones, if not find space near player
 	if bones_mode == "bones" and not may_replace(pos, player) then
-		local air = minetest.find_node_near(pos, 1, {"air"})
+		local air = core.find_node_near(pos, 1, {"air"})
 		if air then
 			pos = air
 		else
@@ -255,31 +255,31 @@ minetest.register_on_dieplayer(function(player)
 			for i = 1, player_inv:get_size(list_name) do
 				local stack = player_inv:get_stack(list_name, i)
 				if stack:get_count() > 0 and
-						minetest.get_item_group(stack:get_name(), "soulbound") == 0 then
+						core.get_item_group(stack:get_name(), "soulbound") == 0 then
 					drop(pos, player_inv:get_stack(list_name, i))
 					player_inv:set_stack(list_name, i, nil)
 				end
 			end
 		end
 		drop(pos, ItemStack("bones:bones"))
-		minetest.log("action", player_name .. " dies at " .. pos_string ..
+		core.log("action", player_name .. " dies at " .. pos_string ..
 			". Inventory dropped")
 		if bones_position_message then
-			minetest.chat_send_player(player_name, S("@1 died at @2, and dropped their inventory.", player_name, pos_string))
+			core.chat_send_player(player_name, S("@1 died at @2, and dropped their inventory.", player_name, pos_string))
 		end
 		return
 	end
 
-	local param2 = minetest.dir_to_facedir(player:get_look_dir())
-	minetest.set_node(pos, {name = "bones:bones", param2 = param2})
+	local param2 = core.dir_to_facedir(player:get_look_dir())
+	core.set_node(pos, {name = "bones:bones", param2 = param2})
 
-	minetest.log("action", player_name .. " dies at " .. pos_string ..
+	core.log("action", player_name .. " dies at " .. pos_string ..
 		". Bones placed")
 	if bones_position_message then
-		minetest.chat_send_player(player_name, S("@1 died at @2, and bones were placed.", player_name, pos_string))
+		core.chat_send_player(player_name, S("@1 died at @2, and bones were placed.", player_name, pos_string))
 	end
 
-	local meta = minetest.get_meta(pos)
+	local meta = core.get_meta(pos)
 	local inv = meta:get_inventory()
 	inv:set_size("main", 8 * 4)
 
@@ -287,7 +287,7 @@ minetest.register_on_dieplayer(function(player)
 		for i = 1, player_inv:get_size(list_name) do
 			local stack = player_inv:get_stack(list_name, i)
 			if stack:get_count() > 0 and
-						minetest.get_item_group(stack:get_name(), "soulbound") == 0 then
+						core.get_item_group(stack:get_name(), "soulbound") == 0 then
 				if inv:room_for_item("main", stack) then
 					inv:add_item("main", stack)
 				else -- no space left
@@ -304,13 +304,13 @@ minetest.register_on_dieplayer(function(player)
 	if share_bones_time ~= 0 then
 		meta:set_string("infotext", S("@1's fresh bones", player_name))
 
-		if share_bones_time_early == 0 or not minetest.is_protected(pos, player_name) then
+		if share_bones_time_early == 0 or not core.is_protected(pos, player_name) then
 			meta:set_int("time", 0)
 		else
 			meta:set_int("time", (share_bones_time - share_bones_time_early))
 		end
 
-		minetest.get_node_timer(pos):start(10)
+		core.get_node_timer(pos):start(10)
 	else
 		meta:set_string("infotext", S("@1's bones", player_name))
 	end

--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -210,7 +210,7 @@ local function is_all_empty(player_inv)
 end
 
 core.register_on_dieplayer(function(player)
-	local bones_mode = core.settings:get("bones_mode") or "bones"
+	local bones_mode = core.settings:get("bones_mode")
 	if bones_mode ~= "bones" and bones_mode ~= "drop" and bones_mode ~= "keep" then
 		bones_mode = "bones"
 	end
@@ -219,35 +219,20 @@ core.register_on_dieplayer(function(player)
 	local player_name = player:get_player_name()
 	local pos = vector.round(player:get_pos())
 	local pos_string = core.pos_to_string(pos)
-
-	-- return if keep inventory set or in creative mode
-	if bones_mode == "keep" or core.is_creative_enabled(player_name) then
-		core.log("action", player_name .. " dies at " .. pos_string ..
-			". No bones placed")
-		if bones_position_message then
-			core.chat_send_player(player_name, S("@1 died at @2.", player_name, pos_string))
-		end
-		return
-	end
-
 	local player_inv = player:get_inventory()
-	if is_all_empty(player_inv) then
-		core.log("action", player_name .. " dies at " .. pos_string ..
-			". No bones placed")
+
+	-- message helper function
+	local function notify(log_msg, chat_msg)
+		core.log("action", player_name .. " dies at " .. pos_string .. ". " .. log_msg)
 		if bones_position_message then
-			core.chat_send_player(player_name, S("@1 died at @2.", player_name, pos_string))
+			core.chat_send_player(player_name, chat_msg)
 		end
-		return
 	end
 
-	-- check if it's possible to place bones, if not find space near player
-	if bones_mode == "bones" and not may_replace(pos, player) then
-		local air = core.find_node_near(pos, 1, {"air"})
-		if air then
-			pos = air
-		else
-			bones_mode = "drop"
-		end
+	-- return if keep inventory set or in creative mode or empty inventory
+	if bones_mode == "keep" or core.is_creative_enabled(player_name) or is_all_empty(player_inv) then
+		notify("No bones placed", S("@1 died at @2.", player_name, pos_string))
+		return
 	end
 
 	-- check if it's possible to place bones, if not find space near player
@@ -286,17 +271,11 @@ core.register_on_dieplayer(function(player)
 		else
 			meta:set_string("infotext", S("@1's bones", player_name))
 		end
-		core.log("action", player_name .. " dies at " .. pos_string .. ". Bones placed")
-		if bones_position_message then
-			core.chat_send_player(player_name, S("@1 died at @2, and bones were placed.",
+		notify("Bones placed", S("@1 died at @2, and bones were placed.",
 				player_name, pos_string))
-		end
 	else
-		core.log("action", player_name .. " dies at " .. pos_string .. ". Inventory dropped")
-		if bones_position_message then
-			core.chat_send_player(player_name,
-					S("@1 died at @2, and dropped their inventory.", player_name, pos_string))
-		end
+		notify("Inventory dropped", S("@1 died at @2, and dropped their inventory.",
+				player_name, pos_string))
 	end
 
 	-- loop through player inventories and place items inside bones or drop

--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -250,68 +250,68 @@ core.register_on_dieplayer(function(player)
 		end
 	end
 
-	if bones_mode == "drop" then
-		for _, list_name in ipairs(player_inventory_lists) do
-			for i = 1, player_inv:get_size(list_name) do
-				local stack = player_inv:get_stack(list_name, i)
-				if stack:get_count() > 0 and
-						core.get_item_group(stack:get_name(), "soulbound") == 0 then
-					drop(pos, player_inv:get_stack(list_name, i))
-					player_inv:set_stack(list_name, i, nil)
-				end
+	-- check if it's possible to place bones, if not find space near player
+	if bones_mode == "bones" and not may_replace(pos, player) then
+		local air = core.find_node_near(pos, 1, {"air"})
+		if air then
+			pos = air
+		else
+			bones_mode = "drop"
+		end
+	end
+
+	local inv, meta
+
+	-- place bones and set inventory/timer
+	if bones_mode == "bones" then
+		local param2 = core.dir_to_facedir(player:get_look_dir())
+		core.set_node(pos, {name = "bones:bones", param2 = param2})
+
+		meta = core.get_meta(pos)
+		inv = meta:get_inventory()
+		inv:set_size("main", 8 * 4)
+		meta:set_string("formspec", bones_formspec)
+		meta:set_string("owner", player_name)
+
+		if share_bones_time ~= 0 then
+			meta:set_string("infotext", S("@1's fresh bones", player_name))
+
+			if share_bones_time_early == 0 or not core.is_protected(pos, player_name) then
+				meta:set_int("time", 0)
+			else
+				meta:set_int("time", (share_bones_time - share_bones_time_early))
 			end
+
+			core.get_node_timer(pos):start(10)
+		else
+			meta:set_string("infotext", S("@1's bones", player_name))
 		end
-		drop(pos, ItemStack("bones:bones"))
-		core.log("action", player_name .. " dies at " .. pos_string ..
-			". Inventory dropped")
+		core.log("action", player_name .. " dies at " .. pos_string .. ". Bones placed")
 		if bones_position_message then
-			core.chat_send_player(player_name, S("@1 died at @2, and dropped their inventory.", player_name, pos_string))
+			core.chat_send_player(player_name, S("@1 died at @2, and bones were placed.",
+				player_name, pos_string))
 		end
-		return
+	else
+		core.log("action", player_name .. " dies at " .. pos_string .. ". Inventory dropped")
+		if bones_position_message then
+			core.chat_send_player(player_name,
+					S("@1 died at @2, and dropped their inventory.", player_name, pos_string))
+		end
 	end
 
-	local param2 = core.dir_to_facedir(player:get_look_dir())
-	core.set_node(pos, {name = "bones:bones", param2 = param2})
-
-	core.log("action", player_name .. " dies at " .. pos_string ..
-		". Bones placed")
-	if bones_position_message then
-		core.chat_send_player(player_name, S("@1 died at @2, and bones were placed.", player_name, pos_string))
-	end
-
-	local meta = core.get_meta(pos)
-	local inv = meta:get_inventory()
-	inv:set_size("main", 8 * 4)
-
+	-- loop through player inventories and place items inside bones or drop
 	for _, list_name in ipairs(player_inventory_lists) do
 		for i = 1, player_inv:get_size(list_name) do
 			local stack = player_inv:get_stack(list_name, i)
 			if stack:get_count() > 0 and
-						core.get_item_group(stack:get_name(), "soulbound") == 0 then
-				if inv:room_for_item("main", stack) then
+					core.get_item_group(stack:get_name(), "soulbound") == 0 then
+				if bones_mode == "bones" and inv:room_for_item("main", stack) then
 					inv:add_item("main", stack)
-				else -- no space left
+				else -- no space left or bones_mode set to drop
 					drop(pos, stack)
 				end
 				player_inv:set_stack(list_name, i, nil)
 			end
 		end
-	end
-
-	meta:set_string("formspec", bones_formspec)
-	meta:set_string("owner", player_name)
-
-	if share_bones_time ~= 0 then
-		meta:set_string("infotext", S("@1's fresh bones", player_name))
-
-		if share_bones_time_early == 0 or not core.is_protected(pos, player_name) then
-			meta:set_int("time", 0)
-		else
-			meta:set_int("time", (share_bones_time - share_bones_time_early))
-		end
-
-		core.get_node_timer(pos):start(10)
-	else
-		meta:set_string("infotext", S("@1's bones", player_name))
 	end
 end)

--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -162,17 +162,18 @@ default.set_inventory_action_loggers(bones_def, "bones")
 
 core.register_node("bones:bones", bones_def)
 
+
 local function may_replace(pos, player)
 	local node_name = core.get_node(pos).name
 	local node_definition = core.registered_nodes[node_name]
 
 	-- if the node is unknown, we return false
-	if not node_definition then
+	if not node_definition or node_name == "ignore" then
 		return false
 	end
 
-	-- allow replacing air
-	if node_name == "air" then
+	-- allow replacing air or flowing liquid
+	if node_name == "air" or node_definition.liquidtype == "flowing" then
 		return true
 	end
 
@@ -181,8 +182,8 @@ local function may_replace(pos, player)
 		return false
 	end
 
-	-- allow replacing liquids
-	if node_definition.liquidtype ~= "none" then
+	-- allow replacing unprotected sources
+	if node_definition.liquidtype == "source" then
 		return true
 	end
 

--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -209,7 +209,7 @@ local function is_all_empty(player_inv)
 	return true
 end
 
-minetest.register_on_dieplayer(function(player)
+core.register_on_dieplayer(function(player)
 	local bones_mode = core.settings:get("bones_mode") or "bones"
 	if bones_mode ~= "bones" and bones_mode ~= "drop" and bones_mode ~= "keep" then
 		bones_mode = "bones"

--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -253,9 +253,13 @@ minetest.register_on_dieplayer(function(player)
 	if bones_mode == "drop" then
 		for _, list_name in ipairs(player_inventory_lists) do
 			for i = 1, player_inv:get_size(list_name) do
-				drop(pos, player_inv:get_stack(list_name, i))
+				local stack = player_inv:get_stack(list_name, i)
+				if stack:get_count() > 0 and
+						minetest.get_item_group(stack:get_name(), "soulbound") == 0 then
+					drop(pos, player_inv:get_stack(list_name, i))
+					player_inv:set_stack(list_name, i, nil)
+				end
 			end
-			player_inv:set_list(list_name, {})
 		end
 		drop(pos, ItemStack("bones:bones"))
 		minetest.log("action", player_name .. " dies at " .. pos_string ..
@@ -282,13 +286,16 @@ minetest.register_on_dieplayer(function(player)
 	for _, list_name in ipairs(player_inventory_lists) do
 		for i = 1, player_inv:get_size(list_name) do
 			local stack = player_inv:get_stack(list_name, i)
-			if inv:room_for_item("main", stack) then
-				inv:add_item("main", stack)
-			else -- no space left
-				drop(pos, stack)
+			if stack:get_count() > 0 and
+						minetest.get_item_group(stack:get_name(), "soulbound") == 0 then
+				if inv:room_for_item("main", stack) then
+					inv:add_item("main", stack)
+				else -- no space left
+					drop(pos, stack)
+				end
+				player_inv:set_stack(list_name, i, nil)
 			end
 		end
-		player_inv:set_list(list_name, {})
 	end
 
 	meta:set_string("formspec", bones_formspec)


### PR DESCRIPTION
Change minetest. to core.

Amend may_replace to also check for "ignore" and allow placing of bones on water_flowing nodes, and if not protected water_source as well.

Adds a {soulbound} group check for each item dropped when player dies, providing a handy feature and to keep the game in-line with 3d_armor drops.